### PR TITLE
infra: build monitoring and alerting stack

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,0 +1,36 @@
+# Monitoring and Alerting Guide
+
+Issue scope: build a production-ready baseline for monitoring, alerting, logs, tracing, uptime, and runbooks.
+
+## What is included
+
+- Prometheus scrape and alert rules
+- Grafana dashboard provisioning
+- Alertmanager routing by severity/team
+- Log aggregation with Loki/Promtail
+- Tracing backend with Tempo
+- Uptime probing with Blackbox Exporter
+- Host resource metrics with Node Exporter
+- Runbook links embedded in alert annotations
+
+## Local validation workflow
+
+1. Start stack:
+   - `cd monitoring && docker compose up -d`
+2. Start backend application.
+3. Confirm Prometheus targets are healthy.
+4. Open Grafana and verify `Bridge Watch Observability Overview` dashboard.
+5. Validate uptime probes (`probe_success`).
+6. Trigger a synthetic alert and verify Alertmanager route.
+
+## Required environment and secret setup
+
+- Replace Slack webhook placeholders in `monitoring/alertmanager.yml`.
+- Replace PagerDuty integration key placeholder.
+- For production, store integration values in secret manager and template at deploy time.
+
+## Operational notes
+
+- Alert rules include `runbook_url` annotations for incident response.
+- Current scrape target uses `host.docker.internal:3001` for local development.
+- For containerized backend deployment, switch target to service DNS name.

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,51 @@
+# Bridge Watch Monitoring Stack
+
+This folder provides a full observability stack for Bridge Watch:
+
+- Metrics: Prometheus
+- Dashboards: Grafana
+- Alerting and routing: Alertmanager
+- Log aggregation: Loki + Promtail
+- Tracing backend: Tempo (OTLP receiver enabled)
+- Uptime checks: Blackbox Exporter
+- Host resource monitoring: Node Exporter
+
+## Start stack
+
+```bash
+cd monitoring
+docker compose up -d
+```
+
+## Endpoints
+
+- Grafana: `http://localhost:3000` (admin/admin)
+- Prometheus: `http://localhost:9090`
+- Alertmanager: `http://localhost:9093`
+- Loki: `http://localhost:3100`
+- Tempo: `http://localhost:3200`
+
+## Trace integration
+
+The Tempo service listens for OTLP on:
+
+- gRPC: `localhost:4317`
+- HTTP: `localhost:4318`
+
+Point the backend OpenTelemetry exporter to one of these endpoints.
+
+## Alert routing
+
+Alertmanager routes:
+
+- `critical` alerts to PagerDuty and Slack
+- `team=bridge` alerts to bridge channel
+- `team=api` alerts to API channel
+
+Replace placeholder integration keys/webhooks in `alertmanager.yml` before production use.
+
+## Runbooks
+
+Alert annotations include `runbook_url` values pointing to:
+
+- `monitoring/runbooks/critical-alerts.md`

--- a/monitoring/alertmanager.yml
+++ b/monitoring/alertmanager.yml
@@ -1,0 +1,47 @@
+global:
+  resolve_timeout: 5m
+
+route:
+  receiver: default-slack
+  group_by: ["alertname", "service", "team"]
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 3h
+  routes:
+    - matchers:
+        - severity="critical"
+      receiver: pagerduty
+      continue: true
+    - matchers:
+        - team="bridge"
+      receiver: bridge-team
+    - matchers:
+        - team="api"
+      receiver: api-team
+
+receivers:
+  - name: default-slack
+    slack_configs:
+      - api_url: "https://hooks.slack.com/services/REPLACE/ME"
+        channel: "#ops-alerts"
+        send_resolved: true
+        title: "[{{ .Status | toUpper }}] {{ .CommonLabels.alertname }}"
+        text: "{{ range .Alerts }}{{ .Annotations.description }}\nRunbook: {{ .Annotations.runbook_url }}\n{{ end }}"
+
+  - name: pagerduty
+    pagerduty_configs:
+      - routing_key: "REPLACE_WITH_PAGERDUTY_INTEGRATION_KEY"
+        severity: "{{ .CommonLabels.severity }}"
+        description: "{{ .CommonLabels.alertname }} - {{ .CommonAnnotations.summary }}"
+
+  - name: bridge-team
+    slack_configs:
+      - api_url: "https://hooks.slack.com/services/REPLACE/ME"
+        channel: "#bridge-alerts"
+        send_resolved: true
+
+  - name: api-team
+    slack_configs:
+      - api_url: "https://hooks.slack.com/services/REPLACE/ME"
+        channel: "#api-alerts"
+        send_resolved: true

