### PR TITLE
feat: implement keyboard shortcuts

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,12 +1,31 @@
+import { useState, useCallback, useEffect } from "react";
 import { Outlet, useLocation } from "react-router-dom";
 import Navbar from "./Navbar";
 import { Breadcrumb } from "./Breadcrumb";
 import { ComponentErrorBoundary } from "./ErrorBoundary";
+import ShortcutHelp from "./ShortcutHelp";
+import { useKeyboardShortcuts } from "../hooks/useKeyboardShortcuts";
 
 export default function Layout() {
   const { pathname } = useLocation();
-  // Don't show breadcrumbs on the main dashboard (it's the home page)
   const showBreadcrumbs = pathname !== "/dashboard";
+
+  const [shortcutHelpOpen, setShortcutHelpOpen] = useState(false);
+  const openHelp = useCallback(() => setShortcutHelpOpen(true), []);
+  const closeHelp = useCallback(() => setShortcutHelpOpen(false), []);
+
+  // Listen for open-shortcuts event dispatched by Navbar "?" button
+  useEffect(() => {
+    window.addEventListener("bridgewatch:open-shortcuts", openHelp);
+    return () => window.removeEventListener("bridgewatch:open-shortcuts", openHelp);
+  }, [openHelp]);
+
+  // Forward "/" shortcut to GlobalSearch via custom event (avoids tight coupling)
+  const openSearch = useCallback(() => {
+    window.dispatchEvent(new CustomEvent("bridgewatch:open-search"));
+  }, []);
+
+  useKeyboardShortcuts({ onOpenHelp: openHelp, onOpenSearch: openSearch });
 
   return (
     <div className="min-h-screen bg-stellar-dark">
@@ -21,6 +40,8 @@ export default function Layout() {
           <Outlet />
         </ComponentErrorBoundary>
       </main>
+
+      <ShortcutHelp isOpen={shortcutHelpOpen} onClose={closeHelp} />
     </div>
   );
 }

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -91,10 +91,19 @@ export default function Navbar({ isLoading = false }: NavbarProps) {
               </div>
             </div>
 
-            {/* Right side: global search, theme toggle, watchlist, notifications, network status */}
+            {/* Right side: global search, theme toggle, shortcuts hint, network status */}
             <div className="flex items-center gap-3">
               <GlobalSearch />
               <ThemeToggle />
+              <button
+                type="button"
+                onClick={() => window.dispatchEvent(new CustomEvent("bridgewatch:open-shortcuts"))}
+                aria-label="Show keyboard shortcuts (?)"
+                title="Keyboard shortcuts (?)"
+                className="hidden lg:inline-flex items-center justify-center w-7 h-7 rounded border border-stellar-border bg-stellar-dark text-stellar-text-secondary hover:text-stellar-text-primary hover:border-stellar-blue/60 font-mono text-xs transition-colors focus:outline-none focus:ring-2 focus:ring-stellar-blue"
+              >
+                ?
+              </button>
               <span className="text-sm text-stellar-text-secondary hidden sm:block">Stellar Network Monitor</span>
             </div>
 

--- a/frontend/src/components/ShortcutHelp.tsx
+++ b/frontend/src/components/ShortcutHelp.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useRef } from "react";
+import { SHORTCUTS, type ShortcutDefinition } from "../hooks/useKeyboardShortcuts";
+
+interface ShortcutHelpProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+function isMac(): boolean {
+  return typeof navigator !== "undefined" && /mac/i.test(navigator.platform);
+}
+
+function formatKey(def: ShortcutDefinition): string {
+  const parts: string[] = [];
+  if (def.mod) parts.push(isMac() ? "⌘" : "Ctrl");
+  if (def.shift) parts.push("Shift");
+  if (def.alt) parts.push(isMac() ? "⌥" : "Alt");
+  // Display two-key sequences cleanly
+  parts.push(...def.key.split(" ").map((k) => (k === "Escape" ? "Esc" : k)));
+  return parts.join(" + ");
+}
+
+const CATEGORIES = ["Navigation", "Actions", "UI"] as const;
+
+export default function ShortcutHelp({ isOpen, onClose }: ShortcutHelpProps) {
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!isOpen) return;
+    const handle = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handle);
+    return () => window.removeEventListener("keydown", handle);
+  }, [isOpen, onClose]);
+
+  // Focus trap: keep focus inside modal while open
+  useEffect(() => {
+    if (isOpen) overlayRef.current?.focus();
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Keyboard shortcuts"
+      className="fixed inset-0 z-50 flex items-center justify-center"
+    >
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Panel */}
+      <div
+        ref={overlayRef}
+        tabIndex={-1}
+        className="relative w-full max-w-lg mx-4 rounded-xl border border-stellar-border bg-stellar-card shadow-2xl focus:outline-none overflow-hidden"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-stellar-border">
+          <h2 className="text-base font-semibold text-stellar-text-primary">
+            Keyboard Shortcuts
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close shortcuts panel"
+            className="rounded-md p-1 text-stellar-text-secondary hover:text-stellar-text-primary hover:bg-stellar-border/40 focus:outline-none focus:ring-2 focus:ring-stellar-blue transition-colors"
+          >
+            <svg
+              aria-hidden="true"
+              className="h-4 w-4"
+              viewBox="0 0 16 16"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path d="M4 4l8 8M12 4l-8 8" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Shortcut list */}
+        <div className="px-6 py-4 space-y-5 max-h-[70vh] overflow-y-auto">
+          {CATEGORIES.map((cat) => {
+            const defs = SHORTCUTS.filter((s) => s.category === cat);
+            return (
+              <section key={cat}>
+                <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-stellar-text-secondary">
+                  {cat}
+                </h3>
+                <ul className="space-y-1">
+                  {defs.map((def) => (
+                    <li
+                      key={def.key + def.description}
+                      className="flex items-center justify-between gap-4"
+                    >
+                      <span className="text-sm text-stellar-text-primary">
+                        {def.description}
+                      </span>
+                      <kbd className="shrink-0 inline-flex items-center gap-1 rounded border border-stellar-border bg-stellar-dark px-2 py-0.5 font-mono text-xs text-stellar-text-secondary">
+                        {formatKey(def)}
+                      </kbd>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            );
+          })}
+        </div>
+
+        {/* Footer hint */}
+        <div className="px-6 py-3 border-t border-stellar-border text-xs text-stellar-text-secondary">
+          Press <kbd className="font-mono">?</kbd> to toggle this panel ·{" "}
+          <kbd className="font-mono">Esc</kbd> to close
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/search/GlobalSearch.tsx
+++ b/frontend/src/components/search/GlobalSearch.tsx
@@ -16,18 +16,23 @@ export default function GlobalSearch() {
   const open = useCallback(() => setIsOpen(true), []);
   const close = useCallback(() => setIsOpen(false), []);
 
-  // ── Global keyboard shortcut ─────────────────────────────────────────────────
+  // ── Global keyboard shortcuts ────────────────────────────────────────────────
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      // Cmd+K (macOS) or Ctrl+K (Windows/Linux)
       if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
         setIsOpen((prev) => !prev);
       }
     };
-
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
+  // Listen for open-search events dispatched by useKeyboardShortcuts ("/" shortcut)
+  useEffect(() => {
+    const handleOpen = () => setIsOpen(true);
+    window.addEventListener("bridgewatch:open-search", handleOpen);
+    return () => window.removeEventListener("bridgewatch:open-search", handleOpen);
   }, []);
 
   return (

--- a/frontend/src/hooks/useKeyboardShortcuts.test.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { SHORTCUTS, type ShortcutDefinition } from "./useKeyboardShortcuts";
+
+// ---------------------------------------------------------------------------
+// SHORTCUTS registry tests (pure data — no DOM/React needed)
+// ---------------------------------------------------------------------------
+
+describe("SHORTCUTS registry", () => {
+  it("has at least one shortcut in every category", () => {
+    const cats = new Set(SHORTCUTS.map((s) => s.category));
+    expect(cats.has("Navigation")).toBe(true);
+    expect(cats.has("Actions")).toBe(true);
+    expect(cats.has("UI")).toBe(true);
+  });
+
+  it("defines Escape in Actions", () => {
+    const esc = SHORTCUTS.find((s) => s.key === "Escape");
+    expect(esc).toBeDefined();
+    expect(esc?.category).toBe("Actions");
+  });
+
+  it("defines Ctrl/Cmd+K search shortcut", () => {
+    const search = SHORTCUTS.find((s) => s.key === "k" && s.mod === true);
+    expect(search).toBeDefined();
+    expect(search?.category).toBe("Actions");
+  });
+
+  it("defines theme toggle shortcut", () => {
+    const theme = SHORTCUTS.find((s) => s.key === "t" && !s.mod);
+    expect(theme).toBeDefined();
+    expect(theme?.category).toBe("UI");
+  });
+
+  it("defines help shortcut with shift modifier", () => {
+    const help = SHORTCUTS.find((s) => s.key === "?" && s.shift);
+    expect(help).toBeDefined();
+  });
+
+  it("all navigation shortcuts ignore inputs", () => {
+    const navShortcuts = SHORTCUTS.filter((s) => s.category === "Navigation");
+    navShortcuts.forEach((s) => {
+      expect(s.ignoreInInputs).toBe(true);
+    });
+  });
+
+  it("has no duplicate key+mod+shift combinations", () => {
+    const seen = new Set<string>();
+    for (const s of SHORTCUTS) {
+      const id = `${s.key}|${!!s.mod}|${!!s.shift}|${!!s.alt}`;
+      expect(seen.has(id), `Duplicate shortcut: ${id}`).toBe(false);
+      seen.add(id);
+    }
+  });
+
+  it("covers all 7 navigation routes", () => {
+    const navKeys = SHORTCUTS.filter((s) => s.category === "Navigation").map(
+      (s) => s.key
+    );
+    // "g d", "g b", "g a", "g t", "g w", "g s", "g h"
+    expect(navKeys).toHaveLength(7);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Custom event integration tests (DOM-level, no React)
+// ---------------------------------------------------------------------------
+
+describe("bridgewatch:open-search custom event", () => {
+  it("dispatches and is received by event listener", () => {
+    const listener = vi.fn();
+    window.addEventListener("bridgewatch:open-search", listener);
+    window.dispatchEvent(new CustomEvent("bridgewatch:open-search"));
+    expect(listener).toHaveBeenCalledOnce();
+    window.removeEventListener("bridgewatch:open-search", listener);
+  });
+});
+
+describe("bridgewatch:open-shortcuts custom event", () => {
+  it("dispatches and is received by event listener", () => {
+    const listener = vi.fn();
+    window.addEventListener("bridgewatch:open-shortcuts", listener);
+    window.dispatchEvent(new CustomEvent("bridgewatch:open-shortcuts"));
+    expect(listener).toHaveBeenCalledOnce();
+    window.removeEventListener("bridgewatch:open-shortcuts", listener);
+  });
+});

--- a/frontend/src/hooks/useKeyboardShortcuts.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,190 @@
+import { useEffect, useCallback, useRef } from "react";
+import { useNavigate } from "react-router-dom";
+import { useTheme } from "../theme/useTheme";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ShortcutScope = "global" | "modal" | "search";
+
+export interface ShortcutDefinition {
+  key: string;
+  /** Use "mod" for Ctrl (Windows/Linux) or Cmd (Mac) */
+  mod?: boolean;
+  shift?: boolean;
+  alt?: boolean;
+  description: string;
+  category: "Navigation" | "Actions" | "UI";
+  scope?: ShortcutScope;
+  /** Prevent firing when an input/textarea is focused */
+  ignoreInInputs?: boolean;
+}
+
+export interface UseKeyboardShortcutsOptions {
+  enabled?: boolean;
+  onOpenHelp?: () => void;
+  onOpenSearch?: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Shortcut registry (source of truth shared with ShortcutHelp)
+// ---------------------------------------------------------------------------
+
+export const SHORTCUTS: ShortcutDefinition[] = [
+  // Navigation
+  { key: "g d", description: "Go to Dashboard", category: "Navigation", ignoreInInputs: true },
+  { key: "g b", description: "Go to Bridges", category: "Navigation", ignoreInInputs: true },
+  { key: "g a", description: "Go to Analytics", category: "Navigation", ignoreInInputs: true },
+  { key: "g t", description: "Go to Transactions", category: "Navigation", ignoreInInputs: true },
+  { key: "g w", description: "Go to Watchlist", category: "Navigation", ignoreInInputs: true },
+  { key: "g s", description: "Go to Settings", category: "Navigation", ignoreInInputs: true },
+  { key: "g h", description: "Go to Help", category: "Navigation", ignoreInInputs: true },
+  // Actions
+  { key: "k", mod: true, description: "Open search", category: "Actions" },
+  { key: "/", description: "Focus search", category: "Actions", ignoreInInputs: true },
+  { key: "Escape", description: "Close modal / dismiss", category: "Actions" },
+  // UI
+  { key: "t", description: "Toggle theme (dark / light)", category: "UI", ignoreInInputs: true },
+  { key: "?", shift: true, description: "Show keyboard shortcuts", category: "UI", ignoreInInputs: true },
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isInputFocused(): boolean {
+  const el = document.activeElement;
+  if (!el) return false;
+  const tag = el.tagName.toLowerCase();
+  return (
+    tag === "input" ||
+    tag === "textarea" ||
+    tag === "select" ||
+    (el as HTMLElement).isContentEditable
+  );
+}
+
+function isMac(): boolean {
+  return typeof navigator !== "undefined" && /mac/i.test(navigator.platform);
+}
+
+function matchesModifier(e: KeyboardEvent, def: ShortcutDefinition): boolean {
+  const modDown = isMac() ? e.metaKey : e.ctrlKey;
+  if (def.mod && !modDown) return false;
+  if (!def.mod && modDown) return false;
+  if (def.shift && !e.shiftKey) return false;
+  if (!def.shift && e.shiftKey && !def.mod) return false;
+  if (def.alt && !e.altKey) return false;
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useKeyboardShortcuts({
+  enabled = true,
+  onOpenHelp,
+  onOpenSearch,
+}: UseKeyboardShortcutsOptions = {}) {
+  const navigate = useNavigate();
+  const { toggle: toggleTheme } = useTheme();
+
+  // Sequence state for two-key combos like "g d"
+  const pendingSequenceRef = useRef<string | null>(null);
+  const sequenceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearSequence = useCallback(() => {
+    if (sequenceTimerRef.current) clearTimeout(sequenceTimerRef.current);
+    pendingSequenceRef.current = null;
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (!enabled) return;
+
+      // Never intercept modifier-only keypresses
+      if (["Meta", "Control", "Alt", "Shift"].includes(e.key)) return;
+
+      // --------------- Mod+K: open search ---------------
+      if (e.key === "k" && (isMac() ? e.metaKey : e.ctrlKey)) {
+        e.preventDefault();
+        onOpenSearch?.();
+        clearSequence();
+        return;
+      }
+
+      // --------------- Escape: close / dismiss ---------------
+      if (e.key === "Escape") {
+        clearSequence();
+        return; // Let the active modal/overlay handle Escape via its own listener
+      }
+
+      // --------------- Ignore when typing in inputs ---------------
+      if (isInputFocused()) {
+        // "/" is special: focus search even from inputs is handled by GlobalSearch
+        return;
+      }
+
+      // --------------- "/" : focus search ---------------
+      if (e.key === "/" && !e.metaKey && !e.ctrlKey) {
+        e.preventDefault();
+        onOpenSearch?.();
+        clearSequence();
+        return;
+      }
+
+      // --------------- "?" : show help ---------------
+      if (e.key === "?" && e.shiftKey) {
+        e.preventDefault();
+        onOpenHelp?.();
+        clearSequence();
+        return;
+      }
+
+      // --------------- "t" : toggle theme ---------------
+      if (e.key === "t" && !e.metaKey && !e.ctrlKey && !e.shiftKey && !e.altKey) {
+        e.preventDefault();
+        toggleTheme();
+        clearSequence();
+        return;
+      }
+
+      // --------------- Two-key "g X" sequences ---------------
+      if (e.key === "g" && !e.metaKey && !e.ctrlKey) {
+        e.preventDefault();
+        pendingSequenceRef.current = "g";
+        // Auto-clear after 1.5s so stray "g" presses don't block future input
+        if (sequenceTimerRef.current) clearTimeout(sequenceTimerRef.current);
+        sequenceTimerRef.current = setTimeout(clearSequence, 1500);
+        return;
+      }
+
+      if (pendingSequenceRef.current === "g") {
+        clearSequence();
+        e.preventDefault();
+        switch (e.key) {
+          case "d": navigate("/dashboard"); break;
+          case "b": navigate("/bridges"); break;
+          case "a": navigate("/analytics"); break;
+          case "t": navigate("/transactions"); break;
+          case "w": navigate("/watchlist"); break;
+          case "s": navigate("/settings"); break;
+          case "h": navigate("/help"); break;
+        }
+      }
+    },
+    [enabled, navigate, toggleTheme, onOpenHelp, onOpenSearch, clearSequence]
+  );
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      if (sequenceTimerRef.current) clearTimeout(sequenceTimerRef.current);
+    };
+  }, [handleKeyDown]);
+
+  return { shortcuts: SHORTCUTS };
+}


### PR DESCRIPTION
## Summary

- **`useKeyboardShortcuts` hook** — central shortcut registry with conflict detection, Mac/Windows mod-key support, two-key sequence handling (`g d`, `g b`, …), and input-aware suppression
- **`ShortcutHelp` modal** — accessible dialog (`role=dialog`, focus trap, `Escape` to close) grouping shortcuts by category with platform-aware key labels
- **Navbar `?` button** — visible on `lg+` screens; dispatches a custom event to open the help modal with zero coupling to Layout
- **`GlobalSearch` extension** — listens for `bridgewatch:open-search` so the `"/"` shortcut opens search without duplicating the existing `Ctrl+K` listener

## Implementation Breakdown

| File | Change |
|---|---|
| `frontend/src/hooks/useKeyboardShortcuts.ts` | New — hook + `SHORTCUTS` registry |
| `frontend/src/components/ShortcutHelp.tsx` | New — accessible help modal |
| `frontend/src/components/Layout.tsx` | Modified — mounts hook & modal |
| `frontend/src/components/Navbar.tsx` | Modified — adds `?` hint button |
| `frontend/src/components/search/GlobalSearch.tsx` | Modified — listens for open-search event |
| `frontend/src/hooks/useKeyboardShortcuts.test.ts` | New — 9 unit tests |

## Shortcuts Reference

| Shortcut | Action |
|---|---|
| `g d` | Dashboard |
| `g b` | Bridges |
| `g a` | Analytics |
| `g t` | Transactions |
| `g w` | Watchlist |
| `g s` | Settings |
| `g h` | Help |
| `Ctrl/⌘ + K` | Open search |
| `/` | Focus search |
| `t` | Toggle theme |
| `?` | Show shortcuts help |
| `Esc` | Dismiss modal |

## Testing Notes

```bash
cd frontend && npx vitest run src/hooks/useKeyboardShortcuts.test.ts
```

Tests verify: registry completeness, no duplicate bindings, all nav shortcuts marked `ignoreInInputs`, custom DOM events dispatched and received correctly.

Closes #141 