### PR TITLE
feat: build webhook notification system

### DIFF
--- a/backend/src/database/migrations/012_webhook_system.ts
+++ b/backend/src/database/migrations/012_webhook_system.ts
@@ -1,0 +1,78 @@
+import type { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable("webhook_endpoints", (table) => {
+    table.uuid("id").primary().defaultTo(knex.raw("gen_random_uuid()"));
+    table.string("owner_address").notNullable();
+    table.string("url").notNullable();
+    table.string("name").notNullable();
+    table.text("description").nullable();
+    table.string("secret").notNullable();
+    table.timestamp("secret_rotated_at").nullable();
+    table.boolean("is_active").notNullable().defaultTo(true);
+    table.integer("rate_limit_per_minute").notNullable().defaultTo(60);
+    table.jsonb("custom_headers").notNullable().defaultTo("{}");
+    table.jsonb("filter_event_types").notNullable().defaultTo("[]");
+    table.boolean("is_batch_delivery_enabled").notNullable().defaultTo(false);
+    table.integer("batch_window_ms").notNullable().defaultTo(5000);
+    table.timestamps(true, true);
+    table.index(["owner_address"]);
+    table.index(["is_active"]);
+  });
+
+  await knex.schema.createTable("webhook_deliveries", (table) => {
+    table.uuid("id").primary().defaultTo(knex.raw("gen_random_uuid()"));
+    table
+      .uuid("webhook_endpoint_id")
+      .notNullable()
+      .references("id")
+      .inTable("webhook_endpoints")
+      .onDelete("CASCADE");
+    table.string("event_type").notNullable();
+    table.jsonb("payload").notNullable();
+    table.string("status").notNullable().defaultTo("pending");
+    table.integer("attempts").notNullable().defaultTo(0);
+    table.timestamp("last_attempt_at").nullable();
+    table.timestamp("next_retry_at").nullable();
+    table.integer("response_status").nullable();
+    table.text("response_body").nullable();
+    table.text("error_message").nullable();
+    table.timestamp("created_at").notNullable().defaultTo(knex.fn.now());
+    table.index(["webhook_endpoint_id"]);
+    table.index(["status"]);
+    table.index(["created_at"]);
+  });
+
+  await knex.schema.createTable("webhook_delivery_logs", (table) => {
+    table.uuid("id").primary().defaultTo(knex.raw("gen_random_uuid()"));
+    table
+      .uuid("webhook_endpoint_id")
+      .notNullable()
+      .references("id")
+      .inTable("webhook_endpoints")
+      .onDelete("CASCADE");
+    table
+      .uuid("webhook_delivery_id")
+      .notNullable()
+      .references("id")
+      .inTable("webhook_deliveries")
+      .onDelete("CASCADE");
+    table.string("event_type").notNullable();
+    table.jsonb("request_headers").notNullable();
+    table.text("request_body").notNullable();
+    table.integer("response_status").nullable();
+    table.text("response_body").nullable();
+    table.integer("duration_ms").notNullable().defaultTo(0);
+    table.integer("attempt_number").notNullable().defaultTo(1);
+    table.text("error_message").nullable();
+    table.timestamp("created_at").notNullable().defaultTo(knex.fn.now());
+    table.index(["webhook_delivery_id"]);
+    table.index(["webhook_endpoint_id"]);
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists("webhook_delivery_logs");
+  await knex.schema.dropTableIfExists("webhook_deliveries");
+  await knex.schema.dropTableIfExists("webhook_endpoints");
+}

--- a/backend/tests/services/webhook.service.test.ts
+++ b/backend/tests/services/webhook.service.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { WebhookService, type WebhookEventType } from "../../src/services/webhook.service.js";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("bullmq", () => {
+  const mockQueue = {
+    add: vi.fn().mockResolvedValue({ id: "job-1" }),
+    on: vi.fn(),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+  return {
+    Queue: vi.fn(() => mockQueue),
+    Worker: vi.fn(),
+  };
+});
+
+vi.mock("../../src/database/connection.js", () => {
+  const rows: Record<string, unknown>[] = [];
+
+  const builder = (returnRows: unknown[] = rows) => {
+    const b: Record<string, unknown> = {};
+    const chain = () => b;
+    b.where = vi.fn().mockReturnValue(b);
+    b.whereNotNull = vi.fn().mockReturnValue(b);
+    b.whereNot = vi.fn().mockReturnValue(b);
+    b.orderBy = vi.fn().mockReturnValue(b);
+    b.limit = vi.fn().mockResolvedValue(returnRows);
+    b.first = vi.fn().mockResolvedValue(returnRows[0] ?? null);
+    b.insert = vi.fn().mockReturnValue(b);
+    b.update = vi.fn().mockResolvedValue(1);
+    b.delete = vi.fn().mockResolvedValue(1);
+    b.returning = vi.fn().mockResolvedValue(returnRows);
+    return b;
+  };
+
+  return {
+    getDatabase: vi.fn(() => {
+      const fn = (table: string) => builder();
+      fn.raw = vi.fn((v: string) => v);
+      fn.fn = { now: () => new Date() };
+      return fn;
+    }),
+  };
+});
+
+vi.mock("../../src/config/index.js", () => ({
+  config: {
+    REDIS_HOST: "localhost",
+    REDIS_PORT: 6379,
+    REDIS_PASSWORD: undefined,
+  },
+}));
+
+vi.mock("../../src/utils/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEndpointRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "ep-1",
+    owner_address: "GABC",
+    url: "https://example.com/hook",
+    name: "Test Endpoint",
+    description: null,
+    secret: "secret-abc",
+    secret_rotated_at: null,
+    is_active: true,
+    rate_limit_per_minute: 60,
+    custom_headers: "{}",
+    filter_event_types: "[]",
+    is_batch_delivery_enabled: false,
+    batch_window_ms: 5000,
+    created_at: new Date(),
+    updated_at: new Date(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("WebhookService — HMAC signing", () => {
+  let service: WebhookService;
+
+  beforeEach(() => {
+    // Reset singleton for isolated tests
+    (WebhookService as any).instance = undefined;
+    service = WebhookService.getInstance();
+  });
+
+  it("generates a 64-char hex secret", () => {
+    const secret = service.generateSecret();
+    expect(secret).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("signPayload produces consistent HMAC for same inputs", () => {
+    const secret = "test-secret";
+    const payload = '{"event":"test"}';
+    const ts = 1700000000000;
+    const sig1 = service.signPayload(payload, secret, ts);
+    const sig2 = service.signPayload(payload, secret, ts);
+    expect(sig1).toBe(sig2);
+    expect(sig1).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("signPayload produces different HMAC for different timestamps", () => {
+    const secret = "test-secret";
+    const payload = '{"event":"test"}';
+    const sig1 = service.signPayload(payload, secret, 1000);
+    const sig2 = service.signPayload(payload, secret, 2000);
+    expect(sig1).not.toBe(sig2);
+  });
+
+  it("generateSignatureHeaders returns required headers", () => {
+    const headers = service.generateSignatureHeaders('{"test":true}', "my-secret");
+    expect(headers).toHaveProperty("X-Webhook-Signature");
+    expect(headers).toHaveProperty("X-Webhook-Timestamp");
+    expect(headers).toHaveProperty("X-Webhook-Event-Id");
+    expect(headers["Content-Type"]).toBe("application/json");
+  });
+
+  it("verifySignature rejects stale timestamps", () => {
+    const secret = "my-secret";
+    const payload = '{"data":1}';
+    const oldTimestamp = (Date.now() - 600_000).toString(); // 10 min ago
+    const sig = service.signPayload(payload, secret, parseInt(oldTimestamp, 10));
+    const valid = service.verifySignature(payload, sig, oldTimestamp, secret);
+    expect(valid).toBe(false);
+  });
+
+  it("verifySignature accepts fresh signatures", () => {
+    const secret = "my-secret";
+    const payload = '{"data":1}';
+    const ts = Date.now();
+    const sig = service.signPayload(payload, secret, ts);
+    const valid = service.verifySignature(payload, sig, ts.toString(), secret);
+    expect(valid).toBe(true);
+  });
+});
+
+describe("WebhookService — rate limiting", () => {
+  let service: WebhookService;
+
+  beforeEach(() => {
+    (WebhookService as any).instance = undefined;
+    service = WebhookService.getInstance();
+    // Clear internal map
+    (service as any).rateLimitMap.clear();
+  });
+
+  it("allows requests up to the limit", () => {
+    for (let i = 0; i < 5; i++) {
+      expect(service.checkRateLimit("ep-1", 5)).toBe(true);
+    }
+  });
+
+  it("rejects requests beyond the limit", () => {
+    for (let i = 0; i < 5; i++) {
+      service.checkRateLimit("ep-1", 5);
+    }
+    expect(service.checkRateLimit("ep-1", 5)).toBe(false);
+  });
+
+  it("tracks rate limits independently per endpoint", () => {
+    for (let i = 0; i < 5; i++) {
+      service.checkRateLimit("ep-1", 5);
+    }
+    expect(service.checkRateLimit("ep-2", 5)).toBe(true);
+  });
+});
+
+describe("WebhookService — endpoint filtering", () => {
+  let service: WebhookService;
+
+  beforeEach(() => {
+    (WebhookService as any).instance = undefined;
+    service = WebhookService.getInstance();
+  });
+
+  it("mapToEndpoint parses JSON fields correctly", () => {
+    const row = makeEndpointRow({
+      custom_headers: JSON.stringify({ "X-Custom": "value" }),
+      filter_event_types: JSON.stringify(["alert.triggered"]),
+    });
+    const endpoint = (service as any).mapToEndpoint(row);
+    expect(endpoint.customHeaders).toEqual({ "X-Custom": "value" });
+    expect(endpoint.filterEventTypes).toEqual(["alert.triggered"]);
+  });
+
+  it("mapToEndpoint handles already-parsed JSONB objects", () => {
+    const row = makeEndpointRow({
+      custom_headers: { "X-Test": "1" },
+      filter_event_types: ["bridge.status_changed"],
+    });
+    const endpoint = (service as any).mapToEndpoint(row);
+    expect(endpoint.customHeaders["X-Test"]).toBe("1");
+    expect(endpoint.filterEventTypes[0]).toBe("bridge.status_changed");
+  });
+});
+
+describe("WebhookService — singleton", () => {
+  it("getInstance returns the same instance", () => {
+    (WebhookService as any).instance = undefined;
+    const a = WebhookService.getInstance();
+    const b = WebhookService.getInstance();
+    expect(a).toBe(b);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds **migration `012_webhook_system.ts`** — creates the three webhook tables (`webhook_endpoints`, `webhook_deliveries`, `webhook_delivery_logs`) with all necessary indexes and `ON DELETE CASCADE` foreign keys, making the system deployable against a real database
- Adds **`webhook.service.test.ts`** — 10 unit tests covering HMAC signing, timestamp-based replay-attack prevention, per-endpoint rate limiting, JSON-field mapping, and singleton behaviour
- The core service (`webhook.service.ts`), delivery worker (`webhookDelivery.worker.ts`), and API routes (`/api/v1/webhooks`) were already present and fully wired into the startup lifecycle

## Implementation Breakdown

| Layer | File | Status |
|---|---|---|
| DB Migration | `backend/src/database/migrations/012_webhook_system.ts` | ✅ Added |
| Service | `backend/src/services/webhook.service.ts` | ✅ Existing (complete) |
| Worker | `backend/src/workers/webhookDelivery.worker.ts` | ✅ Existing (complete) |
| Routes | `backend/src/api/routes/webhooks.ts` | ✅ Existing (complete) |
| Unit Tests | `backend/tests/services/webhook.service.test.ts` | ✅ Added |

### Key features delivered by the full system
- **HMAC-SHA256 signing** with timestamp-scoped payloads (replay-attack prevention, 5-min tolerance window)
- **Exponential backoff retries** — 7 attempts across `1s → 1h` delay ladder via BullMQ
- **Per-endpoint rate limiting** — in-memory sliding window, configurable per endpoint
- **Batch delivery** — windowed event batching for high-throughput scenarios
- **Secret rotation** endpoint — zero-downtime key rollover
- **Delivery logs** — full request/response audit trail per attempt
- **Test endpoint** — `POST /api/v1/webhooks/endpoints/:id/test` sends a dry-run payload
- **Signature verification utility** — `POST /api/v1/webhooks/verify`
- **Event filtering** — per-endpoint allow-list of 10 event types

## Testing Notes

```bash
# Run unit tests
cd backend && npx vitest run tests/services/webhook.service.test.ts
```

All tests are fully mocked (no Redis, no DB required). Tests cover:
- HMAC consistency and differentiation by timestamp
- Signature header shape
- Stale-timestamp rejection (>5 min)
- Fresh-signature acceptance
- Rate-limit enforcement and per-endpoint isolation
- JSONB field parsing (string vs object)
- Singleton guarantee

Closes #162 