--- a/monitoring/alerts.yml
+++ b/monitoring/alerts.yml
@@ -1,0 +1,93 @@
+groups:
+  - name: bridge-watch-availability
+    interval: 30s
+    rules:
+      - alert: BackendDown
+        expr: up{job="bridge-watch-backend"} == 0
+        for: 2m
+        labels:
+          severity: critical
+          service: backend
+          team: platform
+        annotations:
+          summary: "Bridge Watch backend is down"
+          description: "Prometheus cannot scrape backend metrics for more than 2 minutes."
+          runbook_url: "https://github.com/StellaBridge/Bridge-Watch/blob/main/monitoring/runbooks/critical-alerts.md#backenddown"
+
+      - alert: UptimeProbeFailed
+        expr: probe_success == 0
+        for: 2m
+        labels:
+          severity: critical
+          service: uptime
+          team: platform
+        annotations:
+          summary: "Uptime probe failed"
+          description: "Probe failed for {{ $labels.instance }}."
+          runbook_url: "https://github.com/StellaBridge/Bridge-Watch/blob/main/monitoring/runbooks/critical-alerts.md#uptimeprobefailed"
+
+  - name: bridge-watch-resources
+    interval: 30s
+    rules:
+      - alert: HighCPUUsage
+        expr: (1 - avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[5m]))) * 100 > 85
+        for: 10m
+        labels:
+          severity: warning
+          service: infrastructure
+          team: platform
+        annotations:
+          summary: "High CPU usage"
+          description: "CPU usage is above 85% on {{ $labels.instance }}."
+          runbook_url: "https://github.com/StellaBridge/Bridge-Watch/blob/main/monitoring/runbooks/critical-alerts.md#highcpuusage"
+
+      - alert: HighMemoryUsage
+        expr: (1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)) * 100 > 90
+        for: 10m
+        labels:
+          severity: warning
+          service: infrastructure
+          team: platform
+        annotations:
+          summary: "High memory usage"
+          description: "Memory usage is above 90% on {{ $labels.instance }}."
+          runbook_url: "https://github.com/StellaBridge/Bridge-Watch/blob/main/monitoring/runbooks/critical-alerts.md#highmemoryusage"
+
+  - name: bridge-watch-application
+    interval: 30s
+    rules:
+      - alert: HighHTTPErrorRate
+        expr: sum(rate(http_requests_total{status_code=~"5.."}[5m])) / sum(rate(http_requests_total[5m])) > 0.05
+        for: 5m
+        labels:
+          severity: critical
+          service: backend
+          team: api
+        annotations:
+          summary: "High HTTP 5xx error rate"
+          description: "HTTP 5xx rate is above 5% over 5 minutes."
+          runbook_url: "https://github.com/StellaBridge/Bridge-Watch/blob/main/monitoring/runbooks/critical-alerts.md#highhttperrorrate"
+
+      - alert: HighP95Latency
+        expr: histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket[5m]))) > 2
+        for: 10m
+        labels:
+          severity: warning
+          service: backend
+          team: api
+        annotations:
+          summary: "High p95 latency"
+          description: "HTTP p95 latency is above 2s for 10 minutes."
+          runbook_url: "https://github.com/StellaBridge/Bridge-Watch/blob/main/monitoring/runbooks/critical-alerts.md#highp95latency"
+
+      - alert: BridgeHealthLow
+        expr: bridge_health_score < 80
+        for: 10m
+        labels:
+          severity: critical
+          service: bridge
+          team: bridge
+        annotations:
+          summary: "Bridge health score low"
+          description: "{{ $labels.bridge_name }} health score dropped below 80."
+          runbook_url: "https://github.com/StellaBridge/Bridge-Watch/blob/main/monitoring/runbooks/critical-alerts.md#bridgehealthlow"

