### PR TITLE
test: implement end-to-end testing suite

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,51 @@
+name: E2E Tests
+
+on:
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [main, develop]
+
+jobs:
+  playwright-e2e:
+    name: Playwright E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: Run E2E tests
+        run: npm run test:e2e
+        env:
+          CI: "true"
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report
+          if-no-files-found: ignore
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-results
+          path: test-results
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ Thumbs.db
 
 # Testing
 coverage/
+playwright-report/
+test-results/
+blob-report/
 load-tests/results/*.json
 load-tests/results/*.txt
 load-tests/results/*.md

--- a/PR_DESCRIPTION_168.md
+++ b/PR_DESCRIPTION_168.md
@@ -1,0 +1,20 @@
+## Summary
+- #168: Implement End-to-End Testing Suite
+
+## Changes
+- Added Playwright E2E infrastructure at the repository root with cross-browser and mobile projects, retries for flaky test handling, and artifact reporters (HTML, JUnit, JSON).
+- Implemented page-object-based tests for critical flows: landing-to-dashboard navigation, dashboard customization interactions, bridges page rendering, and mobile navigation behavior.
+- Added deterministic API fixture mocking (`e2e/fixtures` + `e2e/utils/mockApi.ts`) to keep E2E coverage stable without requiring backend services.
+- Added CI integration via `.github/workflows/e2e.yml` to install Playwright browsers, execute E2E tests, and upload reports/results artifacts.
+- Documented E2E patterns, execution commands, flaky-test strategy, and data management conventions in `docs/E2E_TESTING_GUIDE.md`.
+- Updated root scripts and ignore rules to support E2E execution and artifact management.
+
+## Testing
+- [x] Run `npm run test:e2e` locally (all configured projects)
+- [x] Verify cross-browser matrix: Chromium, Firefox, WebKit
+- [x] Verify mobile viewport flow via `mobile-chrome` project
+- [x] Validate dashboard onboarding does not block automated flows (localStorage pre-seeded)
+- [x] Validate fixture-driven API responses for `/api/v1/assets`, `/api/v1/assets/:symbol/health`, `/api/v1/bridges`
+
+## Closing
+Closes StellaBridge/Bridge-Watch#168

--- a/docs/E2E_TESTING_GUIDE.md
+++ b/docs/E2E_TESTING_GUIDE.md
@@ -1,0 +1,69 @@
+# End-to-End Testing Guide
+
+This project uses Playwright for end-to-end (E2E) testing of critical user flows.
+
+## Goals
+
+- Validate high-value user journeys from UI entrypoint to routed pages.
+- Catch cross-browser regressions early.
+- Support stable CI execution with retries, traces, screenshots, and video evidence.
+
+## Current Coverage
+
+- Landing page renders and routes to Dashboard.
+- Dashboard renders key widgets with mocked backend responses.
+- Dashboard customization panel interactions.
+- Bridges page renders bridge cards.
+- Mobile navigation menu flow to Bridges page.
+
+## Test Architecture
+
+- `e2e/tests`: Test specs focused on user behavior.
+- `e2e/pages`: Page Object Models to keep selectors and interactions centralized.
+- `e2e/fixtures`: Deterministic test data fixtures.
+- `e2e/utils/mockApi.ts`: API interception and mocked responses.
+
+## Running Tests
+
+From repository root:
+
+- `npm run test:e2e` - Run all E2E tests.
+- `npm run test:e2e:headed` - Run in headed mode for local debugging.
+- `npm run test:e2e:ui` - Open Playwright UI mode.
+- `npm run test:e2e:report` - View generated HTML report.
+
+## Browser and Device Matrix
+
+Playwright projects currently run:
+
+- Chromium (Desktop)
+- Firefox (Desktop)
+- WebKit (Desktop)
+- Pixel 7 (Mobile viewport + user agent)
+
+## Failure Evidence and Reporting
+
+- Screenshot capture on failure (`only-on-failure`).
+- Video capture retained for retries/failures.
+- Trace capture on first retry.
+- CI artifacts uploaded:
+  - `playwright-report`
+  - `test-results` (includes JUnit + JSON outputs)
+
+## Flaky Test Handling
+
+- Retries enabled (`2` in CI, `1` locally).
+- API requests are mocked for deterministic responses.
+- Assertions use semantic roles and visible text over unstable DOM structure.
+
+## Test Data Management Pattern
+
+- Keep realistic, minimal fixtures in `e2e/fixtures`.
+- Add/modify fixture files for new flows instead of hardcoding payloads in specs.
+- Use route-level mock handlers in `mockApi.ts` so multiple tests reuse the same setup.
+
+## CI Integration
+
+GitHub Actions workflow: `.github/workflows/e2e.yml`
+
+CI workflow installs dependencies, installs Playwright browsers, runs E2E tests, and uploads reports/results for debugging.

--- a/e2e/fixtures/asset-health.json
+++ b/e2e/fixtures/asset-health.json
@@ -1,0 +1,26 @@
+{
+  "USDC": {
+    "symbol": "USDC",
+    "overallScore": 92,
+    "factors": {
+      "liquidityDepth": 94,
+      "priceStability": 89,
+      "bridgeUptime": 96,
+      "reserveBacking": 93,
+      "volumeTrend": 90
+    },
+    "trend": "improving"
+  },
+  "EURC": {
+    "symbol": "EURC",
+    "overallScore": 74,
+    "factors": {
+      "liquidityDepth": 70,
+      "priceStability": 79,
+      "bridgeUptime": 72,
+      "reserveBacking": 74,
+      "volumeTrend": 75
+    },
+    "trend": "stable"
+  }
+}

--- a/e2e/fixtures/assets.json
+++ b/e2e/fixtures/assets.json
@@ -1,0 +1,17 @@
+{
+  "assets": [
+    {
+      "symbol": "USDC",
+      "name": "USD Coin",
+      "sourceChain": "Ethereum",
+      "issuerAddress": "GABCUSDC123"
+    },
+    {
+      "symbol": "EURC",
+      "name": "Euro Coin",
+      "sourceChain": "Ethereum",
+      "issuerAddress": "GABCEURC123"
+    }
+  ],
+  "total": 2
+}

--- a/e2e/fixtures/bridges.json
+++ b/e2e/fixtures/bridges.json
@@ -1,0 +1,20 @@
+{
+  "bridges": [
+    {
+      "name": "Allbridge",
+      "status": "healthy",
+      "totalValueLocked": 1525000,
+      "supplyOnStellar": 1200000,
+      "supplyOnSource": 1201500,
+      "mismatchPercentage": 0.124
+    },
+    {
+      "name": "Wormhole",
+      "status": "degraded",
+      "totalValueLocked": 934000,
+      "supplyOnStellar": 910000,
+      "supplyOnSource": 918800,
+      "mismatchPercentage": 0.958
+    }
+  ]
+}

--- a/e2e/pages/BridgesPage.ts
+++ b/e2e/pages/BridgesPage.ts
@@ -1,0 +1,20 @@
+import { type Locator, type Page, expect } from "@playwright/test";
+
+export class BridgesPage {
+  readonly page: Page;
+  readonly heading: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.heading = page.getByRole("heading", { name: "Bridges" });
+  }
+
+  async goto(): Promise<void> {
+    await this.page.goto("/bridges");
+    await expect(this.heading).toBeVisible();
+  }
+
+  async assertBridgeVisible(bridgeName: string): Promise<void> {
+    await expect(this.page.getByText(bridgeName)).toBeVisible();
+  }
+}

--- a/e2e/pages/DashboardPage.ts
+++ b/e2e/pages/DashboardPage.ts
@@ -1,0 +1,44 @@
+import { type Locator, type Page, expect } from "@playwright/test";
+
+export class DashboardPage {
+  readonly page: Page;
+  readonly heading: Locator;
+  readonly assetHealthHeading: Locator;
+  readonly bridgeStatusHeading: Locator;
+  readonly customizeWidgetsButton: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.heading = page.getByRole("heading", { name: "Dashboard" });
+    this.assetHealthHeading = page.getByRole("heading", { name: "Asset Health" });
+    this.bridgeStatusHeading = page.getByRole("heading", { name: "Bridge Status" });
+    this.customizeWidgetsButton = page.getByRole("button", { name: "Customize widgets" });
+  }
+
+  async dismissOnboardingIfPresent(): Promise<void> {
+    const dialog = this.page.getByRole("dialog", { name: "Welcome to Bridge Watch" });
+    if (await dialog.isVisible()) {
+      const skipButton = this.page.getByRole("button", { name: "Skip" });
+      if (await skipButton.isVisible()) {
+        await skipButton.click({ force: true });
+      } else {
+        await this.page.getByRole("button", { name: "Close onboarding" }).click({ force: true });
+      }
+      await expect(dialog).toBeHidden();
+    }
+  }
+
+  async assertLoaded(): Promise<void> {
+    await this.dismissOnboardingIfPresent();
+    await expect(this.heading).toBeVisible();
+    await expect(this.assetHealthHeading).toBeVisible();
+    await expect(this.bridgeStatusHeading).toBeVisible();
+    await expect(this.page.getByRole("link", { name: /View details for bridge Allbridge/i })).toBeVisible();
+    await expect(this.page.getByText("Allbridge")).toBeVisible();
+  }
+
+  async openCustomizationPanel(): Promise<void> {
+    await this.customizeWidgetsButton.click();
+    await expect(this.page.getByText("Preset layouts")).toBeVisible();
+  }
+}

--- a/e2e/pages/LandingPage.ts
+++ b/e2e/pages/LandingPage.ts
@@ -1,0 +1,23 @@
+import { type Locator, type Page, expect } from "@playwright/test";
+
+export class LandingPage {
+  readonly page: Page;
+  readonly launchAppButton: Locator;
+  readonly heroHeading: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.launchAppButton = page.getByRole("link", { name: "Launch App" });
+    this.heroHeading = page.getByRole("heading", { name: "Real-Time Bridge Monitoring" });
+  }
+
+  async goto(): Promise<void> {
+    await this.page.goto("/");
+    await expect(this.heroHeading).toBeVisible();
+  }
+
+  async openDashboard(): Promise<void> {
+    await this.launchAppButton.click();
+    await expect(this.page).toHaveURL(/\/dashboard$/);
+  }
+}

--- a/e2e/tests/critical-flows.spec.ts
+++ b/e2e/tests/critical-flows.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from "@playwright/test";
+import { LandingPage } from "../pages/LandingPage";
+import { DashboardPage } from "../pages/DashboardPage";
+import { BridgesPage } from "../pages/BridgesPage";
+import { mockCoreApi } from "../utils/mockApi";
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("bridge-watch:onboarding:v1", "true");
+  });
+  await mockCoreApi(page);
+});
+
+test("navigates landing to dashboard and renders core widgets", async ({ page }) => {
+  const landingPage = new LandingPage(page);
+  const dashboardPage = new DashboardPage(page);
+
+  await landingPage.goto();
+  await landingPage.openDashboard();
+  await dashboardPage.assertLoaded();
+});
+
+test("opens widget customization and applies dashboard interactions", async ({ page }) => {
+  const dashboardPage = new DashboardPage(page);
+
+  await page.goto("/dashboard");
+  await dashboardPage.assertLoaded();
+  await dashboardPage.openCustomizationPanel();
+
+  await page.getByRole("button", { name: "Operations" }).click();
+  await expect(page.getByText("Layout import/export payload")).toBeVisible();
+});
+
+test("loads bridges page and bridge cards from mocked data", async ({ page }) => {
+  const bridgesPage = new BridgesPage(page);
+  await bridgesPage.goto();
+  await bridgesPage.assertBridgeVisible("Allbridge");
+  await bridgesPage.assertBridgeVisible("Wormhole");
+});

--- a/e2e/tests/mobile-navigation.spec.ts
+++ b/e2e/tests/mobile-navigation.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from "@playwright/test";
+import { mockCoreApi } from "../utils/mockApi";
+import { DashboardPage } from "../pages/DashboardPage";
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("bridge-watch:onboarding:v1", "true");
+  });
+  await mockCoreApi(page);
+});
+
+test("mobile menu opens and can navigate to bridges page", async ({ page, isMobile }) => {
+  test.skip(!isMobile, "Mobile-only test");
+  const dashboardPage = new DashboardPage(page);
+
+  await page.goto("/dashboard");
+  await dashboardPage.dismissOnboardingIfPresent();
+  await page.getByRole("button", { name: "Open navigation menu" }).click();
+  const mobileNavDialog = page.getByRole("dialog", { name: "Mobile navigation" });
+  await mobileNavDialog.getByRole("link", { name: /Bridges Bridge performance/i }).click();
+
+  await expect(page).toHaveURL(/\/bridges$/);
+  await expect(page.getByRole("heading", { name: "Bridges" })).toBeVisible();
+});

--- a/e2e/utils/mockApi.ts
+++ b/e2e/utils/mockApi.ts
@@ -1,0 +1,57 @@
+import { type Page } from "@playwright/test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const assetsFixture = JSON.parse(
+  readFileSync(resolve(__dirname, "../fixtures/assets.json"), "utf8"),
+);
+const assetHealthFixture = JSON.parse(
+  readFileSync(resolve(__dirname, "../fixtures/asset-health.json"), "utf8"),
+);
+const bridgesFixture = JSON.parse(
+  readFileSync(resolve(__dirname, "../fixtures/bridges.json"), "utf8"),
+);
+
+const jsonHeaders = { "content-type": "application/json" };
+
+export async function mockCoreApi(page: Page): Promise<void> {
+  await page.route("**/api/v1/assets", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: jsonHeaders,
+      body: JSON.stringify(assetsFixture),
+    });
+  });
+
+  await page.route("**/api/v1/assets/*/health*", async (route) => {
+    const url = new URL(route.request().url());
+    const match = url.pathname.match(/\/api\/v1\/assets\/([^/]+)\/health/);
+    const symbol = match?.[1] ?? "";
+    const body = (assetHealthFixture as Record<string, unknown>)[symbol] ?? null;
+
+    await route.fulfill({
+      status: 200,
+      headers: jsonHeaders,
+      body: JSON.stringify(body),
+    });
+  });
+
+  await page.route("**/api/v1/bridges", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: jsonHeaders,
+      body: JSON.stringify(bridgesFixture),
+    });
+  });
+
+  await page.route("**/health", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: jsonHeaders,
+      body: JSON.stringify({
+        status: "ok",
+        timestamp: new Date().toISOString(),
+      }),
+    });
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "frontend"
       ],
       "devDependencies": {
+        "@playwright/test": "^1.54.2",
         "@rollup/rollup-linux-x64-gnu": "^4.60.2"
       },
       "engines": {
@@ -140,6 +141,7 @@
       "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.2",
         "@vitest/mocker": "4.1.2",
@@ -249,6 +251,7 @@
       "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -453,6 +456,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -844,6 +848,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -892,6 +897,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -913,6 +919,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -949,31 +956,6 @@
         "react": ">=16.8.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -981,7 +963,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -999,7 +980,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1017,7 +997,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1035,7 +1014,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1053,7 +1031,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1071,7 +1048,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1089,7 +1065,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1107,7 +1082,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1125,7 +1099,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1143,7 +1116,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1161,7 +1133,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1179,7 +1150,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1197,7 +1167,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1215,7 +1184,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1233,7 +1201,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1251,7 +1218,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1269,7 +1235,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1287,7 +1252,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1305,7 +1269,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1323,7 +1286,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1341,7 +1303,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1359,7 +1320,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1377,7 +1337,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1395,7 +1354,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1413,7 +1371,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1431,7 +1388,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1449,7 +1405,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2421,6 +2376,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@remix-run/router": {
@@ -3508,6 +3479,7 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -3570,6 +3542,7 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -3970,6 +3943,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4484,6 +4458,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5551,6 +5526,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -6691,21 +6667,6 @@
         }
       }
     },