--- a/monitoring/blackbox.yml
+++ b/monitoring/blackbox.yml
@@ -1,0 +1,8 @@
+modules:
+  http_2xx:
+    prober: http
+    timeout: 5s
+    http:
+      valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+      preferred_ip_protocol: "ip4"
+      method: GET

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -1,0 +1,136 @@
+version: "3.9"
+
+services:
+  prometheus:
+    image: prom/prometheus:v2.54.1
+    container_name: bridgewatch-prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=15d
+      - --web.enable-lifecycle
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./alerts.yml:/etc/prometheus/alerts.yml:ro
+      - prometheus-data:/prometheus
+    depends_on:
+      - alertmanager
+      - blackbox-exporter
+    networks:
+      - monitoring
+
+  alertmanager:
+    image: prom/alertmanager:v0.28.1
+    container_name: bridgewatch-alertmanager
+    command:
+      - --config.file=/etc/alertmanager/alertmanager.yml
+      - --storage.path=/alertmanager
+    ports:
+      - "9093:9093"
+    volumes:
+      - ./alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+      - alertmanager-data:/alertmanager
+    networks:
+      - monitoring
+
+  grafana:
+    image: grafana/grafana:11.2.0
+    container_name: bridgewatch-grafana
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    ports:
+      - "3000:3000"
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+    depends_on:
+      - prometheus
+      - loki
+      - tempo
+    networks:
+      - monitoring
+
+  loki:
+    image: grafana/loki:3.1.1
+    container_name: bridgewatch-loki
+    command: ["-config.file=/etc/loki/loki.yml"]
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./loki.yml:/etc/loki/loki.yml:ro
+      - loki-data:/loki
+    networks:
+      - monitoring
+
+  promtail:
+    image: grafana/promtail:3.1.1
+    container_name: bridgewatch-promtail
+    command: ["-config.file=/etc/promtail/promtail.yml"]
+    volumes:
+      - ./promtail.yml:/etc/promtail/promtail.yml:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/log:/var/log:ro
+      - promtail-data:/tmp
+    depends_on:
+      - loki
+    networks:
+      - monitoring
+
+  tempo:
+    image: grafana/tempo:2.6.1
+    container_name: bridgewatch-tempo
+    command: ["-config.file=/etc/tempo/tempo.yml"]
+    ports:
+      - "3200:3200"
+      - "4317:4317"
+      - "4318:4318"
+    volumes:
+      - ./tempo.yml:/etc/tempo/tempo.yml:ro
+      - tempo-data:/tmp/tempo
+    networks:
+      - monitoring
+
+  node-exporter:
+    image: prom/node-exporter:v1.8.2
+    container_name: bridgewatch-node-exporter
+    command:
+      - --path.procfs=/host/proc
+      - --path.sysfs=/host/sys
+      - --collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+    ports:
+      - "9100:9100"
+    networks:
+      - monitoring
+
+  blackbox-exporter:
+    image: prom/blackbox-exporter:v0.25.0
+    container_name: bridgewatch-blackbox
+    command:
+      - --config.file=/etc/blackbox_exporter/config.yml
+    ports:
+      - "9115:9115"
+    volumes:
+      - ./blackbox.yml:/etc/blackbox_exporter/config.yml:ro
+    networks:
+      - monitoring
+
+volumes:
+  prometheus-data:
+  alertmanager-data:
+  grafana-data:
+  loki-data:
+  tempo-data:
+  promtail-data:
+
+networks:
+  monitoring:
+    driver: bridge

--- a/monitoring/grafana/dashboards/observability-overview.json
+++ b/monitoring/grafana/dashboards/observability-overview.json
@@ -1,0 +1,86 @@
+{
+  "dashboard": {
+    "id": null,
+    "uid": "bridgewatch-overview",
+    "title": "Bridge Watch Observability Overview",
+    "tags": ["observability", "bridge-watch"],
+    "timezone": "browser",
+    "schemaVersion": 39,
+    "version": 1,
+    "refresh": "30s",
+    "panels": [
+      {
+        "id": 1,
+        "title": "Service Availability",
+        "type": "stat",
+        "gridPos": { "x": 0, "y": 0, "w": 6, "h": 6 },
+        "targets": [{ "refId": "A", "expr": "avg(up{job=\"bridge-watch-backend\"}) * 100" }],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "percent",
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [{ "color": "red", "value": 0 }, { "color": "green", "value": 99 }]
+            }
+          }
+        }
+      },
+      {
+        "id": 2,
+        "title": "HTTP Error Rate (5xx)",
+        "type": "timeseries",
+        "gridPos": { "x": 6, "y": 0, "w": 9, "h": 6 },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "sum(rate(http_requests_total{status_code=~\"5..\"}[5m])) / sum(rate(http_requests_total[5m])) * 100"
+          }
+        ]
+      },
+      {
+        "id": 3,
+        "title": "p95 HTTP Latency",
+        "type": "timeseries",
+        "gridPos": { "x": 15, "y": 0, "w": 9, "h": 6 },
+        "targets": [
+          {
+            "refId": "A",
+            "expr": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket[5m])))"
+          }
+        ]
+      },
+      {
+        "id": 4,
+        "title": "Bridge Health Score",
+        "type": "timeseries",
+        "gridPos": { "x": 0, "y": 6, "w": 12, "h": 8 },
+        "targets": [{ "refId": "A", "expr": "bridge_health_score", "legendFormat": "{{bridge_name}}" }]
+      },
+      {
+        "id": 5,
+        "title": "Host Resource Usage",
+        "type": "timeseries",
+        "gridPos": { "x": 12, "y": 6, "w": 12, "h": 8 },
+        "targets": [
+          { "refId": "A", "expr": "(1 - avg by (instance) (rate(node_cpu_seconds_total{mode=\"idle\"}[5m]))) * 100", "legendFormat": "CPU {{instance}}" },
+          { "refId": "B", "expr": "(1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)) * 100", "legendFormat": "Memory {{instance}}" }
+        ]
+      },
+      {
+        "id": 6,
+        "title": "Uptime Probe Success",
+        "type": "timeseries",
+        "gridPos": { "x": 0, "y": 14, "w": 12, "h": 8 },
+        "targets": [{ "refId": "A", "expr": "probe_success", "legendFormat": "{{instance}}" }]
+      },
+      {
+        "id": 7,
+        "title": "Recent Logs (Loki)",
+        "type": "logs",
+        "gridPos": { "x": 12, "y": 14, "w": 12, "h": 8 },
+        "targets": [{ "refId": "A", "expr": "{service=~\".*\"}" }]
+      }
+    ]
+  },
+  "overwrite": true
+}

--- a/monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: bridge-watch-monitoring
+    orgId: 1
+    folder: Bridge Watch
+    type: file
+    disableDeletion: false
+    editable: true
+    updateIntervalSeconds: 15
+    options:
+      path: /var/lib/grafana/dashboards

--- a/monitoring/grafana/provisioning/datasources/datasources.yml
+++ b/monitoring/grafana/provisioning/datasources/datasources.yml
@@ -1,0 +1,27 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    editable: false
+
+  - name: Tempo
+    type: tempo
+    access: proxy
+    url: http://tempo:3200
+    editable: false
+
+  - name: Alertmanager
+    type: alertmanager
+    access: proxy
+    url: http://alertmanager:9093
+    editable: false

--- a/monitoring/loki.yml
+++ b/monitoring/loki.yml
@@ -1,0 +1,34 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: loki_index_
+        period: 24h
+
+limits_config:
+  retention_period: 336h
+
+compactor:
+  working_directory: /loki/compactor
+  compaction_interval: 10m
+  retention_enabled: true

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,48 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  external_labels:
+    project: bridge-watch
+    env: production
+
+rule_files:
+  - /etc/prometheus/alerts.yml
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+            - alertmanager:9093
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ["prometheus:9090"]
+
+  - job_name: bridge-watch-backend
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["host.docker.internal:3001"]
+        labels:
+          service: backend
+          team: platform
+
+  - job_name: node-exporter
+    static_configs:
+      - targets: ["node-exporter:9100"]
+
+  - job_name: blackbox-uptime
+    metrics_path: /probe
+    params:
+      module: [http_2xx]
+    static_configs:
+      - targets:
+          - http://host.docker.internal:3001/health
+          - http://host.docker.internal:3001/metrics/health
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: blackbox-exporter:9115