-    "node_modules/html-encoding-sniffer/node_modules/@noble/hashes": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
-      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -6761,6 +6722,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.29.2"
       },
@@ -7372,6 +7334,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -7416,6 +7379,7 @@
       "integrity": "sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.0.1",
         "@asamuzakjp/dom-selector": "^7.0.3",
@@ -7467,21 +7431,6 @@
         "@noble/hashes": {
           "optional": true
         }
-      }
-    },
-    "node_modules/jsdom/node_modules/@noble/hashes": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
-      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/jsdom/node_modules/lru-cache": {
@@ -8360,6 +8309,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^5.0.0",
         "@mswjs/interceptors": "^0.41.2",
@@ -8987,6 +8937,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9098,6 +9049,53 @@
         "node": ">= 6"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/png-js": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.0.0.tgz",
@@ -9132,6 +9130,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9477,6 +9476,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -9489,6 +9489,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -11139,6 +11140,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11287,6 +11289,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -11796,6 +11799,7 @@
       "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "2.1.9",
         "@vitest/mocker": "2.1.9",
@@ -12103,21 +12107,6 @@
         "@noble/hashes": {
           "optional": true
         }
-      }
-    },
-    "node_modules/whatwg-url/node_modules/@noble/hashes": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
-      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
     "test:backend": "npm run test --workspace=backend",
     "test:load": "k6 run load-tests/scenarios/api-load.js -e PROFILE=smoke -e BASE_URL=http://127.0.0.1:3001",
     "test:load:report": "node load-tests/scripts/generate-report.mjs load-tests/results/summary.json load-tests/results/report.md",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:report": "playwright show-report",
     "lint": "npm run lint --workspaces --if-present",
     "setup": "bash scripts/setup.sh",
     "setup:quick": "bash scripts/setup.sh --skip-contracts --skip-ide -y"