--- a/monitoring/promtail.yml
+++ b/monitoring/promtail.yml
@@ -1,0 +1,26 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+    relabel_configs:
+      - source_labels: ["__meta_docker_container_name"]
+        regex: "/(.*)"
+        target_label: container
+      - source_labels: ["__meta_docker_container_label_com_docker_compose_service"]
+        target_label: service
+      - source_labels: ["__meta_docker_container_log_stream"]
+        target_label: stream
+      - source_labels: ["__meta_docker_container_name"]
+        target_label: __path__
+        replacement: /var/lib/docker/containers/*/*.log

--- a/monitoring/runbooks/critical-alerts.md
+++ b/monitoring/runbooks/critical-alerts.md
@@ -1,0 +1,51 @@
+# Monitoring Runbooks
+
+## BackendDown
+
+1. Confirm backend container or process status.
+2. Verify `/health` and `/metrics` endpoints are reachable.
+3. Check recent deploys and roll back if needed.
+4. Inspect backend logs in Grafana Loki for crash loops and startup errors.
+5. Resolve and verify `up{job="bridge-watch-backend"} == 1`.
+
+## UptimeProbeFailed
+
+1. Open target endpoint manually from inside and outside the cluster/network.
+2. Validate DNS and ingress routing configuration.
+3. Check TLS configuration if HTTPS endpoint is probed.
+4. Confirm blackbox exporter is healthy and targets are correct.
+
+## HighHTTPErrorRate
+
+1. Identify failing routes from `http_requests_total`.
+2. Correlate with recent traces and logs.
+3. Check dependency health (database, external providers).
+4. Mitigate with rollback or feature flag if regression is recent.
+
+## HighP95Latency
+
+1. Break down latency by route and dependency.
+2. Confirm database latency and queue pressure.
+3. Check CPU and memory saturation.
+4. Scale backend workers or tune slow dependency calls.
+
+## BridgeHealthLow
+
+1. Identify affected bridge from labels.
+2. Check verification failures and reason tags.
+3. Review upstream provider status and circuit breaker activity.
+4. Escalate to bridge on-call if degradation persists.
+
+## HighCPUUsage
+
+1. Identify noisy process/container.
+2. Compare with request rate and job throughput.
+3. Reduce burst workload or scale horizontally.
+4. Profile CPU hotspots if sustained.
+
+## HighMemoryUsage
+
+1. Inspect process RSS and heap growth over time.
+2. Review GC pressure and large in-memory queues.
+3. Restart unhealthy pods/containers if leaking.
+4. Create follow-up issue with heap profile evidence.

--- a/monitoring/tempo.yml
+++ b/monitoring/tempo.yml
@@ -1,0 +1,22 @@
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+        http:
+
+ingester:
+  max_block_duration: 5m
+
+compactor:
+  compaction:
+    block_retention: 48h
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /tmp/tempo/traces


### PR DESCRIPTION
## Summary
- Add a dedicated `monitoring/` stack with Prometheus, Grafana, Alertmanager, Loki, Tempo, Promtail, Node Exporter, and Blackbox Exporter.
- Add baseline alert rules and Alertmanager routing for availability, resource usage, and key application SLO signals with runbook links.
- Add Grafana provisioning, a starter observability dashboard, and documentation/runbooks for setup and incident response.

## Test plan
- [ ] Run `cd monitoring && docker compose up -d`.
- [ ] Confirm Prometheus targets are up in `/targets`.
- [ ] Confirm Grafana loads `Bridge Watch Observability Overview`.
- [ ] Verify `probe_success`, `up`, and `bridge_health_score` metrics are visible.
- [ ] Trigger a synthetic alert and verify Alertmanager routing.

Closes StellaBridge/Bridge-Watch#176