@@ -41,6 +45,7 @@
     "analytics"
   ],
   "devDependencies": {
+    "@playwright/test": "^1.54.2",
     "@rollup/rollup-linux-x64-gnu": "^4.60.2"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,52 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const baseURL = process.env.E2E_BASE_URL ?? "http://127.0.0.1:4173";
+
+export default defineConfig({
+  testDir: "./e2e/tests",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 1,
+  workers: process.env.CI ? 2 : undefined,
+  timeout: 45_000,
+  expect: {
+    timeout: 8_000,
+  },
+  reporter: [
+    ["list"],
+    ["html", { outputFolder: "playwright-report", open: "never" }],
+    ["junit", { outputFile: "test-results/e2e-junit.xml" }],
+    ["json", { outputFile: "test-results/e2e-results.json" }],
+  ],
+  use: {
+    baseURL,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: process.env.CI ? "retain-on-failure" : "on-first-retry",
+    viewport: { width: 1280, height: 720 },
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] },
+    },
+    {
+      name: "webkit",
+      use: { ...devices["Desktop Safari"] },
+    },
+    {
+      name: "mobile-chrome",
+      use: { ...devices["Pixel 7"] },
+    },
+  ],
+  webServer: {
+    command: "npm --workspace=frontend run dev -- --host 127.0.0.1 --port 4173",
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});


### PR DESCRIPTION
## Summary
- Add a Playwright-based E2E test framework with page objects, deterministic API fixtures, and reusable mock utilities
- Cover critical frontend user flows (landing -> dashboard, dashboard customization, bridges page) plus mobile navigation flow
- Integrate E2E into CI with cross-browser execution, retries, and artifact reporting (HTML/JUnit/JSON, screenshots, trace, video)

## Test plan
- [x] Run `npm run test:e2e` locally
- [x] Verify cross-browser projects: Chromium, Firefox, WebKit
- [x] Verify mobile viewport project: mobile-chrome
- [x] Confirm failure diagnostics are configured: screenshots, traces, and video retention on retries/failures
- [x] Validate test documentation in `docs/E2E_TESTING_GUIDE.md`

Closes StellaBridge/Bridge-Watch#168

