### PR TITLE
feat: add backfill orchestration service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -104,6 +104,11 @@ BRIDGE_SUPPLY_MISMATCH_THRESHOLD=0.1
 # -----------------------------------------------------------------------------
 RETRY_MAX=3
 BRIDGE_VERIFICATION_INTERVAL_MS=300000
+BACKFILL_QUEUE_CONCURRENCY=2
+BACKFILL_DEFAULT_MAX_PAGES=250
+BACKFILL_CHUNK_PAGES=5
+BACKFILL_PAGE_SIZE=100
+BACKFILL_PROVIDER_DELAY_MS=500
 
 # -----------------------------------------------------------------------------
 # Health Score Weights (must sum to 1.0)

--- a/backend/docs/API.md
+++ b/backend/docs/API.md
@@ -174,6 +174,14 @@ Common HTTP status codes:
 | GET | `/monitor` | Queue status and failed jobs |
 | POST | `/:jobName/trigger` | Manually enqueue a job |
 
+### Backfill `/api/v1/backfill`
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/` | Start a transactional backfill job for an asset |
+| GET | `/` | List current backfill jobs and progress |
+| GET | `/:jobId` | Get backfill job status and metrics |
+| POST | `/:jobId/resume` | Resume a failed or paused backfill job |
+
 ### Config `/api/v1/config`
 | Method | Path | Description |
 |--------|------|-------------|

--- a/backend/package.json
+++ b/backend/package.json
@@ -65,6 +65,7 @@
     "@typescript-eslint/parser": "^7.18.0",
     "@vitest/coverage-v8": "^2.1.9",
     "eslint": "^8.57.1",
+    "pathe": "^2.0.3",
     "tsx": "^4.19.2",
     "typescript": "^5.9.3",
     "vitest": "^2.1.5"

--- a/backend/src/api/routes/backfill.routes.js
+++ b/backend/src/api/routes/backfill.routes.js
@@ -1,0 +1,159 @@
+"use strict";
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g = Object.create((typeof Iterator === "function" ? Iterator : Object).prototype);
+    return g.next = verb(0), g["throw"] = verb(1), g["return"] = verb(2), typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (g && (g = 0, op[0] && (_ = 0)), _) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.backfillRoutes = backfillRoutes;
+var backfill_service_js_1 = require("../../services/backfill.service.js");
+var backfillService = new backfill_service_js_1.BackfillService();
+function backfillRoutes(server) {
+    return __awaiter(this, void 0, void 0, function () {
+        var _this = this;
+        return __generator(this, function (_a) {
+            server.post("/", {
+                schema: {
+                    tags: ["Backfill"],
+                    summary: "Start a historical transaction backfill job",
+                    body: {
+                        type: "object",
+                        required: ["assetCode", "assetIssuer"],
+                        properties: {
+                            assetCode: { type: "string" },
+                            assetIssuer: { type: "string" },
+                            bridgeName: { type: "string" },
+                            operationTypes: { type: "array", items: { type: "string" } },
+                            cursor: { type: "string" },
+                            pages: { type: "number", default: 250 },
+                            pageSize: { type: "number", default: 100 },
+                            chunkPages: { type: "number", default: 5 },
+                            priority: { type: "string", enum: ["normal", "high"], default: "normal" },
+                        },
+                    },
+                    response: { 200: { type: "object", additionalProperties: true } },
+                },
+            }, function (request) { return __awaiter(_this, void 0, void 0, function () {
+                var result;
+                return __generator(this, function (_a) {
+                    switch (_a.label) {
+                        case 0: return [4 /*yield*/, backfillService.createTransactionBackfill(request.body)];
+                        case 1:
+                            result = _a.sent();
+                            return [2 /*return*/, __assign({ success: true }, result)];
+                    }
+                });
+            }); });
+            server.get("/", {
+                schema: {
+                    tags: ["Backfill"],
+                    summary: "List active backfill jobs",
+                    response: { 200: { type: "object", additionalProperties: true } },
+                },
+            }, function () { return __awaiter(_this, void 0, void 0, function () {
+                var jobs;
+                return __generator(this, function (_a) {
+                    switch (_a.label) {
+                        case 0: return [4 /*yield*/, backfillService.listBackfillJobs()];
+                        case 1:
+                            jobs = _a.sent();
+                            return [2 /*return*/, { jobs: jobs }];
+                    }
+                });
+            }); });
+            server.get("/:jobId", {
+                schema: {
+                    tags: ["Backfill"],
+                    summary: "Get backfill job status",
+                    params: {
+                        type: "object",
+                        required: ["jobId"],
+                        properties: { jobId: { type: "string" } },
+                    },
+                    response: { 200: { type: "object", additionalProperties: true } },
+                },
+            }, function (request, reply) { return __awaiter(_this, void 0, void 0, function () {
+                var job;
+                return __generator(this, function (_a) {
+                    switch (_a.label) {
+                        case 0: return [4 /*yield*/, backfillService.getJobStatus(request.params.jobId)];
+                        case 1:
+                            job = _a.sent();
+                            if (!job) {
+                                return [2 /*return*/, reply.status(404).send({ error: "Backfill job not found" })];
+                            }
+                            return [2 /*return*/, { job: job }];
+                    }
+                });
+            }); });
+            server.post("/:jobId/resume", {
+                schema: {
+                    tags: ["Backfill"],
+                    summary: "Resume a failed or paused backfill job",
+                    params: {
+                        type: "object",
+                        required: ["jobId"],
+                        properties: { jobId: { type: "string" } },
+                    },
+                    response: { 200: { type: "object", additionalProperties: true } },
+                },
+            }, function (request, reply) { return __awaiter(_this, void 0, void 0, function () {
+                var job;
+                return __generator(this, function (_a) {
+                    switch (_a.label) {
+                        case 0: return [4 /*yield*/, backfillService.resumeBackfillJob(request.params.jobId)];
+                        case 1:
+                            job = _a.sent();
+                            if (!job) {
+                                return [2 /*return*/, reply.status(404).send({ error: "Backfill job not found" })];
+                            }
+                            return [2 /*return*/, { job: job }];
+                    }
+                });
+            }); });
+            return [2 /*return*/];
+        });
+    });
+}

--- a/backend/src/api/routes/backfill.routes.ts
+++ b/backend/src/api/routes/backfill.routes.ts
@@ -1,0 +1,113 @@
+import type { FastifyInstance } from "fastify";
+import { BackfillService } from "../../services/backfill.service.js";
+
+const backfillService = new BackfillService();
+
+export async function backfillRoutes(server: FastifyInstance) {
+  server.post<{
+    Body: {
+      assetCode: string;
+      assetIssuer: string;
+      bridgeName?: string;
+      operationTypes?: string[];
+      cursor?: string;
+      pages?: number;
+      pageSize?: number;
+      chunkPages?: number;
+      priority?: "normal" | "high";
+    };
+  }>(
+    "/",
+    {
+      schema: {
+        tags: ["Backfill"],
+        summary: "Start a historical transaction backfill job",
+        body: {
+          type: "object",
+          required: ["assetCode", "assetIssuer"],
+          properties: {
+            assetCode: { type: "string" },
+            assetIssuer: { type: "string" },
+            bridgeName: { type: "string" },
+            operationTypes: { type: "array", items: { type: "string" } },
+            cursor: { type: "string" },
+            pages: { type: "number", default: 250 },
+            pageSize: { type: "number", default: 100 },
+            chunkPages: { type: "number", default: 5 },
+            priority: { type: "string", enum: ["normal", "high"], default: "normal" },
+          },
+        },
+        response: { 200: { type: "object", additionalProperties: true } },
+      },
+    },
+    async (request) => {
+      const result = await backfillService.createTransactionBackfill(request.body);
+      return { success: true, ...result };
+    },
+  );
+
+  server.get(
+    "/",
+    {
+      schema: {
+        tags: ["Backfill"],
+        summary: "List active backfill jobs",
+        response: { 200: { type: "object", additionalProperties: true } },
+      },
+    },
+    async () => {
+      const jobs = await backfillService.listBackfillJobs();
+      return { jobs };
+    },
+  );
+
+  server.get<{
+    Params: { jobId: string };
+  }>(
+    "/:jobId",
+    {
+      schema: {
+        tags: ["Backfill"],
+        summary: "Get backfill job status",
+        params: {
+          type: "object",
+          required: ["jobId"],
+          properties: { jobId: { type: "string" } },
+        },
+        response: { 200: { type: "object", additionalProperties: true } },
+      },
+    },
+    async (request, reply) => {
+      const job = await backfillService.getJobStatus(request.params.jobId);
+      if (!job) {
+        return reply.status(404).send({ error: "Backfill job not found" });
+      }
+      return { job };
+    },
+  );
+
+  server.post<{
+    Params: { jobId: string };
+  }>(
+    "/:jobId/resume",
+    {
+      schema: {
+        tags: ["Backfill"],
+        summary: "Resume a failed or paused backfill job",
+        params: {
+          type: "object",
+          required: ["jobId"],
+          properties: { jobId: { type: "string" } },
+        },
+        response: { 200: { type: "object", additionalProperties: true } },
+      },
+    },
+    async (request, reply) => {
+      const job = await backfillService.resumeBackfillJob(request.params.jobId);
+      if (!job) {
+        return reply.status(404).send({ error: "Backfill job not found" });
+      }
+      return { job };
+    },
+  );
+}

--- a/backend/src/api/routes/index.ts
+++ b/backend/src/api/routes/index.ts
@@ -36,6 +36,7 @@ import { healthScoreHistoryRoutes } from "./healthScoreHistory.routes.js";
 import { horizonStreamRoutes } from "./horizonStream.routes.js";
 import { adminRotationRoutes } from "./adminRotation.js";
 import { digestSchedulerRoutes } from "./digestScheduler.js";
+import { backfillRoutes } from "./backfill.routes.js";
 
 export async function registerRoutes(server: FastifyInstance) {
   server.register(assetsRoutes, { prefix: "/api/v1/assets" });
@@ -77,4 +78,5 @@ export async function registerRoutes(server: FastifyInstance) {
   server.register(horizonStreamRoutes, { prefix: "/api/v1/horizon-streams" });
   server.register(adminRotationRoutes, { prefix: "/api/v1/admin/rotation" });
   server.register(digestSchedulerRoutes, { prefix: "/api/v1/digest" });
+  server.register(backfillRoutes, { prefix: "/api/v1/backfill" });
 }

--- a/backend/src/config/database.js
+++ b/backend/src/config/database.js
@@ -1,0 +1,39 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.databaseConfig = void 0;
+var index_js_1 = require("./index.js");
+exports.databaseConfig = {
+    client: "pg",
+    connection: {
+        host: index_js_1.config.POSTGRES_HOST,
+        port: index_js_1.config.POSTGRES_PORT,
+        database: index_js_1.config.POSTGRES_DB,
+        user: index_js_1.config.POSTGRES_USER,
+        password: index_js_1.config.POSTGRES_PASSWORD,
+        // Keep connections alive
+        keepAlive: true,
+    },
+    pool: {
+        min: 2,
+        max: 20,
+        // Destroy idle connections after 30s
+        idleTimeoutMillis: 30000,
+        // Fail fast if pool is exhausted
+        acquireTimeoutMillis: 10000,
+        // Validate connection before use
+        afterCreate: function (conn, done) {
+            conn.query("SET timezone='UTC'", function (err) { return done(err, conn); });
+        },
+    },
+    migrations: {
+        directory: "./src/database/migrations",
+        tableName: "knex_migrations",
+        extension: "ts",
+        loadExtensions: [".ts", ".js"],
+    },
+    seeds: {
+        directory: "./src/database/seeds",
+        extension: "ts",
+        loadExtensions: [".ts", ".js"],
+    },
+};

--- a/backend/src/config/index.js
+++ b/backend/src/config/index.js
@@ -1,0 +1,181 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.config = exports.SUPPORTED_ASSETS = void 0;
+var zod_1 = require("zod");
+var dotenv_1 = require("dotenv");
+dotenv_1.default.config();
+var envSchema = zod_1.z.object({
+    NODE_ENV: zod_1.z
+        .enum(["development", "production", "test"])
+        .default("development"),
+    PORT: zod_1.z.coerce.number().default(3001),
+    WS_PORT: zod_1.z.coerce.number().default(3002),
+    // PostgreSQL + TimescaleDB
+    POSTGRES_HOST: zod_1.z.string().default("localhost"),
+    POSTGRES_PORT: zod_1.z.coerce.number().default(5432),
+    POSTGRES_DB: zod_1.z.string().default("bridge_watch"),
+    POSTGRES_USER: zod_1.z.string().default("bridge_watch"),
+    POSTGRES_PASSWORD: zod_1.z.string().default("bridge_watch_dev"),
+    // Redis
+    REDIS_HOST: zod_1.z.string().default("localhost"),
+    REDIS_PORT: zod_1.z.coerce.number().default(6379),
+    REDIS_PASSWORD: zod_1.z.string().default(""),
+    // Stellar
+    STELLAR_NETWORK: zod_1.z.enum(["testnet", "mainnet"]).default("testnet"),
+    STELLAR_HORIZON_URL: zod_1.z
+        .string()
+        .url()
+        .default("https://horizon-testnet.stellar.org"),
+    SOROBAN_RPC_URL: zod_1.z
+        .string()
+        .url()
+        .default("https://soroban-testnet.stellar.org"),
+    SOROBAN_MAINNET_RPC_URL: zod_1.z.string().url().optional(),
+    CIRCUIT_BREAKER_CONTRACT_ID: zod_1.z.string().optional(),
+    LIQUIDITY_CONTRACT_ADDRESS: zod_1.z.string().optional(),
+    // Ethereum / EVM chains
+    ETHEREUM_RPC_URL: zod_1.z.string().url().optional(),
+    ETHEREUM_RPC_WS_URL: zod_1.z.string().url().optional(),
+    ETHEREUM_RPC_FALLBACK_URL: zod_1.z.string().url().optional(),
+    RPC_PROVIDER_TYPE: zod_1.z.enum(["http", "ws"]).default("http"),
+    USDC_BRIDGE_ADDRESS: zod_1.z.string().optional(),
+    EURC_BRIDGE_ADDRESS: zod_1.z.string().optional(),
+    USDC_TOKEN_ADDRESS: zod_1.z.string().optional(),
+    EURC_TOKEN_ADDRESS: zod_1.z.string().optional(),
+    // Polygon
+    POLYGON_RPC_URL: zod_1.z.string().url().optional(),
+    POLYGON_RPC_FALLBACK_URL: zod_1.z.string().url().optional(),
+    // Base
+    BASE_RPC_URL: zod_1.z.string().url().optional(),
+    BASE_RPC_FALLBACK_URL: zod_1.z.string().url().optional(),
+    // External APIs
+    CIRCLE_API_KEY: zod_1.z.string().optional(),
+    // Circle API base URL — use sandbox for non-production environments
+    CIRCLE_API_URL: zod_1.z
+        .string()
+        .url()
+        .default("https://api.circle.com"),
+    // Request timeout for Circle API calls (ms)
+    CIRCLE_API_TIMEOUT_MS: zod_1.z.coerce.number().default(5000),
+    // Redis TTL for cached Circle price responses (seconds)
+    CIRCLE_CACHE_TTL_SEC: zod_1.z.coerce.number().default(60),
+    // Circle API rate limiting: max requests per window
+    CIRCLE_RATE_LIMIT_MAX: zod_1.z.coerce.number().default(30),
+    // Circle API rate limiting: window duration (ms)
+    CIRCLE_RATE_LIMIT_WINDOW_MS: zod_1.z.coerce.number().default(60000),
+    COINBASE_API_KEY: zod_1.z.string().optional(),
+    COINBASE_API_SECRET: zod_1.z.string().optional(),
+    API_KEY_BOOTSTRAP_TOKEN: zod_1.z.string().optional(),
+    // Logging
+    LOG_LEVEL: zod_1.z
+        .enum(["fatal", "error", "warn", "info", "debug", "trace"])
+        .default("info"),
+    LOG_FILE: zod_1.z.string().optional(),
+    LOG_MAX_FILE_SIZE: zod_1.z.coerce.number().default(100 * 1024 * 1024), // 100MB
+    LOG_MAX_FILES: zod_1.z.coerce.number().default(10),
+    LOG_RETENTION_DAYS: zod_1.z.coerce.number().default(30),
+    LOG_REQUEST_BODY: zod_1.z.coerce.boolean().default(false),
+    LOG_RESPONSE_BODY: zod_1.z.coerce.boolean().default(false),
+    LOG_SENSITIVE_DATA: zod_1.z.coerce.boolean().default(false),
+    REQUEST_SLOW_THRESHOLD_MS: zod_1.z.coerce.number().default(1000),
+    // Rate Limiting
+    RATE_LIMIT_MAX: zod_1.z.coerce.number().default(100),
+    RATE_LIMIT_WINDOW_MS: zod_1.z.coerce.number().default(60000),
+    // Burst allowance as a fraction of RATE_LIMIT_MAX (0.1 = 10% extra)
+    RATE_LIMIT_BURST_MULTIPLIER: zod_1.z.coerce.number().min(0).default(0.1),
+    // Comma-separated IPs that bypass rate limiting entirely
+    RATE_LIMIT_WHITELIST_IPS: zod_1.z.string().optional(),
+    // Comma-separated API keys that bypass rate limiting entirely
+    RATE_LIMIT_WHITELIST_KEYS: zod_1.z.string().optional(),
+    // Enhanced Rate Limiting Configuration
+    RATE_LIMIT_ENABLE_DYNAMIC: zod_1.z.coerce.boolean().default(true),
+    RATE_LIMIT_GLOBAL_ALERT_THRESHOLD: zod_1.z.coerce.number().default(0.9),
+    RATE_LIMIT_BURST_ALERT_THRESHOLD: zod_1.z.coerce.number().default(0.8),
+    RATE_LIMIT_SUSTAINED_ALERT_THRESHOLD: zod_1.z.coerce.number().default(0.7),
+    RATE_LIMIT_STATS_RETENTION_HOURS: zod_1.z.coerce.number().default(168), // 7 days
+    RATE_LIMIT_ENABLE_MONITORING: zod_1.z.coerce.boolean().default(true),
+    RATE_LIMIT_ADMIN_API_KEY_PREFIX: zod_1.z.string().default("admin_"),
+    // Per-endpoint rate limits (requests per window)
+    RATE_LIMIT_ENDPOINT_ASSETS: zod_1.z.coerce.number().default(200),
+    RATE_LIMIT_ENDPOINT_BRIDGES: zod_1.z.coerce.number().default(150),
+    RATE_LIMIT_ENDPOINT_ALERTS: zod_1.z.coerce.number().default(50),
+    RATE_LIMIT_ENDPOINT_ANALYTICS: zod_1.z.coerce.number().default(100),
+    RATE_LIMIT_ENDPOINT_CONFIG: zod_1.z.coerce.number().default(30),
+    RATE_LIMIT_ENDPOINT_HEALTH: zod_1.z.coerce.number().default(1000),
+    // Alert Thresholds
+    PRICE_DEVIATION_THRESHOLD: zod_1.z.coerce.number().default(0.02),
+    BRIDGE_SUPPLY_MISMATCH_THRESHOLD: zod_1.z.coerce.number().default(0.1),
+    // Verification & Retries
+    RETRY_MAX: zod_1.z.coerce.number().default(3),
+    BRIDGE_VERIFICATION_INTERVAL_MS: zod_1.z.coerce.number().default(300000),
+    BACKFILL_QUEUE_CONCURRENCY: zod_1.z.coerce.number().default(2),
+    BACKFILL_DEFAULT_MAX_PAGES: zod_1.z.coerce.number().default(250),
+    BACKFILL_CHUNK_PAGES: zod_1.z.coerce.number().default(5),
+    BACKFILL_PAGE_SIZE: zod_1.z.coerce.number().default(100),
+    BACKFILL_PROVIDER_DELAY_MS: zod_1.z.coerce.number().default(500),
+    // Price Aggregation
+    HORIZON_TIMEOUT_MS: zod_1.z.coerce.number().default(500),
+    REDIS_CACHE_TTL_SEC: zod_1.z.coerce.number().default(30),
+    REDIS_PRICE_CACHE_PREFIX: zod_1.z.string().default("price:aggregated"),
+    // WebSocket
+    /**
+     * Secret token required to subscribe to private WebSocket channels (e.g.
+     * "alerts").  When absent, private-channel authentication is disabled and
+     * any token is rejected.  Set this to a strong random string in production.
+     */
+    WS_AUTH_SECRET: zod_1.z.string().optional(),
+    // Health Score Weights
+    HEALTH_WEIGHT_LIQUIDITY: zod_1.z.coerce.number().default(0.25),
+    HEALTH_WEIGHT_PRICE: zod_1.z.coerce.number().default(0.25),
+    HEALTH_WEIGHT_BRIDGE: zod_1.z.coerce.number().default(0.20),
+    HEALTH_WEIGHT_RESERVES: zod_1.z.coerce.number().default(0.20),
+    HEALTH_WEIGHT_VOLUME: zod_1.z.coerce.number().default(0.10),
+    // Export Service
+    EXPORT_STORAGE_PATH: zod_1.z.string().default("./exports"),
+    EXPORT_DOWNLOAD_URL_EXPIRY_HOURS: zod_1.z.coerce.number().default(24),
+    EXPORT_COMPRESSION_THRESHOLD_BYTES: zod_1.z.coerce.number().default(1048576), // 1MB
+    EXPORT_STREAMING_PAGE_SIZE: zod_1.z.coerce.number().default(1000),
+    EXPORT_QUEUE_CONCURRENCY: zod_1.z.coerce.number().default(3),
+    EXPORT_MAX_DATE_RANGE_DAYS: zod_1.z.coerce.number().default(90),
+    // Email Configuration
+    SMTP_HOST: zod_1.z.string().optional(),
+    SMTP_PORT: zod_1.z.coerce.number().default(587),
+    SMTP_SECURE: zod_1.z.coerce.boolean().default(false),
+    SMTP_USER: zod_1.z.string().optional(),
+    SMTP_PASSWORD: zod_1.z.string().optional(),
+    SMTP_FROM_ADDRESS: zod_1.z.string().default("noreply@bridgewatch.io"),
+    SMTP_FROM_NAME: zod_1.z.string().default("Bridge Watch"),
+    // Discord Bot Configuration
+    DISCORD_BOT_TOKEN: zod_1.z.string().optional(),
+    DISCORD_CLIENT_ID: zod_1.z.string().optional(),
+    // Health Check Configuration
+    HEALTH_CHECK_TIMEOUT_MS: zod_1.z.coerce.number().default(5000),
+    HEALTH_CHECK_INTERVAL_MS: zod_1.z.coerce.number().default(30000),
+    HEALTH_CHECK_MEMORY_THRESHOLD: zod_1.z.coerce.number().default(90),
+    HEALTH_CHECK_DISK_THRESHOLD: zod_1.z.coerce.number().default(80),
+    HEALTH_CHECK_EXTERNAL_APIS: zod_1.z.string().default("true"),
+    // Data Validation Configuration
+    VALIDATION_STRICT_MODE: zod_1.z.coerce.boolean().default(false),
+    VALIDATION_ADMIN_BYPASS: zod_1.z.coerce.boolean().default(true),
+    VALIDATION_BATCH_SIZE: zod_1.z.coerce.number().default(100),
+    VALIDATION_MAX_BATCH_SIZE: zod_1.z.coerce.number().default(1000),
+    VALIDATION_DUPLICATE_CHECK: zod_1.z.coerce.boolean().default(true),
+    VALIDATION_NORMALIZATION: zod_1.z.coerce.boolean().default(true),
+    VALIDATION_CONSISTENCY_CHECKS: zod_1.z.coerce.boolean().default(true),
+    VALIDATION_ERROR_THRESHOLD: zod_1.z.coerce.number().default(0.1), // 10% error rate threshold
+    VALIDATION_WARNING_THRESHOLD: zod_1.z.coerce.number().default(0.3), // 30% warning threshold
+    VALIDATION_DATA_QUALITY_THRESHOLD: zod_1.z.coerce.number().default(70), // 70% quality score threshold
+});
+exports.SUPPORTED_ASSETS = [
+    { code: "XLM", issuer: "native" },
+    { code: "USDC", issuer: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN" },
+    { code: "PYUSD", issuer: "GBHZAE5IQTOPQZ66TFWZYIYCHQ6T3GMWHDKFEXAKYWJ2BHLZQ227KRYE" },
+    { code: "EURC", issuer: "GDQOE23CFSUMSVZZ4YRVXGW7PCFNIAHLMRAHDE4Z32DIBQGH4KZZK2KZ" },
+    { code: "FOBXX", issuer: "GBX7VUT2UTUKO2H76J26D7QYWNFW6C2NYN6K74Y3K43HGBXYZ" },
+];
+var parsed = envSchema.safeParse(process.env);
+if (!parsed.success) {
+    console.error("Invalid environment variables:", parsed.error.format());
+    process.exit(1);
+}
+exports.config = parsed.data;

--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -118,6 +118,11 @@ const envSchema = z.object({
   // Verification & Retries
   RETRY_MAX: z.coerce.number().default(3),
   BRIDGE_VERIFICATION_INTERVAL_MS: z.coerce.number().default(300000),
+  BACKFILL_QUEUE_CONCURRENCY: z.coerce.number().default(2),
+  BACKFILL_DEFAULT_MAX_PAGES: z.coerce.number().default(250),
+  BACKFILL_CHUNK_PAGES: z.coerce.number().default(5),
+  BACKFILL_PAGE_SIZE: z.coerce.number().default(100),
+  BACKFILL_PROVIDER_DELAY_MS: z.coerce.number().default(500),
 
   // Price Aggregation
   HORIZON_TIMEOUT_MS: z.coerce.number().default(500),

--- a/backend/src/config/redis.js
+++ b/backend/src/config/redis.js
@@ -1,0 +1,50 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.createRedisClient = void 0;
+var ioredis_1 = require("ioredis");
+var index_js_1 = require("./index.js");
+var logger_js_1 = require("../utils/logger.js");
+// Redis Connection Options
+var redisOptions = {
+    host: index_js_1.config.REDIS_HOST,
+    port: index_js_1.config.REDIS_PORT,
+    password: index_js_1.config.REDIS_PASSWORD || undefined,
+    maxRetriesPerRequest: 3,
+    retryStrategy: function (times) {
+        var delay = Math.min(times * 100, 3000);
+        return delay;
+    },
+};
+// Cluster Options
+var clusterOptions = {
+    redisOptions: {
+        password: index_js_1.config.REDIS_PASSWORD || undefined,
+    },
+    clusterRetryStrategy: function (times) { return Math.min(times * 100, 3000); },
+    enableReadyCheck: true,
+    scaleReads: "slave", // scale read queries to slaves
+};
+var redisClient;
+var createRedisClient = function () {
+    if (index_js_1.config.NODE_ENV === "production" && process.env.REDIS_CLUSTER === "true") {
+        // Provide your cluster nodes configuration here
+        // In a real environment, this might come from env config like REDIS_CLUSTER_NODES
+        var nodes = [
+            { host: index_js_1.config.REDIS_HOST, port: index_js_1.config.REDIS_PORT },
+        ];
+        redisClient = new ioredis_1.default.Cluster(nodes, clusterOptions);
+        logger_js_1.logger.info("Initialized Redis Cluster client");
+    }
+    else {
+        redisClient = new ioredis_1.default(redisOptions);
+        logger_js_1.logger.info("Initialized standard Redis client");
+    }
+    redisClient.on("error", function (err) {
+        logger_js_1.logger.error({ err: err }, "Redis connection error");
+    });
+    redisClient.on("connect", function () {
+        logger_js_1.logger.info("Connected to Redis");
+    });
+    return redisClient;
+};
+exports.createRedisClient = createRedisClient;

--- a/backend/src/database/connection.js
+++ b/backend/src/database/connection.js
@@ -1,0 +1,68 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g = Object.create((typeof Iterator === "function" ? Iterator : Object).prototype);
+    return g.next = verb(0), g["throw"] = verb(1), g["return"] = verb(2), typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (g && (g = 0, op[0] && (_ = 0)), _) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getDatabase = getDatabase;
+exports.closeDatabase = closeDatabase;
+var knex_1 = require("knex");
+var database_js_1 = require("../config/database.js");
+var logger_js_1 = require("../utils/logger.js");
+var db;
+function getDatabase() {
+    if (!db) {
+        db = (0, knex_1.default)(database_js_1.databaseConfig);
+        logger_js_1.logger.info("Database connection initialized");
+    }
+    return db;
+}
+function closeDatabase() {
+    return __awaiter(this, void 0, void 0, function () {
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0:
+                    if (!db) return [3 /*break*/, 2];
+                    return [4 /*yield*/, db.destroy()];
+                case 1:
+                    _a.sent();
+                    db = undefined; // Reset so the next getDatabase() call creates a fresh pool
+                    logger_js_1.logger.info("Database connection closed");
+                    _a.label = 2;
+                case 2: return [2 /*return*/];
+            }
+        });
+    });
+}

--- a/backend/src/jobs/backfill.job.js
+++ b/backend/src/jobs/backfill.job.js
@@ -1,0 +1,86 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g = Object.create((typeof Iterator === "function" ? Iterator : Object).prototype);
+    return g.next = verb(0), g["throw"] = verb(1), g["return"] = verb(2), typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (g && (g = 0, op[0] && (_ = 0)), _) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.initBackfillJob = initBackfillJob;
+var backfill_service_js_1 = require("../services/backfill.service.js");
+var backfill_queue_js_1 = require("./backfill.queue.js");
+var logger_js_1 = require("../utils/logger.js");
+function initBackfillJob() {
+    return __awaiter(this, void 0, void 0, function () {
+        var queue, backfillService;
+        var _this = this;
+        return __generator(this, function (_a) {
+            queue = (0, backfill_queue_js_1.getBackfillQueue)();
+            backfillService = new backfill_service_js_1.BackfillService();
+            queue.initWorker(function (job) { return __awaiter(_this, void 0, void 0, function () {
+                return __generator(this, function (_a) {
+                    switch (_a.label) {
+                        case 0:
+                            if (job.name !== "backfill-chunk") {
+                                throw new Error("Unsupported backfill job type: ".concat(job.name));
+                            }
+                            return [4 /*yield*/, backfillService.processBackfillChunk(job.data)];
+                        case 1:
+                            _a.sent();
+                            return [2 /*return*/];
+                    }
+                });
+            }); }, function (job, error) { return __awaiter(_this, void 0, void 0, function () {
+                var attempts, maxAttempts;
+                var _a, _b, _c;
+                return __generator(this, function (_d) {
+                    switch (_d.label) {
+                        case 0:
+                            if (!job || job.name !== "backfill-chunk")
+                                return [2 /*return*/];
+                            attempts = (_a = job.attemptsMade) !== null && _a !== void 0 ? _a : 0;
+                            maxAttempts = (_c = (_b = job.opts) === null || _b === void 0 ? void 0 : _b.attempts) !== null && _c !== void 0 ? _c : 1;
+                            if (!(attempts >= maxAttempts)) return [3 /*break*/, 2];
+                            return [4 /*yield*/, backfillService.markJobFailed(job.data.jobId, error.message)];
+                        case 1:
+                            _d.sent();
+                            _d.label = 2;
+                        case 2: return [2 /*return*/];
+                    }
+                });
+            }); });
+            logger_js_1.logger.info("Backfill job system initialized");
+            return [2 /*return*/];
+        });
+    });
+}

--- a/backend/src/jobs/backfill.job.ts
+++ b/backend/src/jobs/backfill.job.ts
@@ -1,0 +1,39 @@
+import type { Job } from "bullmq";
+import { BackfillService } from "../services/backfill.service.js";
+import { getBackfillQueue } from "./backfill.queue.js";
+import { logger } from "../utils/logger.js";
+
+export interface BackfillChunkJobData {
+  jobId: string;
+  assetCode: string;
+  assetIssuer: string;
+  bridgeName?: string;
+  operationTypes: string[];
+  cursor: string;
+  pages: number;
+  pageSize: number;
+}
+
+export async function initBackfillJob(): Promise<void> {
+  const queue = getBackfillQueue();
+  const backfillService = new BackfillService();
+
+  queue.initWorker(
+    async (job: Job<BackfillChunkJobData>) => {
+      if (job.name !== "backfill-chunk") {
+        throw new Error(`Unsupported backfill job type: ${job.name}`);
+      }
+      await backfillService.processBackfillChunk(job.data);
+    },
+    async (job: Job | undefined, error: Error) => {
+      if (!job || job.name !== "backfill-chunk") return;
+      const attempts = job.attemptsMade ?? 0;
+      const maxAttempts = (job.opts?.attempts as number) ?? 1;
+      if (attempts >= maxAttempts) {
+        await backfillService.markJobFailed((job.data as BackfillChunkJobData).jobId, error.message);
+      }
+    },
+  );
+
+  logger.info("Backfill job system initialized");
+}

--- a/backend/src/jobs/backfill.queue.js
+++ b/backend/src/jobs/backfill.queue.js
@@ -1,0 +1,141 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g = Object.create((typeof Iterator === "function" ? Iterator : Object).prototype);
+    return g.next = verb(0), g["throw"] = verb(1), g["return"] = verb(2), typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (g && (g = 0, op[0] && (_ = 0)), _) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.BackfillQueue = void 0;
+exports.getBackfillQueue = getBackfillQueue;
+var bullmq_1 = require("bullmq");
+var index_js_1 = require("../config/index.js");
+var logger_js_1 = require("../utils/logger.js");
+var QUEUE_NAME = "backfill";
+var connection = {
+    host: index_js_1.config.REDIS_HOST,
+    port: index_js_1.config.REDIS_PORT,
+    password: index_js_1.config.REDIS_PASSWORD || undefined,
+};
+var BackfillQueue = /** @class */ (function () {
+    function BackfillQueue() {
+        this.worker = null;
+        this.queue = new bullmq_1.Queue(QUEUE_NAME, {
+            connection: connection,
+            defaultJobOptions: {
+                attempts: index_js_1.config.RETRY_MAX || 3,
+                backoff: {
+                    type: "exponential",
+                    delay: 1000,
+                },
+                removeOnComplete: {
+                    age: 3600,
+                    count: 1000,
+                },
+                removeOnFail: {
+                    age: 86400,
+                },
+            },
+        });
+        logger_js_1.logger.info({ queueName: QUEUE_NAME }, "Backfill queue initialized");
+    }
+    BackfillQueue.getInstance = function () {
+        if (!BackfillQueue.instance) {
+            BackfillQueue.instance = new BackfillQueue();
+        }
+        return BackfillQueue.instance;
+    };
+    BackfillQueue.prototype.addJob = function (name_1, data_1) {
+        return __awaiter(this, arguments, void 0, function (name, data, options) {
+            if (options === void 0) { options = {}; }
+            return __generator(this, function (_a) {
+                logger_js_1.logger.info({ jobName: name, options: options }, "Enqueuing backfill job");
+                return [2 /*return*/, this.queue.add(name, data, options)];
+            });
+        });
+    };
+    BackfillQueue.prototype.initWorker = function (processor, onFailed) {
+        var _this = this;
+        if (this.worker) {
+            logger_js_1.logger.warn("Backfill worker already initialized");
+            return;
+        }
+        this.worker = new bullmq_1.Worker(QUEUE_NAME, processor, {
+            connection: connection,
+            concurrency: index_js_1.config.BACKFILL_QUEUE_CONCURRENCY,
+        });
+        this.worker.on("completed", function (job) {
+            logger_js_1.logger.info({ jobId: job.id, jobName: job.name }, "Backfill job completed");
+        });
+        this.worker.on("failed", function (job, err) { return __awaiter(_this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        logger_js_1.logger.error({ jobId: job === null || job === void 0 ? void 0 : job.id, jobName: job === null || job === void 0 ? void 0 : job.name, error: err.message }, "Backfill job failed");
+                        if (!(job && onFailed)) return [3 /*break*/, 2];
+                        return [4 /*yield*/, onFailed(job, err)];
+                    case 1:
+                        _a.sent();
+                        _a.label = 2;
+                    case 2: return [2 /*return*/];
+                }
+            });
+        }); });
+    };
+    BackfillQueue.prototype.stop = function () {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        if (!this.worker) return [3 /*break*/, 2];
+                        return [4 /*yield*/, this.worker.close()];
+                    case 1:
+                        _a.sent();
+                        this.worker = null;
+                        logger_js_1.logger.info("Backfill worker stopped");
+                        _a.label = 2;
+                    case 2: return [4 /*yield*/, this.queue.close()];
+                    case 3:
+                        _a.sent();
+                        logger_js_1.logger.info("Backfill queue closed");
+                        return [2 /*return*/];
+                }
+            });
+        });
+    };
+    return BackfillQueue;
+}());
+exports.BackfillQueue = BackfillQueue;
+function getBackfillQueue() {
+    return BackfillQueue.getInstance();
+}

--- a/backend/src/jobs/backfill.queue.ts
+++ b/backend/src/jobs/backfill.queue.ts
@@ -1,0 +1,95 @@
+import { Queue, Worker, Job, ConnectionOptions } from "bullmq";
+import { config } from "../config/index.js";
+import { logger } from "../utils/logger.js";
+
+const QUEUE_NAME = "backfill";
+const connection: ConnectionOptions = {
+  host: config.REDIS_HOST,
+  port: config.REDIS_PORT,
+  password: config.REDIS_PASSWORD || undefined,
+};
+
+export class BackfillQueue {
+  private static instance: BackfillQueue;
+  public queue: Queue;
+  private worker: Worker | null = null;
+
+  private constructor() {
+    this.queue = new Queue(QUEUE_NAME, {
+      connection,
+      defaultJobOptions: {
+        attempts: config.RETRY_MAX || 3,
+        backoff: {
+          type: "exponential",
+          delay: 1000,
+        },
+        removeOnComplete: {
+          age: 3600,
+          count: 1000,
+        },
+        removeOnFail: {
+          age: 86400,
+        },
+      },
+    });
+
+    logger.info({ queueName: QUEUE_NAME }, "Backfill queue initialized");
+  }
+
+  public static getInstance(): BackfillQueue {
+    if (!BackfillQueue.instance) {
+      BackfillQueue.instance = new BackfillQueue();
+    }
+    return BackfillQueue.instance;
+  }
+
+  public async addJob(name: string, data: unknown, options: Record<string, unknown> = {}) {
+    logger.info({ jobName: name, options }, "Enqueuing backfill job");
+    return this.queue.add(name, data, options);
+  }
+
+  public initWorker(
+    processor: (job: Job) => Promise<void>,
+    onFailed?: (job: Job, error: Error) => Promise<void>,
+  ): void {
+    if (this.worker) {
+      logger.warn("Backfill worker already initialized");
+      return;
+    }
+
+    this.worker = new Worker(
+      QUEUE_NAME,
+      processor,
+      {
+        connection,
+        concurrency: config.BACKFILL_QUEUE_CONCURRENCY,
+      },
+    );
+
+    this.worker.on("completed", (job: Job) => {
+      logger.info({ jobId: job.id, jobName: job.name }, "Backfill job completed");
+    });
+
+    this.worker.on("failed", async (job: Job | undefined, err: Error) => {
+      logger.error({ jobId: job?.id, jobName: job?.name, error: err.message }, "Backfill job failed");
+      if (job && onFailed) {
+        await onFailed(job, err);
+      }
+    });
+  }
+
+  public async stop(): Promise<void> {
+    if (this.worker) {
+      await this.worker.close();
+      this.worker = null;
+      logger.info("Backfill worker stopped");
+    }
+
+    await this.queue.close();
+    logger.info("Backfill queue closed");
+  }
+}
+
+export function getBackfillQueue(): BackfillQueue {
+  return BackfillQueue.getInstance();
+}

--- a/backend/src/services/audit.service.js
+++ b/backend/src/services/audit.service.js
@@ -1,0 +1,373 @@
+"use strict";
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g = Object.create((typeof Iterator === "function" ? Iterator : Object).prototype);
+    return g.next = verb(0), g["throw"] = verb(1), g["return"] = verb(2), typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (g && (g = 0, op[0] && (_ = 0)), _) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || Array.prototype.slice.call(from));
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.auditService = exports.AuditService = void 0;
+var crypto_1 = require("crypto");
+var connection_js_1 = require("../database/connection.js");
+var logger_js_1 = require("../utils/logger.js");
+// =============================================================================
+// AUDIT SERVICE
+// =============================================================================
+var AuditService = /** @class */ (function () {
+    function AuditService() {
+    }
+    AuditService.getInstance = function () {
+        if (!AuditService.instance) {
+            AuditService.instance = new AuditService();
+        }
+        return AuditService.instance;
+    };
+    // ---------------------------------------------------------------------------
+    // TAMPER DETECTION
+    // ---------------------------------------------------------------------------
+    AuditService.prototype.computeChecksum = function (entry) {
+        var payload = JSON.stringify({
+            action: entry.action,
+            actorId: entry.actorId,
+            actorType: entry.actorType,
+            ipAddress: entry.ipAddress,
+            resourceType: entry.resourceType,
+            resourceId: entry.resourceId,
+            before: entry.before,
+            after: entry.after,
+            severity: entry.severity,
+        });
+        return crypto_1.default.createHash("sha256").update(payload).digest("hex");
+    };
+    AuditService.prototype.verifyChecksum = function (entry) {
+        var expected = this.computeChecksum(entry);
+        return crypto_1.default.timingSafeEqual(Buffer.from(entry.checksum), Buffer.from(expected));
+    };
+    // ---------------------------------------------------------------------------
+    // LOG
+    // ---------------------------------------------------------------------------
+    AuditService.prototype.log = function (params) {
+        return __awaiter(this, void 0, void 0, function () {
+            var db, draft, checksum, row;
+            var _a, _b, _c, _d, _e, _f, _g, _h, _j;
+            return __generator(this, function (_k) {
+                switch (_k.label) {
+                    case 0:
+                        db = (0, connection_js_1.getDatabase)();
+                        draft = {
+                            action: params.action,
+                            actorId: params.actorId,
+                            actorType: (_a = params.actorType) !== null && _a !== void 0 ? _a : "user",
+                            ipAddress: (_b = params.ipAddress) !== null && _b !== void 0 ? _b : null,
+                            userAgent: (_c = params.userAgent) !== null && _c !== void 0 ? _c : null,
+                            resourceType: (_d = params.resourceType) !== null && _d !== void 0 ? _d : null,
+                            resourceId: (_e = params.resourceId) !== null && _e !== void 0 ? _e : null,
+                            before: (_f = params.before) !== null && _f !== void 0 ? _f : null,
+                            after: (_g = params.after) !== null && _g !== void 0 ? _g : null,
+                            metadata: (_h = params.metadata) !== null && _h !== void 0 ? _h : {},
+                            severity: (_j = params.severity) !== null && _j !== void 0 ? _j : this.inferSeverity(params.action),
+                        };
+                        checksum = this.computeChecksum(draft);
+                        return [4 /*yield*/, db("audit_logs")
+                                .insert({
+                                id: crypto_1.default.randomUUID(),
+                                action: draft.action,
+                                actor_id: draft.actorId,
+                                actor_type: draft.actorType,
+                                ip_address: draft.ipAddress,
+                                user_agent: draft.userAgent,
+                                resource_type: draft.resourceType,
+                                resource_id: draft.resourceId,
+                                before: draft.before ? JSON.stringify(draft.before) : null,
+                                after: draft.after ? JSON.stringify(draft.after) : null,
+                                metadata: JSON.stringify(draft.metadata),
+                                severity: draft.severity,
+                                checksum: checksum,
+                                created_at: new Date(),
+                            })
+                                .returning("*")];
+                    case 1:
+                        row = (_k.sent())[0];
+                        logger_js_1.logger.info({ auditId: row.id, action: draft.action, actorId: draft.actorId, severity: draft.severity }, "Audit event recorded");
+                        return [2 /*return*/, this.mapRow(row)];
+                }
+            });
+        });
+    };
+    // ---------------------------------------------------------------------------
+    // QUERY
+    // ---------------------------------------------------------------------------
+    AuditService.prototype.query = function () {
+        return __awaiter(this, arguments, void 0, function (params) {
+            var db, limit, offset, query, countQuery, _a, rows, countResult;
+            var _b, _c, _d;
+            if (params === void 0) { params = {}; }
+            return __generator(this, function (_e) {
+                switch (_e.label) {
+                    case 0:
+                        db = (0, connection_js_1.getDatabase)();
+                        limit = Math.min((_b = params.limit) !== null && _b !== void 0 ? _b : 100, 1000);
+                        offset = (_c = params.offset) !== null && _c !== void 0 ? _c : 0;
+                        query = db("audit_logs");
+                        countQuery = db("audit_logs");
+                        if (params.actorId) {
+                            query = query.where("actor_id", params.actorId);
+                            countQuery = countQuery.where("actor_id", params.actorId);
+                        }
+                        if (params.action) {
+                            query = query.where("action", params.action);
+                            countQuery = countQuery.where("action", params.action);
+                        }
+                        if (params.resourceType) {
+                            query = query.where("resource_type", params.resourceType);
+                            countQuery = countQuery.where("resource_type", params.resourceType);
+                        }
+                        if (params.resourceId) {
+                            query = query.where("resource_id", params.resourceId);
+                            countQuery = countQuery.where("resource_id", params.resourceId);
+                        }
+                        if (params.severity) {
+                            query = query.where("severity", params.severity);
+                            countQuery = countQuery.where("severity", params.severity);
+                        }
+                        if (params.from) {
+                            query = query.where("created_at", ">=", params.from);
+                            countQuery = countQuery.where("created_at", ">=", params.from);
+                        }
+                        if (params.to) {
+                            query = query.where("created_at", "<=", params.to);
+                            countQuery = countQuery.where("created_at", "<=", params.to);
+                        }
+                        return [4 /*yield*/, Promise.all([
+                                query.orderBy("created_at", "desc").limit(limit).offset(offset),
+                                countQuery.count("id as count").first(),
+                            ])];
+                    case 1:
+                        _a = _e.sent(), rows = _a[0], countResult = _a[1];
+                        return [2 /*return*/, {
+                                entries: rows.map(this.mapRow),
+                                total: Number((_d = countResult === null || countResult === void 0 ? void 0 : countResult.count) !== null && _d !== void 0 ? _d : 0),
+                            }];
+                }
+            });
+        });
+    };
+    AuditService.prototype.getEntry = function (id) {
+        return __awaiter(this, void 0, void 0, function () {
+            var db, row;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        db = (0, connection_js_1.getDatabase)();
+                        return [4 /*yield*/, db("audit_logs").where("id", id).first()];
+                    case 1:
+                        row = _a.sent();
+                        return [2 /*return*/, row ? this.mapRow(row) : null];
+                }
+            });
+        });
+    };
+    // ---------------------------------------------------------------------------
+    // STATS
+    // ---------------------------------------------------------------------------
+    AuditService.prototype.getStats = function (from) {
+        return __awaiter(this, void 0, void 0, function () {
+            var db, baseQuery, _a, totalRow, severityRows, actionRows, recentRow, bySeverity, _i, severityRows_1, row, byAction, _b, actionRows_1, row;
+            var _c, _d;
+            return __generator(this, function (_e) {
+                switch (_e.label) {
+                    case 0:
+                        db = (0, connection_js_1.getDatabase)();
+                        baseQuery = db("audit_logs");
+                        if (from)
+                            baseQuery = baseQuery.where("created_at", ">=", from);
+                        return [4 /*yield*/, Promise.all([
+                                baseQuery.clone().count("id as count").first(),
+                                baseQuery.clone().select("severity").count("id as count").groupBy("severity"),
+                                baseQuery.clone().select("action").count("id as count").groupBy("action").orderBy("count", "desc").limit(20),
+                                db("audit_logs")
+                                    .where("created_at", ">=", new Date(Date.now() - 3600000))
+                                    .count("id as count")
+                                    .first(),
+                            ])];
+                    case 1:
+                        _a = _e.sent(), totalRow = _a[0], severityRows = _a[1], actionRows = _a[2], recentRow = _a[3];
+                        bySeverity = { info: 0, warning: 0, critical: 0 };
+                        for (_i = 0, severityRows_1 = severityRows; _i < severityRows_1.length; _i++) {
+                            row = severityRows_1[_i];
+                            bySeverity[row.severity] = Number(row.count);
+                        }
+                        byAction = {};
+                        for (_b = 0, actionRows_1 = actionRows; _b < actionRows_1.length; _b++) {
+                            row = actionRows_1[_b];
+                            byAction[row.action] = Number(row.count);
+                        }
+                        return [2 /*return*/, {
+                                total: Number((_c = totalRow === null || totalRow === void 0 ? void 0 : totalRow.count) !== null && _c !== void 0 ? _c : 0),
+                                bySeverity: bySeverity,
+                                byAction: byAction,
+                                recentCount: Number((_d = recentRow === null || recentRow === void 0 ? void 0 : recentRow.count) !== null && _d !== void 0 ? _d : 0),
+                            }];
+                }
+            });
+        });
+    };
+    // ---------------------------------------------------------------------------
+    // EXPORT
+    // ---------------------------------------------------------------------------
+    AuditService.prototype.exportCsv = function () {
+        return __awaiter(this, arguments, void 0, function (params) {
+            var entries, header, rows;
+            if (params === void 0) { params = {}; }
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.query(__assign(__assign({}, params), { limit: 10000, offset: 0 }))];
+                    case 1:
+                        entries = (_a.sent()).entries;
+                        header = [
+                            "id", "action", "actor_id", "actor_type", "ip_address",
+                            "resource_type", "resource_id", "severity", "checksum", "created_at",
+                        ].join(",");
+                        rows = entries.map(function (e) {
+                            var _a, _b, _c;
+                            return [
+                                e.id,
+                                e.action,
+                                e.actorId,
+                                e.actorType,
+                                (_a = e.ipAddress) !== null && _a !== void 0 ? _a : "",
+                                (_b = e.resourceType) !== null && _b !== void 0 ? _b : "",
+                                (_c = e.resourceId) !== null && _c !== void 0 ? _c : "",
+                                e.severity,
+                                e.checksum,
+                                e.createdAt.toISOString(),
+                            ]
+                                .map(function (v) { return "\"".concat(String(v).replace(/"/g, '""'), "\""); })
+                                .join(",");
+                        });
+                        return [2 /*return*/, __spreadArray([header], rows, true).join("\n")];
+                }
+            });
+        });
+    };
+    // ---------------------------------------------------------------------------
+    // RETENTION
+    // ---------------------------------------------------------------------------
+    AuditService.prototype.applyRetentionPolicy = function (retentionDays) {
+        return __awaiter(this, void 0, void 0, function () {
+            var db, cutoff, deleted;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        db = (0, connection_js_1.getDatabase)();
+                        cutoff = new Date(Date.now() - retentionDays * 86400000);
+                        return [4 /*yield*/, db("audit_logs")
+                                .where("severity", "info")
+                                .where("created_at", "<", cutoff)
+                                .delete()];
+                    case 1:
+                        deleted = _a.sent();
+                        logger_js_1.logger.info({ deleted: deleted, cutoff: cutoff, retentionDays: retentionDays }, "Audit log retention policy applied");
+                        return [2 /*return*/, deleted];
+                }
+            });
+        });
+    };
+    // ---------------------------------------------------------------------------
+    // HELPERS
+    // ---------------------------------------------------------------------------
+    AuditService.prototype.inferSeverity = function (action) {
+        if (action === "admin.user_permission_changed" ||
+            action === "auth.api_key_revoked" ||
+            action === "webhook.secret_rotated" ||
+            action === "admin.config_changed")
+            return "warning";
+        if (action === "admin.retention_policy_changed")
+            return "critical";
+        return "info";
+    };
+    AuditService.prototype.mapRow = function (row) {
+        var _a, _b, _c, _d, _e;
+        var parse = function (v) {
+            if (!v)
+                return null;
+            if (typeof v === "object")
+                return v;
+            try {
+                return JSON.parse(v);
+            }
+            catch (_a) {
+                return null;
+            }
+        };
+        return {
+            id: row.id,
+            action: row.action,
+            actorId: row.actor_id,
+            actorType: row.actor_type,
+            ipAddress: (_a = row.ip_address) !== null && _a !== void 0 ? _a : null,
+            userAgent: (_b = row.user_agent) !== null && _b !== void 0 ? _b : null,
+            resourceType: (_c = row.resource_type) !== null && _c !== void 0 ? _c : null,
+            resourceId: (_d = row.resource_id) !== null && _d !== void 0 ? _d : null,
+            before: parse(row.before),
+            after: parse(row.after),
+            metadata: ((_e = parse(row.metadata)) !== null && _e !== void 0 ? _e : {}),
+            severity: row.severity,
+            checksum: row.checksum,
+            createdAt: row.created_at,
+        };
+    };
+    return AuditService;
+}());
+exports.AuditService = AuditService;
+exports.auditService = AuditService.getInstance();

--- a/backend/src/services/backfill.service.js
+++ b/backend/src/services/backfill.service.js
@@ -1,0 +1,457 @@
+"use strict";
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g = Object.create((typeof Iterator === "function" ? Iterator : Object).prototype);
+    return g.next = verb(0), g["throw"] = verb(1), g["return"] = verb(2), typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (g && (g = 0, op[0] && (_ = 0)), _) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.BackfillService = void 0;
+var crypto_1 = require("crypto");
+var redis_js_1 = require("../utils/redis.js");
+var index_js_1 = require("../config/index.js");
+var audit_service_js_1 = require("./audit.service.js");
+var transaction_service_js_1 = require("./transaction.service.js");
+var backfill_queue_js_1 = require("../jobs/backfill.queue.js");
+var logger_js_1 = require("../utils/logger.js");
+var JOB_KEY_PREFIX = "backfill:job:";
+var JOB_LIST_KEY = "backfill:jobs";
+var JOB_ERRORS_SUFFIX = ":errors";
+var BackfillService = /** @class */ (function () {
+    function BackfillService() {
+        this.transactionService = new transaction_service_js_1.TransactionService();
+        this.auditService = audit_service_js_1.AuditService.getInstance();
+        this.queue = (0, backfill_queue_js_1.getBackfillQueue)();
+    }
+    BackfillService.prototype.getJobKey = function (jobId) {
+        return "".concat(JOB_KEY_PREFIX).concat(jobId);
+    };
+    BackfillService.prototype.getErrorListKey = function (jobId) {
+        return "".concat(this.getJobKey(jobId)).concat(JOB_ERRORS_SUFFIX);
+    };
+    BackfillService.prototype.normalizePageSize = function (pageSize) {
+        return Math.min(Math.max(pageSize !== null && pageSize !== void 0 ? pageSize : index_js_1.config.BACKFILL_PAGE_SIZE, 1), 200);
+    };
+    BackfillService.prototype.normalizeChunkPages = function (chunkPages) {
+        return Math.max(chunkPages !== null && chunkPages !== void 0 ? chunkPages : index_js_1.config.BACKFILL_CHUNK_PAGES, 1);
+    };
+    BackfillService.prototype.normalizeRequestedPages = function (pages) {
+        return Math.max(pages !== null && pages !== void 0 ? pages : index_js_1.config.BACKFILL_DEFAULT_MAX_PAGES, 1);
+    };
+    BackfillService.prototype.getPriorityValue = function (priority) {
+        return priority === "high" ? 1 : 10;
+    };
+    BackfillService.prototype.saveJobState = function (job) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, Promise.all([
+                            redis_js_1.redis.set(this.getJobKey(job.id), JSON.stringify(job)),
+                            redis_js_1.redis.sadd(JOB_LIST_KEY, job.id),
+                        ])];
+                    case 1:
+                        _a.sent();
+                        return [2 /*return*/];
+                }
+            });
+        });
+    };
+    BackfillService.prototype.loadJobState = function (jobId) {
+        return __awaiter(this, void 0, void 0, function () {
+            var raw;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, redis_js_1.redis.get(this.getJobKey(jobId))];
+                    case 1:
+                        raw = _a.sent();
+                        if (!raw)
+                            return [2 /*return*/, null];
+                        return [2 /*return*/, JSON.parse(raw)];
+                }
+            });
+        });
+    };
+    BackfillService.prototype.appendError = function (jobId, message) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, redis_js_1.redis.rpush(this.getErrorListKey(jobId), message)];
+                    case 1:
+                        _a.sent();
+                        return [2 /*return*/];
+                }
+            });
+        });
+    };
+    BackfillService.prototype.getErrorHistory = function (jobId) {
+        return __awaiter(this, void 0, void 0, function () {
+            var _a;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0: return [4 /*yield*/, redis_js_1.redis.lrange(this.getErrorListKey(jobId), 0, -1)];
+                    case 1: return [2 /*return*/, (_a = (_b.sent())) !== null && _a !== void 0 ? _a : []];
+                }
+            });
+        });
+    };
+    BackfillService.prototype.computeProgress = function (state) {
+        var percent = state.requestedPages === 0
+            ? 100
+            : Math.min(100, Math.round(((state.pagesCompleted / state.requestedPages) * 100)));
+        return { percent: percent };
+    };
+    BackfillService.prototype.createTransactionBackfill = function (request) {
+        return __awaiter(this, void 0, void 0, function () {
+            var jobId, pageSize, chunkPages, requestedPages, initialCursor, priority, state, firstChunkPages;
+            var _a, _b, _c, _d;
+            return __generator(this, function (_e) {
+                switch (_e.label) {
+                    case 0:
+                        jobId = crypto_1.default.randomUUID();
+                        pageSize = this.normalizePageSize(request.pageSize);
+                        chunkPages = this.normalizeChunkPages(request.chunkPages);
+                        requestedPages = this.normalizeRequestedPages(request.pages);
+                        initialCursor = (_b = (_a = request.cursor) === null || _a === void 0 ? void 0 : _a.trim()) !== null && _b !== void 0 ? _b : "";
+                        priority = (_c = request.priority) !== null && _c !== void 0 ? _c : "normal";
+                        state = {
+                            id: jobId,
+                            type: "transactions",
+                            status: "pending",
+                            assetCode: request.assetCode,
+                            assetIssuer: request.assetIssuer,
+                            bridgeName: request.bridgeName,
+                            operationTypes: (_d = request.operationTypes) !== null && _d !== void 0 ? _d : [],
+                            cursor: initialCursor,
+                            pageSize: pageSize,
+                            chunkPages: chunkPages,
+                            requestedPages: requestedPages,
+                            pagesCompleted: 0,
+                            pagesRemaining: requestedPages,
+                            recordsFetched: 0,
+                            recordsStored: 0,
+                            errorCount: 0,
+                            priority: priority,
+                            providerDelayMs: index_js_1.config.BACKFILL_PROVIDER_DELAY_MS,
+                            createdAt: new Date().toISOString(),
+                            updatedAt: new Date().toISOString(),
+                        };
+                        return [4 /*yield*/, this.saveJobState(state)];
+                    case 1:
+                        _e.sent();
+                        return [4 /*yield*/, this.auditService.log({
+                                action: "data.created",
+                                actorId: "system",
+                                actorType: "system",
+                                resourceType: "backfill_job",
+                                resourceId: jobId,
+                                metadata: {
+                                    assetCode: state.assetCode,
+                                    assetIssuer: state.assetIssuer,
+                                    requestedPages: state.requestedPages,
+                                    chunkPages: state.chunkPages,
+                                    priority: state.priority,
+                                },
+                                severity: "info",
+                            })];
+                    case 2:
+                        _e.sent();
+                        firstChunkPages = Math.min(chunkPages, requestedPages);
+                        return [4 /*yield*/, this.queue.addJob("backfill-chunk", {
+                                jobId: jobId,
+                                assetCode: request.assetCode,
+                                assetIssuer: request.assetIssuer,
+                                bridgeName: request.bridgeName,
+                                operationTypes: state.operationTypes,
+                                cursor: initialCursor,
+                                pages: firstChunkPages,
+                                pageSize: pageSize,
+                            }, {
+                                priority: this.getPriorityValue(priority),
+                            })];
+                    case 3:
+                        _e.sent();
+                        return [2 /*return*/, { jobId: jobId, status: state.status }];
+                }
+            });
+        });
+    };
+    BackfillService.prototype.getJobStatus = function (jobId) {
+        return __awaiter(this, void 0, void 0, function () {
+            var state, _a;
+            var _b;
+            return __generator(this, function (_c) {
+                switch (_c.label) {
+                    case 0: return [4 /*yield*/, this.loadJobState(jobId)];
+                    case 1:
+                        state = _c.sent();
+                        if (!state)
+                            return [2 /*return*/, null];
+                        _a = [__assign({}, state)];
+                        _b = {};
+                        return [4 /*yield*/, this.getErrorHistory(jobId)];
+                    case 2: return [2 /*return*/, __assign.apply(void 0, _a.concat([(_b.errors = _c.sent(), _b.progress = this.computeProgress(state), _b)]))];
+                }
+            });
+        });
+    };
+    BackfillService.prototype.listBackfillJobs = function () {
+        return __awaiter(this, void 0, void 0, function () {
+            var ids, jobs;
+            var _this = this;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, redis_js_1.redis.smembers(JOB_LIST_KEY)];
+                    case 1:
+                        ids = _a.sent();
+                        return [4 /*yield*/, Promise.all(ids.map(function (id) { return __awaiter(_this, void 0, void 0, function () { return __generator(this, function (_a) {
+                                return [2 /*return*/, this.getJobStatus(id)];
+                            }); }); }))];
+                    case 2:
+                        jobs = _a.sent();
+                        return [2 /*return*/, jobs.filter(function (job) { return job !== null; })];
+                }
+            });
+        });
+    };
+    BackfillService.prototype.resumeBackfillJob = function (jobId) {
+        return __awaiter(this, void 0, void 0, function () {
+            var state, nextPages, _a;
+            var _b;
+            return __generator(this, function (_c) {
+                switch (_c.label) {
+                    case 0: return [4 /*yield*/, this.loadJobState(jobId)];
+                    case 1:
+                        state = _c.sent();
+                        if (!state)
+                            return [2 /*return*/, null];
+                        if (state.status === "completed")
+                            return [2 /*return*/, state];
+                        if (!(state.pagesRemaining <= 0)) return [3 /*break*/, 3];
+                        state.status = "completed";
+                        state.updatedAt = new Date().toISOString();
+                        return [4 /*yield*/, this.saveJobState(state)];
+                    case 2:
+                        _c.sent();
+                        return [2 /*return*/, state];
+                    case 3:
+                        state.status = "pending";
+                        state.updatedAt = new Date().toISOString();
+                        return [4 /*yield*/, this.saveJobState(state)];
+                    case 4:
+                        _c.sent();
+                        return [4 /*yield*/, this.auditService.log({
+                                action: "data.updated",
+                                actorId: "system",
+                                actorType: "system",
+                                resourceType: "backfill_job",
+                                resourceId: jobId,
+                                metadata: {
+                                    status: state.status,
+                                    pagesRemaining: state.pagesRemaining,
+                                },
+                                severity: "info",
+                            })];
+                    case 5:
+                        _c.sent();
+                        nextPages = Math.min(state.chunkPages, state.pagesRemaining);
+                        return [4 /*yield*/, this.queue.addJob("backfill-chunk", {
+                                jobId: jobId,
+                                assetCode: state.assetCode,
+                                assetIssuer: state.assetIssuer,
+                                bridgeName: state.bridgeName,
+                                operationTypes: state.operationTypes,
+                                cursor: state.cursor,
+                                pages: nextPages,
+                                pageSize: state.pageSize,
+                            }, {
+                                priority: this.getPriorityValue(state.priority),
+                            })];
+                    case 6:
+                        _c.sent();
+                        _a = [__assign({}, state)];
+                        _b = {};
+                        return [4 /*yield*/, this.getErrorHistory(jobId)];
+                    case 7: return [2 /*return*/, __assign.apply(void 0, _a.concat([(_b.errors = _c.sent(), _b.progress = this.computeProgress(state), _b)]))];
+                }
+            });
+        });
+    };
+    BackfillService.prototype.processBackfillChunk = function (payload) {
+        return __awaiter(this, void 0, void 0, function () {
+            var state, fetchResult, nextChunkPages, error_1;
+            var _a, _b;
+            return __generator(this, function (_c) {
+                switch (_c.label) {
+                    case 0: return [4 /*yield*/, this.loadJobState(payload.jobId)];
+                    case 1:
+                        state = _c.sent();
+                        if (!state) {
+                            throw new Error("Backfill job not found: ".concat(payload.jobId));
+                        }
+                        if (state.status === "completed" || state.status === "cancelled") {
+                            logger_js_1.logger.info({ jobId: payload.jobId }, "Skipping chunk for completed or cancelled job");
+                            return [2 /*return*/];
+                        }
+                        state.status = "running";
+                        state.updatedAt = new Date().toISOString();
+                        return [4 /*yield*/, this.saveJobState(state)];
+                    case 2:
+                        _c.sent();
+                        _c.label = 3;
+                    case 3:
+                        _c.trys.push([3, 11, , 14]);
+                        return [4 /*yield*/, this.transactionService.backfillAssetTransactions(payload.assetCode, payload.assetIssuer, {
+                                bridgeName: payload.bridgeName,
+                                cursor: payload.cursor,
+                                operationTypes: payload.operationTypes,
+                                pages: payload.pages,
+                                pageSize: payload.pageSize,
+                            })];
+                    case 4:
+                        fetchResult = _c.sent();
+                        state.pagesCompleted += payload.pages;
+                        state.pagesRemaining = Math.max(state.pagesRemaining - payload.pages, 0);
+                        state.recordsFetched += fetchResult.fetched;
+                        state.recordsStored += fetchResult.stored;
+                        state.cursor = (_a = fetchResult.lastCursor) !== null && _a !== void 0 ? _a : payload.cursor;
+                        state.updatedAt = new Date().toISOString();
+                        if (!(state.pagesRemaining <= 0 || !fetchResult.lastCursor)) return [3 /*break*/, 7];
+                        state.status = "completed";
+                        return [4 /*yield*/, this.auditService.log({
+                                action: "data.updated",
+                                actorId: "system",
+                                actorType: "system",
+                                resourceType: "backfill_job",
+                                resourceId: state.id,
+                                metadata: { status: state.status },
+                                severity: "info",
+                            })];
+                    case 5:
+                        _c.sent();
+                        return [4 /*yield*/, this.saveJobState(state)];
+                    case 6:
+                        _c.sent();
+                        return [2 /*return*/];
+                    case 7: return [4 /*yield*/, this.saveJobState(state)];
+                    case 8:
+                        _c.sent();
+                        return [4 /*yield*/, this.sleep(state.providerDelayMs)];
+                    case 9:
+                        _c.sent();
+                        nextChunkPages = Math.min(state.chunkPages, state.pagesRemaining);
+                        return [4 /*yield*/, this.queue.addJob("backfill-chunk", {
+                                jobId: state.id,
+                                assetCode: state.assetCode,
+                                assetIssuer: state.assetIssuer,
+                                bridgeName: state.bridgeName,
+                                operationTypes: state.operationTypes,
+                                cursor: state.cursor,
+                                pages: nextChunkPages,
+                                pageSize: state.pageSize,
+                            }, {
+                                priority: this.getPriorityValue(state.priority),
+                            })];
+                    case 10:
+                        _c.sent();
+                        return [3 /*break*/, 14];
+                    case 11:
+                        error_1 = _c.sent();
+                        state.errorCount += 1;
+                        state.updatedAt = new Date().toISOString();
+                        return [4 /*yield*/, this.appendError(state.id, String((_b = error_1.message) !== null && _b !== void 0 ? _b : "unknown error"))];
+                    case 12:
+                        _c.sent();
+                        return [4 /*yield*/, this.saveJobState(state)];
+                    case 13:
+                        _c.sent();
+                        throw error_1;
+                    case 14: return [2 /*return*/];
+                }
+            });
+        });
+    };
+    BackfillService.prototype.markJobFailed = function (jobId, failureMessage) {
+        return __awaiter(this, void 0, void 0, function () {
+            var state;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.loadJobState(jobId)];
+                    case 1:
+                        state = _a.sent();
+                        if (!state)
+                            return [2 /*return*/];
+                        state.status = "failed";
+                        state.errorCount += 1;
+                        state.updatedAt = new Date().toISOString();
+                        return [4 /*yield*/, this.appendError(jobId, failureMessage)];
+                    case 2:
+                        _a.sent();
+                        return [4 /*yield*/, this.saveJobState(state)];
+                    case 3:
+                        _a.sent();
+                        return [4 /*yield*/, this.auditService.log({
+                                action: "data.updated",
+                                actorId: "system",
+                                actorType: "system",
+                                resourceType: "backfill_job",
+                                resourceId: jobId,
+                                metadata: {
+                                    status: state.status,
+                                    error: failureMessage,
+                                },
+                                severity: "warning",
+                            })];
+                    case 4:
+                        _a.sent();
+                        return [2 /*return*/];
+                }
+            });
+        });
+    };
+    BackfillService.prototype.sleep = function (ms) {
+        return new Promise(function (resolve) { return setTimeout(resolve, ms); });
+    };
+    return BackfillService;
+}());
+exports.BackfillService = BackfillService;

--- a/backend/src/services/backfill.service.ts
+++ b/backend/src/services/backfill.service.ts
@@ -1,0 +1,371 @@
+import crypto from "crypto";
+import { redis } from "../utils/redis.js";
+import { config } from "../config/index.js";
+import { AuditService } from "./audit.service.js";
+import { TransactionService } from "./transaction.service.js";
+import { getBackfillQueue } from "../jobs/backfill.queue.js";
+import { logger } from "../utils/logger.js";
+
+export type BackfillPriority = "normal" | "high";
+export type BackfillJobStatus = "pending" | "running" | "completed" | "failed" | "paused" | "cancelled";
+
+export interface BackfillJobState {
+  id: string;
+  type: "transactions";
+  status: BackfillJobStatus;
+  assetCode: string;
+  assetIssuer: string;
+  bridgeName?: string;
+  operationTypes: string[];
+  cursor: string;
+  pageSize: number;
+  chunkPages: number;
+  requestedPages: number;
+  pagesCompleted: number;
+  pagesRemaining: number;
+  recordsFetched: number;
+  recordsStored: number;
+  errorCount: number;
+  priority: BackfillPriority;
+  providerDelayMs: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface BackfillJobSummary extends BackfillJobState {
+  errors: string[];
+  progress: {
+    percent: number;
+  };
+}
+
+export interface BackfillRequest {
+  assetCode: string;
+  assetIssuer: string;
+  bridgeName?: string;
+  operationTypes?: string[];
+  cursor?: string;
+  pages?: number;
+  pageSize?: number;
+  chunkPages?: number;
+  priority?: BackfillPriority;
+}
+
+export interface BackfillChunkPayload {
+  jobId: string;
+  assetCode: string;
+  assetIssuer: string;
+  bridgeName?: string;
+  operationTypes: string[];
+  cursor: string;
+  pages: number;
+  pageSize: number;
+}
+
+const JOB_KEY_PREFIX = "backfill:job:";
+const JOB_LIST_KEY = "backfill:jobs";
+const JOB_ERRORS_SUFFIX = ":errors";
+
+export class BackfillService {
+  private transactionService = new TransactionService();
+  private auditService = AuditService.getInstance();
+  private queue = getBackfillQueue();
+
+  private getJobKey(jobId: string) {
+    return `${JOB_KEY_PREFIX}${jobId}`;
+  }
+
+  private getErrorListKey(jobId: string) {
+    return `${this.getJobKey(jobId)}${JOB_ERRORS_SUFFIX}`;
+  }
+
+  private normalizePageSize(pageSize?: number): number {
+    return Math.min(Math.max(pageSize ?? config.BACKFILL_PAGE_SIZE, 1), 200);
+  }
+
+  private normalizeChunkPages(chunkPages?: number): number {
+    return Math.max(chunkPages ?? config.BACKFILL_CHUNK_PAGES, 1);
+  }
+
+  private normalizeRequestedPages(pages?: number): number {
+    return Math.max(pages ?? config.BACKFILL_DEFAULT_MAX_PAGES, 1);
+  }
+
+  private getPriorityValue(priority: BackfillPriority): number {
+    return priority === "high" ? 1 : 10;
+  }
+
+  private async saveJobState(job: BackfillJobState): Promise<void> {
+    await Promise.all([
+      redis.set(this.getJobKey(job.id), JSON.stringify(job)),
+      redis.sadd(JOB_LIST_KEY, job.id),
+    ]);
+  }
+
+  private async loadJobState(jobId: string): Promise<BackfillJobState | null> {
+    const raw = await redis.get(this.getJobKey(jobId));
+    if (!raw) return null;
+
+    return JSON.parse(raw) as BackfillJobState;
+  }
+
+  private async appendError(jobId: string, message: string): Promise<void> {
+    await redis.rpush(this.getErrorListKey(jobId), message);
+  }
+
+  private async getErrorHistory(jobId: string): Promise<string[]> {
+    return (await redis.lrange(this.getErrorListKey(jobId), 0, -1)) ?? [];
+  }
+
+  private computeProgress(state: BackfillJobState) {
+    const percent = state.requestedPages === 0
+      ? 100
+      : Math.min(100, Math.round(((state.pagesCompleted / state.requestedPages) * 100))); 
+
+    return { percent };
+  }
+
+  public async createTransactionBackfill(request: BackfillRequest): Promise<{ jobId: string; status: BackfillJobStatus }> {
+    const jobId = crypto.randomUUID();
+    const pageSize = this.normalizePageSize(request.pageSize);
+    const chunkPages = this.normalizeChunkPages(request.chunkPages);
+    const requestedPages = this.normalizeRequestedPages(request.pages);
+    const initialCursor = request.cursor?.trim() ?? "";
+    const priority = request.priority ?? "normal";
+
+    const state: BackfillJobState = {
+      id: jobId,
+      type: "transactions",
+      status: "pending",
+      assetCode: request.assetCode,
+      assetIssuer: request.assetIssuer,
+      bridgeName: request.bridgeName,
+      operationTypes: request.operationTypes ?? [],
+      cursor: initialCursor,
+      pageSize,
+      chunkPages,
+      requestedPages,
+      pagesCompleted: 0,
+      pagesRemaining: requestedPages,
+      recordsFetched: 0,
+      recordsStored: 0,
+      errorCount: 0,
+      priority,
+      providerDelayMs: config.BACKFILL_PROVIDER_DELAY_MS,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    await this.saveJobState(state);
+    await this.auditService.log({
+      action: "data.created",
+      actorId: "system",
+      actorType: "system",
+      resourceType: "backfill_job",
+      resourceId: jobId,
+      metadata: {
+        assetCode: state.assetCode,
+        assetIssuer: state.assetIssuer,
+        requestedPages: state.requestedPages,
+        chunkPages: state.chunkPages,
+        priority: state.priority,
+      },
+      severity: "info",
+    });
+
+    const firstChunkPages = Math.min(chunkPages, requestedPages);
+    await this.queue.addJob(
+      "backfill-chunk",
+      {
+        jobId,
+        assetCode: request.assetCode,
+        assetIssuer: request.assetIssuer,
+        bridgeName: request.bridgeName,
+        operationTypes: state.operationTypes,
+        cursor: initialCursor,
+        pages: firstChunkPages,
+        pageSize,
+      },
+      {
+        priority: this.getPriorityValue(priority),
+      },
+    );
+
+    return { jobId, status: state.status };
+  }
+
+  public async getJobStatus(jobId: string): Promise<BackfillJobSummary | null> {
+    const state = await this.loadJobState(jobId);
+    if (!state) return null;
+
+    return {
+      ...state,
+      errors: await this.getErrorHistory(jobId),
+      progress: this.computeProgress(state),
+    };
+  }
+
+  public async listBackfillJobs(): Promise<BackfillJobSummary[]> {
+    const ids = await redis.smembers(JOB_LIST_KEY);
+    const jobs = await Promise.all(ids.map(async (id) => this.getJobStatus(id)));
+    return jobs.filter((job): job is BackfillJobSummary => job !== null);
+  }
+
+  public async resumeBackfillJob(jobId: string): Promise<BackfillJobSummary | null> {
+    const state = await this.loadJobState(jobId);
+    if (!state) return null;
+    if (state.status === "completed") return state as BackfillJobSummary;
+    if (state.pagesRemaining <= 0) {
+      state.status = "completed";
+      state.updatedAt = new Date().toISOString();
+      await this.saveJobState(state);
+      return state as BackfillJobSummary;
+    }
+
+    state.status = "pending";
+    state.updatedAt = new Date().toISOString();
+    await this.saveJobState(state);
+    await this.auditService.log({
+      action: "data.updated",
+      actorId: "system",
+      actorType: "system",
+      resourceType: "backfill_job",
+      resourceId: jobId,
+      metadata: {
+        status: state.status,
+        pagesRemaining: state.pagesRemaining,
+      },
+      severity: "info",
+    });
+
+    const nextPages = Math.min(state.chunkPages, state.pagesRemaining);
+    await this.queue.addJob(
+      "backfill-chunk",
+      {
+        jobId,
+        assetCode: state.assetCode,
+        assetIssuer: state.assetIssuer,
+        bridgeName: state.bridgeName,
+        operationTypes: state.operationTypes,
+        cursor: state.cursor,
+        pages: nextPages,
+        pageSize: state.pageSize,
+      },
+      {
+        priority: this.getPriorityValue(state.priority),
+      },
+    );
+
+    return {
+      ...state,
+      errors: await this.getErrorHistory(jobId),
+      progress: this.computeProgress(state),
+    };
+  }
+
+  public async processBackfillChunk(payload: BackfillChunkPayload): Promise<void> {
+    const state = await this.loadJobState(payload.jobId);
+    if (!state) {
+      throw new Error(`Backfill job not found: ${payload.jobId}`);
+    }
+    if (state.status === "completed" || state.status === "cancelled") {
+      logger.info({ jobId: payload.jobId }, "Skipping chunk for completed or cancelled job");
+      return;
+    }
+
+    state.status = "running";
+    state.updatedAt = new Date().toISOString();
+    await this.saveJobState(state);
+
+    try {
+      const fetchResult = await this.transactionService.backfillAssetTransactions(
+        payload.assetCode,
+        payload.assetIssuer,
+        {
+          bridgeName: payload.bridgeName,
+          cursor: payload.cursor,
+          operationTypes: payload.operationTypes,
+          pages: payload.pages,
+          pageSize: payload.pageSize,
+        },
+      );
+
+      state.pagesCompleted += payload.pages;
+      state.pagesRemaining = Math.max(state.pagesRemaining - payload.pages, 0);
+      state.recordsFetched += fetchResult.fetched;
+      state.recordsStored += fetchResult.stored;
+      state.cursor = fetchResult.lastCursor ?? payload.cursor;
+      state.updatedAt = new Date().toISOString();
+
+      if (state.pagesRemaining <= 0 || !fetchResult.lastCursor) {
+        state.status = "completed";
+        await this.auditService.log({
+          action: "data.updated",
+          actorId: "system",
+          actorType: "system",
+          resourceType: "backfill_job",
+          resourceId: state.id,
+          metadata: { status: state.status },
+          severity: "info",
+        });
+        await this.saveJobState(state);
+        return;
+      }
+
+      await this.saveJobState(state);
+      await this.sleep(state.providerDelayMs);
+
+      const nextChunkPages = Math.min(state.chunkPages, state.pagesRemaining);
+      await this.queue.addJob(
+        "backfill-chunk",
+        {
+          jobId: state.id,
+          assetCode: state.assetCode,
+          assetIssuer: state.assetIssuer,
+          bridgeName: state.bridgeName,
+          operationTypes: state.operationTypes,
+          cursor: state.cursor,
+          pages: nextChunkPages,
+          pageSize: state.pageSize,
+        },
+        {
+          priority: this.getPriorityValue(state.priority),
+        },
+      );
+    } catch (error) {
+      state.errorCount += 1;
+      state.updatedAt = new Date().toISOString();
+      await this.appendError(state.id, String((error as Error).message ?? "unknown error"));
+      await this.saveJobState(state);
+      throw error;
+    }
+  }
+
+  public async markJobFailed(jobId: string, failureMessage: string): Promise<void> {
+    const state = await this.loadJobState(jobId);
+    if (!state) return;
+
+    state.status = "failed";
+    state.errorCount += 1;
+    state.updatedAt = new Date().toISOString();
+    await this.appendError(jobId, failureMessage);
+    await this.saveJobState(state);
+
+    await this.auditService.log({
+      action: "data.updated",
+      actorId: "system",
+      actorType: "system",
+      resourceType: "backfill_job",
+      resourceId: jobId,
+      metadata: {
+        status: state.status,
+        error: failureMessage,
+      },
+      severity: "warning",
+    });
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}

--- a/backend/src/services/transaction.service.js
+++ b/backend/src/services/transaction.service.js
@@ -1,0 +1,511 @@
+"use strict";
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g = Object.create((typeof Iterator === "function" ? Iterator : Object).prototype);
+    return g.next = verb(0), g["throw"] = verb(1), g["return"] = verb(2), typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (g && (g = 0, op[0] && (_ = 0)), _) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || Array.prototype.slice.call(from));
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.TransactionService = void 0;
+var StellarSdk = require("@stellar/stellar-sdk");
+var connection_js_1 = require("../database/connection.js");
+var index_js_1 = require("../config/index.js");
+var logger_js_1 = require("../utils/logger.js");
+var HORIZON_REQUEST_DELAY_MS = 120;
+var DEFAULT_PAGE_SIZE = 200;
+var TransactionService = /** @class */ (function () {
+    function TransactionService() {
+        this.db = (0, connection_js_1.getDatabase)();
+        this.horizon = new StellarSdk.Horizon.Server(index_js_1.config.STELLAR_HORIZON_URL, {
+            allowHttp: index_js_1.config.NODE_ENV === "development",
+        });
+    }
+    TransactionService.prototype.fetchTransactionsByAsset = function (assetCode_1, assetIssuer_1) {
+        return __awaiter(this, arguments, void 0, function (assetCode, assetIssuer, options) {
+            var pageSize, maxPages, allowedTypes, includeAllTypes, cursor, _a, fetched, stored, pagesRead, lastCursor, asset, requestBase, requestBuilder, page, records, parsed, newest, token, error_1, message;
+            var _this = this;
+            var _b, _c, _d, _e, _f, _g, _h, _j;
+            if (options === void 0) { options = {}; }
+            return __generator(this, function (_k) {
+                switch (_k.label) {
+                    case 0:
+                        pageSize = Math.min(Math.max((_b = options.pageSize) !== null && _b !== void 0 ? _b : DEFAULT_PAGE_SIZE, 1), DEFAULT_PAGE_SIZE);
+                        maxPages = Math.max((_c = options.maxPages) !== null && _c !== void 0 ? _c : 1, 1);
+                        allowedTypes = new Set(((_d = options.operationTypes) !== null && _d !== void 0 ? _d : []).map(function (type) { return type.toLowerCase(); }));
+                        includeAllTypes = allowedTypes.size === 0;
+                        if (!((_e = options.cursor) !== null && _e !== void 0)) return [3 /*break*/, 1];
+                        _a = _e;
+                        return [3 /*break*/, 3];
+                    case 1: return [4 /*yield*/, this.getSavedCursor(assetCode, assetIssuer)];
+                    case 2:
+                        _a = (_k.sent());
+                        _k.label = 3;
+                    case 3:
+                        cursor = (_f = _a) !== null && _f !== void 0 ? _f : "now";
+                        fetched = 0;
+                        stored = 0;
+                        pagesRead = 0;
+                        lastCursor = null;
+                        _k.label = 4;
+                    case 4:
+                        _k.trys.push([4, 12, , 14]);
+                        _k.label = 5;
+                    case 5:
+                        if (!(pagesRead < maxPages)) return [3 /*break*/, 10];
+                        asset = new StellarSdk.Asset(assetCode, assetIssuer);
+                        requestBase = this.horizon.payments()
+                            .forAsset(asset)
+                            .order((_g = options.order) !== null && _g !== void 0 ? _g : "desc")
+                            .limit(pageSize);
+                        requestBuilder = cursor && requestBase.cursor
+                            ? requestBase.cursor(cursor)
+                            : requestBase;
+                        return [4 /*yield*/, requestBuilder.call()];
+                    case 6:
+                        page = _k.sent();
+                        records = page.records;
+                        if (!records.length) {
+                            return [3 /*break*/, 10];
+                        }
+                        fetched += records.length;
+                        parsed = records
+                            .filter(function (record) {
+                            var _a;
+                            var operationType = String((_a = record.type) !== null && _a !== void 0 ? _a : "").toLowerCase();
+                            return includeAllTypes || allowedTypes.has(operationType);
+                        })
+                            .map(function (record) { return _this.parsePaymentRecord(record, assetCode, assetIssuer, options.bridgeName); });
+                        if (!(parsed.length > 0)) return [3 /*break*/, 8];
+                        return [4 /*yield*/, this.upsertTransactions(parsed)];
+                    case 7:
+                        _k.sent();
+                        stored += parsed.length;
+                        _k.label = 8;
+                    case 8:
+                        newest = records[records.length - 1];
+                        token = String((_h = newest === null || newest === void 0 ? void 0 : newest.paging_token) !== null && _h !== void 0 ? _h : "").trim();
+                        if (!token) {
+                            return [3 /*break*/, 10];
+                        }
+                        cursor = token;
+                        lastCursor = token;
+                        pagesRead += 1;
+                        return [4 /*yield*/, this.sleep(HORIZON_REQUEST_DELAY_MS)];
+                    case 9:
+                        _k.sent();
+                        if (records.length < pageSize) {
+                            return [3 /*break*/, 10];
+                        }
+                        return [3 /*break*/, 5];
+                    case 10: return [4 /*yield*/, this.saveSyncState(assetCode, assetIssuer, {
+                            last_paging_token: lastCursor,
+                            error_count: 0,
+                            last_error: null,
+                        })];
+                    case 11:
+                        _k.sent();
+                        return [2 /*return*/, { fetched: fetched, stored: stored, lastCursor: lastCursor }];
+                    case 12:
+                        error_1 = _k.sent();
+                        message = (_j = error_1.message) !== null && _j !== void 0 ? _j : "unknown transaction fetch error";
+                        logger_js_1.logger.error({ assetCode: assetCode, assetIssuer: assetIssuer, error: error_1 }, "Failed to fetch transaction history from Horizon");
+                        return [4 /*yield*/, this.bumpSyncError(assetCode, assetIssuer, message)];
+                    case 13:
+                        _k.sent();
+                        throw error_1;
+                    case 14: return [2 /*return*/];
+                }
+            });
+        });
+    };
+    TransactionService.prototype.backfillAssetTransactions = function (assetCode_1, assetIssuer_1) {
+        return __awaiter(this, arguments, void 0, function (assetCode, assetIssuer, options) {
+            var _a, _b, _c;
+            if (options === void 0) { options = {}; }
+            return __generator(this, function (_d) {
+                return [2 /*return*/, this.fetchTransactionsByAsset(assetCode, assetIssuer, __assign(__assign({}, options), { order: "asc", maxPages: (_b = (_a = options.pages) !== null && _a !== void 0 ? _a : options.maxPages) !== null && _b !== void 0 ? _b : 25, cursor: (_c = options.cursor) !== null && _c !== void 0 ? _c : "" }))];
+            });
+        });
+    };
+    TransactionService.prototype.detectNewTransactions = function (assetCode, assetIssuer, operationTypes) {
+        return __awaiter(this, void 0, void 0, function () {
+            var cursor;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.getSavedCursor(assetCode, assetIssuer)];
+                    case 1:
+                        cursor = _a.sent();
+                        return [2 /*return*/, this.fetchTransactionsByAsset(assetCode, assetIssuer, {
+                                cursor: cursor !== null && cursor !== void 0 ? cursor : "now",
+                                order: "asc",
+                                maxPages: 3,
+                                operationTypes: operationTypes,
+                            })];
+                }
+            });
+        });
+    };
+    TransactionService.prototype.listTransactions = function (filters, page, pageSize) {
+        return __awaiter(this, void 0, void 0, function () {
+            var safePage, safePageSize, offset, query, totalRow, total, rows;
+            var _this = this;
+            var _a;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0:
+                        safePage = Math.max(page, 1);
+                        safePageSize = Math.min(Math.max(pageSize, 1), 100);
+                        offset = (safePage - 1) * safePageSize;
+                        query = this.db("asset_transactions");
+                        this.applyFilters(query, filters);
+                        return [4 /*yield*/, query.clone().count("id as count").first()];
+                    case 1:
+                        totalRow = _b.sent();
+                        total = Number((_a = totalRow === null || totalRow === void 0 ? void 0 : totalRow.count) !== null && _a !== void 0 ? _a : 0);
+                        return [4 /*yield*/, query
+                                .clone()
+                                .select("*")
+                                .orderBy("occurred_at", "desc")
+                                .limit(safePageSize)
+                                .offset(offset)];
+                    case 2:
+                        rows = (_b.sent());
+                        return [2 /*return*/, {
+                                transactions: rows.map(function (row) { return _this.mapRow(row); }),
+                                total: total,
+                                page: safePage,
+                                pageSize: safePageSize,
+                                totalPages: Math.max(1, Math.ceil(total / safePageSize)),
+                            }];
+                }
+            });
+        });
+    };
+    TransactionService.prototype.exportTransactionsCsv = function (filters) {
+        return __awaiter(this, void 0, void 0, function () {
+            var query, rows, header, csvRows;
+            var _this = this;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        query = this.db("asset_transactions").select("*").orderBy("occurred_at", "desc");
+                        this.applyFilters(query, filters);
+                        return [4 /*yield*/, query];
+                    case 1:
+                        rows = (_a.sent());
+                        header = [
+                            "id",
+                            "txHash",
+                            "bridge",
+                            "asset",
+                            "operationType",
+                            "status",
+                            "amount",
+                            "fee",
+                            "senderAddress",
+                            "recipientAddress",
+                            "timestamp",
+                        ];
+                        csvRows = rows.map(function (row) {
+                            var mapped = _this.mapRow(row);
+                            return [
+                                mapped.id,
+                                mapped.txHash,
+                                mapped.bridge,
+                                mapped.asset,
+                                mapped.operationType,
+                                mapped.status,
+                                mapped.amount,
+                                mapped.fee,
+                                mapped.senderAddress,
+                                mapped.recipientAddress,
+                                mapped.timestamp,
+                            ]
+                                .map(function (value) { return _this.escapeCsv(String(value !== null && value !== void 0 ? value : "")); })
+                                .join(",");
+                        });
+                        return [2 /*return*/, __spreadArray([header.join(",")], csvRows, true).join("\n")];
+                }
+            });
+        });
+    };
+    TransactionService.prototype.getSyncState = function (assetCode, assetIssuer) {
+        return __awaiter(this, void 0, void 0, function () {
+            var state;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.db("asset_transaction_sync_state")
+                            .select("*")
+                            .where({ asset_code: assetCode, asset_issuer: assetIssuer })
+                            .first()];
+                    case 1:
+                        state = _a.sent();
+                        return [2 /*return*/, state !== null && state !== void 0 ? state : null];
+                }
+            });
+        });
+    };
+    TransactionService.prototype.parsePaymentRecord = function (operation, assetCode, assetIssuer, bridgeName) {
+        var _a, _b, _c, _d, _e, _f;
+        var now = new Date();
+        var transactionHash = String((_a = operation.transaction_hash) !== null && _a !== void 0 ? _a : "");
+        var status = operation.transaction_successful === true ? "completed" : "failed";
+        return {
+            bridge_name: bridgeName !== null && bridgeName !== void 0 ? bridgeName : null,
+            asset_code: assetCode,
+            asset_issuer: assetIssuer,
+            transaction_hash: transactionHash,
+            operation_id: String((_b = operation.id) !== null && _b !== void 0 ? _b : transactionHash),
+            operation_type: String((_c = operation.type) !== null && _c !== void 0 ? _c : "unknown"),
+            status: status,
+            ledger: operation.ledger ? Number(operation.ledger) : null,
+            paging_token: String((_d = operation.paging_token) !== null && _d !== void 0 ? _d : ""),
+            source_account: this.valueOrNull(operation.source_account),
+            from_address: this.valueOrNull(operation.from),
+            to_address: this.valueOrNull(operation.to),
+            amount: String((_e = operation.amount) !== null && _e !== void 0 ? _e : "0"),
+            fee_charged: "0",
+            occurred_at: new Date(String((_f = operation.created_at) !== null && _f !== void 0 ? _f : now.toISOString())),
+            raw_transaction: null,
+            raw_operation: operation,
+            created_at: now,
+            updated_at: now,
+        };
+    };
+    TransactionService.prototype.upsertTransactions = function (records) {
+        return __awaiter(this, void 0, void 0, function () {
+            var index, chunk;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        index = 0;
+                        _a.label = 1;
+                    case 1:
+                        if (!(index < records.length)) return [3 /*break*/, 4];
+                        chunk = records.slice(index, index + 100);
+                        return [4 /*yield*/, this.db("asset_transactions")
+                                .insert(chunk)
+                                .onConflict("operation_id")
+                                .merge({
+                                status: this.db.raw("excluded.status"),
+                                bridge_name: this.db.raw("excluded.bridge_name"),
+                                fee_charged: this.db.raw("excluded.fee_charged"),
+                                raw_operation: this.db.raw("excluded.raw_operation"),
+                                updated_at: this.db.fn.now(),
+                            })];
+                    case 2:
+                        _a.sent();
+                        _a.label = 3;
+                    case 3:
+                        index += 100;
+                        return [3 /*break*/, 1];
+                    case 4: return [2 /*return*/];
+                }
+            });
+        });
+    };
+    TransactionService.prototype.applyFilters = function (query, filters) {
+        if (filters.bridge) {
+            query.where("bridge_name", filters.bridge);
+        }
+        if (filters.asset) {
+            query.where("asset_code", filters.asset);
+        }
+        if (filters.status) {
+            query.where("status", filters.status);
+        }
+        if (filters.operationType) {
+            query.where("operation_type", filters.operationType);
+        }
+        if (filters.dateFrom) {
+            query.where("occurred_at", ">=", new Date(filters.dateFrom));
+        }
+        if (filters.dateTo) {
+            query.where("occurred_at", "<=", new Date(filters.dateTo));
+        }
+        if (filters.search) {
+            var term_1 = "%".concat(filters.search.trim(), "%");
+            query.andWhere(function (builder) {
+                builder
+                    .where("transaction_hash", "ilike", term_1)
+                    .orWhere("source_account", "ilike", term_1)
+                    .orWhere("from_address", "ilike", term_1)
+                    .orWhere("to_address", "ilike", term_1);
+            });
+        }
+    };
+    TransactionService.prototype.mapRow = function (row) {
+        var _a, _b, _c, _d;
+        return {
+            id: row.id,
+            txHash: row.transaction_hash,
+            bridge: (_a = row.bridge_name) !== null && _a !== void 0 ? _a : "stellar",
+            asset: row.asset_code,
+            amount: Number(row.amount),
+            sourceChain: "stellar",
+            destinationChain: "stellar",
+            senderAddress: (_c = (_b = row.from_address) !== null && _b !== void 0 ? _b : row.source_account) !== null && _c !== void 0 ? _c : "",
+            recipientAddress: (_d = row.to_address) !== null && _d !== void 0 ? _d : "",
+            status: this.normalizeStatus(row.status),
+            fee: Number(row.fee_charged),
+            timestamp: row.occurred_at.toISOString(),
+            confirmedAt: row.status === "completed" ? row.occurred_at.toISOString() : null,
+            stellarTxHash: row.transaction_hash,
+            ethereumTxHash: null,
+            blockNumber: row.ledger ? Number(row.ledger) : null,
+            operationType: row.operation_type,
+        };
+    };
+    TransactionService.prototype.normalizeStatus = function (value) {
+        if (value === "failed")
+            return "failed";
+        if (value === "pending")
+            return "pending";
+        return "completed";
+    };
+    TransactionService.prototype.valueOrNull = function (value) {
+        if (typeof value !== "string")
+            return null;
+        return value.trim().length > 0 ? value : null;
+    };
+    TransactionService.prototype.getSavedCursor = function (assetCode, assetIssuer) {
+        return __awaiter(this, void 0, void 0, function () {
+            var state;
+            var _a;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0: return [4 /*yield*/, this.getSyncState(assetCode, assetIssuer)];
+                    case 1:
+                        state = _b.sent();
+                        return [2 /*return*/, (_a = state === null || state === void 0 ? void 0 : state.last_paging_token) !== null && _a !== void 0 ? _a : null];
+                }
+            });
+        });
+    };
+    TransactionService.prototype.saveSyncState = function (assetCode, assetIssuer, update) {
+        return __awaiter(this, void 0, void 0, function () {
+            var _a, _b, _c, _d, _e, _f, _g, _h;
+            return __generator(this, function (_j) {
+                switch (_j.label) {
+                    case 0: return [4 /*yield*/, this.db("asset_transaction_sync_state")
+                            .insert({
+                            asset_code: assetCode,
+                            asset_issuer: assetIssuer,
+                            last_paging_token: (_a = update.last_paging_token) !== null && _a !== void 0 ? _a : null,
+                            last_ledger: (_b = update.last_ledger) !== null && _b !== void 0 ? _b : null,
+                            error_count: (_c = update.error_count) !== null && _c !== void 0 ? _c : 0,
+                            last_error: (_d = update.last_error) !== null && _d !== void 0 ? _d : null,
+                            last_synced_at: new Date(),
+                            created_at: new Date(),
+                            updated_at: new Date(),
+                        })
+                            .onConflict(["asset_code", "asset_issuer"])
+                            .merge({
+                            last_paging_token: (_e = update.last_paging_token) !== null && _e !== void 0 ? _e : null,
+                            last_ledger: (_f = update.last_ledger) !== null && _f !== void 0 ? _f : null,
+                            error_count: (_g = update.error_count) !== null && _g !== void 0 ? _g : 0,
+                            last_error: (_h = update.last_error) !== null && _h !== void 0 ? _h : null,
+                            last_synced_at: new Date(),
+                            updated_at: new Date(),
+                        })];
+                    case 1:
+                        _j.sent();
+                        return [2 /*return*/];
+                }
+            });
+        });
+    };
+    TransactionService.prototype.bumpSyncError = function (assetCode, assetIssuer, message) {
+        return __awaiter(this, void 0, void 0, function () {
+            var existing, nextCount;
+            var _a, _b;
+            return __generator(this, function (_c) {
+                switch (_c.label) {
+                    case 0: return [4 /*yield*/, this.getSyncState(assetCode, assetIssuer)];
+                    case 1:
+                        existing = _c.sent();
+                        nextCount = ((_a = existing === null || existing === void 0 ? void 0 : existing.error_count) !== null && _a !== void 0 ? _a : 0) + 1;
+                        return [4 /*yield*/, this.saveSyncState(assetCode, assetIssuer, {
+                                last_paging_token: (_b = existing === null || existing === void 0 ? void 0 : existing.last_paging_token) !== null && _b !== void 0 ? _b : null,
+                                last_ledger: (existing === null || existing === void 0 ? void 0 : existing.last_ledger) ? Number(existing.last_ledger) : null,
+                                error_count: nextCount,
+                                last_error: message,
+                            })];
+                    case 2:
+                        _c.sent();
+                        return [2 /*return*/];
+                }
+            });
+        });
+    };
+    TransactionService.prototype.escapeCsv = function (value) {
+        if (value.includes(",") || value.includes("\"") || value.includes("\n")) {
+            return "\"".concat(value.replace(/"/g, '""'), "\"");
+        }
+        return value;
+    };
+    TransactionService.prototype.sleep = function (ms) {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, new Promise(function (resolve) { return setTimeout(resolve, ms); })];
+                    case 1:
+                        _a.sent();
+                        return [2 /*return*/];
+                }
+            });
+        });
+    };
+    return TransactionService;
+}());
+exports.TransactionService = TransactionService;

--- a/backend/src/utils/logger.js
+++ b/backend/src/utils/logger.js
@@ -1,0 +1,204 @@
+"use strict";
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.accessLogger = exports.auditLogger = exports.errorLogger = exports.performanceLogger = exports.logger = void 0;
+exports.createChildLogger = createChildLogger;
+exports.createRequestLogger = createRequestLogger;
+var os_1 = require("os");
+var pino_1 = require("pino");
+var index_js_1 = require("../config/index.js");
+function isObject(value) {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+function writeFlexibleLog(target, level, args) {
+    if (args.length === 0)
+        return;
+    var first = args[0];
+    var second = args[1];
+    var third = args[2];
+    if (typeof first === "string") {
+        if (second instanceof Error) {
+            var meta = isObject(third) ? third : {};
+            target[level](__assign({ err: second }, meta), first);
+            return;
+        }
+        if (isObject(second)) {
+            target[level](second, first);
+            return;
+        }
+        target[level](first);
+        return;
+    }
+    if (first instanceof Error) {
+        var msg = typeof second === "string" ? second : first.message;
+        var meta = isObject(third) ? third : {};
+        target[level](__assign({ err: first }, meta), msg);
+        return;
+    }
+    if (isObject(first)) {
+        if (typeof second === "string") {
+            target[level](first, second);
+            return;
+        }
+        target[level](first);
+        return;
+    }
+    target[level](first);
+}
+function makeFlexibleLogger(target) {
+    return {
+        trace: function () {
+            var args = [];
+            for (var _i = 0; _i < arguments.length; _i++) {
+                args[_i] = arguments[_i];
+            }
+            return writeFlexibleLog(target, "trace", args);
+        },
+        debug: function () {
+            var args = [];
+            for (var _i = 0; _i < arguments.length; _i++) {
+                args[_i] = arguments[_i];
+            }
+            return writeFlexibleLog(target, "debug", args);
+        },
+        info: function () {
+            var args = [];
+            for (var _i = 0; _i < arguments.length; _i++) {
+                args[_i] = arguments[_i];
+            }
+            return writeFlexibleLog(target, "info", args);
+        },
+        warn: function () {
+            var args = [];
+            for (var _i = 0; _i < arguments.length; _i++) {
+                args[_i] = arguments[_i];
+            }
+            return writeFlexibleLog(target, "warn", args);
+        },
+        error: function () {
+            var args = [];
+            for (var _i = 0; _i < arguments.length; _i++) {
+                args[_i] = arguments[_i];
+            }
+            return writeFlexibleLog(target, "error", args);
+        },
+        fatal: function () {
+            var args = [];
+            for (var _i = 0; _i < arguments.length; _i++) {
+                args[_i] = arguments[_i];
+            }
+            return writeFlexibleLog(target, "fatal", args);
+        },
+        child: function (bindings) { return makeFlexibleLogger(target.child(bindings)); },
+    };
+}
+// Create base logger configuration
+var baseConfig = {
+    level: index_js_1.config.LOG_LEVEL,
+    formatters: {
+        level: function (label) { return ({ level: label }); },
+        log: function (object) {
+            // Add timestamp if not present
+            if (!object.timestamp) {
+                object.timestamp = new Date().toISOString();
+            }
+            return object;
+        },
+    },
+    // Custom redaction for sensitive fields
+    redact: {
+        paths: [
+            'password',
+            'token',
+            'secret',
+            'key',
+            'auth',
+            'credential',
+            'email',
+            'phone',
+            'ssn',
+            'creditCard',
+            'account',
+            'routing',
+            'apikey',
+            'api_key',
+            'private_key',
+            'public_key',
+            'certificate',
+        ],
+        censor: '***REDACTED***',
+    },
+    // Add service information
+    base: {
+        service: 'bridge-watch-api',
+        version: process.env.npm_package_version || '0.1.0',
+        environment: index_js_1.config.NODE_ENV,
+        hostname: os_1.default.hostname(),
+        pid: process.pid,
+    },
+};
+// Development configuration with pretty printing
+var developmentConfig = __assign(__assign({}, baseConfig), { transport: {
+        target: "pino-pretty",
+        options: {
+            colorize: true,
+            translateTime: "HH:MM:ss Z",
+            ignore: "pid,hostname",
+            messageFormat: "{reqId} {msg}",
+            customPrettifiers: {
+                time: function (timestamp) {
+                    return new Date(timestamp).toLocaleString();
+                },
+            },
+        },
+    } });
+// Production configuration with structured JSON
+var productionConfig = __assign(__assign({}, baseConfig), (index_js_1.config.LOG_FILE && {
+    transport: {
+        target: "pino/file",
+        options: {
+            destination: index_js_1.config.LOG_FILE,
+            mkdir: true,
+        },
+    },
+}));
+// Test configuration (minimal output)
+var testConfig = __assign(__assign({}, baseConfig), { level: "silent" });
+// Select configuration based on environment
+var loggerConfig = index_js_1.config.NODE_ENV === "development"
+    ? developmentConfig
+    : index_js_1.config.NODE_ENV === "test"
+        ? testConfig
+        : productionConfig;
+exports.logger = (0, pino_1.default)(loggerConfig);
+// Export child logger factory for specific components
+function createChildLogger(component, metadata) {
+    var child = exports.logger.child(__assign({ component: component }, metadata));
+    return makeFlexibleLogger(child);
+}
+// Export request-specific logger factory
+function createRequestLogger(requestId, traceContext) {
+    return exports.logger.child(__assign({ requestId: requestId }, traceContext));
+}
+// Export performance logger
+exports.performanceLogger = createChildLogger('performance');
+// Export error logger
+exports.errorLogger = createChildLogger('error');
+// Export audit logger for security events
+exports.auditLogger = createChildLogger('audit', {
+    type: 'security',
+});
+// Export access logger for API access
+exports.accessLogger = createChildLogger('access', {
+    type: 'access',
+});

--- a/backend/src/utils/redis.js
+++ b/backend/src/utils/redis.js
@@ -1,0 +1,6 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.redis = void 0;
+var redis_js_1 = require("../config/redis.js");
+var redis = (0, redis_js_1.createRedisClient)();
+exports.redis = redis;

--- a/backend/src/workers/index.ts
+++ b/backend/src/workers/index.ts
@@ -7,6 +7,7 @@ import { processAnalyticsAggregation } from "./analyticsAggregation.worker.js";
 import { processDigestScheduler } from "./digestScheduler.worker.js";
 import { logger } from "../utils/logger.js";
 import { initSupplyVerificationJob } from "../jobs/supplyVerification.job.js";
+import { initBackfillJob } from "../jobs/backfill.job.js";
 import { runAuditRetentionJob } from "../jobs/auditRetention.job.js";
 
 export async function initJobSystem() {
@@ -43,6 +44,9 @@ export async function initJobSystem() {
 
   // Initialize supply verification job system (dedicated queue and worker)
   await initSupplyVerificationJob();
+
+  // Initialize backfill orchestration worker
+  await initBackfillJob();
 
   // Schedule repeatable jobs
   // price-collection: every 30 seconds

--- a/backend/tests/services/backfill.service.test.ts
+++ b/backend/tests/services/backfill.service.test.ts
@@ -1,0 +1,196 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { BackfillService } from "../../src/services/backfill.service.js";
+
+var mockSet;
+var mockGet;
+var mockSadd;
+var mockSmembers;
+var mockRpush;
+var mockLrange;
+var mockAddJob;
+var mockBackfillAssetTransactions;
+var mockAuditLog;
+
+vi.mock("../../src/utils/redis.js", () => {
+  mockSet = vi.fn().mockResolvedValue("OK");
+  mockGet = vi.fn();
+  mockSadd = vi.fn().mockResolvedValue(1);
+  mockSmembers = vi.fn().mockResolvedValue([]);
+  mockRpush = vi.fn().mockResolvedValue(1);
+  mockLrange = vi.fn().mockResolvedValue([]);
+
+  return {
+    redis: {
+      set: mockSet,
+      get: mockGet,
+      sadd: mockSadd,
+      smembers: mockSmembers,
+      rpush: mockRpush,
+      lrange: mockLrange,
+    },
+  };
+});
+
+vi.mock("../../src/jobs/backfill.queue.js", () => {
+  mockAddJob = vi.fn().mockResolvedValue({ id: "job-1" });
+  return {
+    getBackfillQueue: vi.fn(() => ({
+      addJob: mockAddJob,
+    })),
+  };
+});
+
+vi.mock("../../src/services/transaction.service.js", () => {
+  mockBackfillAssetTransactions = vi.fn();
+  return {
+    TransactionService: vi.fn().mockImplementation(() => ({
+      backfillAssetTransactions: mockBackfillAssetTransactions,
+    })),
+  };
+});
+
+vi.mock("../../src/services/audit.service.js", () => {
+  mockAuditLog = vi.fn().mockResolvedValue({});
+  return {
+    AuditService: {
+      getInstance: vi.fn(() => ({ log: mockAuditLog })),
+    },
+  };
+});
+
+vi.mock("../../src/utils/logger.js", () => ({ logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } }));
+
+describe("BackfillService", () => {
+  let service: BackfillService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new BackfillService();
+    mockGet.mockResolvedValue(null);
+    mockSmembers.mockResolvedValue([]);
+  });
+
+  it("creates a backfill job and enqueues the first chunk", async () => {
+    const result = await service.createTransactionBackfill({
+      assetCode: "USDC",
+      assetIssuer: "GDUKMGUGDZQK6YH73JJDZP4445L3MDUX44SQGDRB3QXKOS4TKYAAAAAAA",
+      pages: 10,
+      pageSize: 50,
+      chunkPages: 5,
+      priority: "high",
+    });
+
+    expect(result.jobId).toBeDefined();
+    expect(result.status).toBe("pending");
+    expect(mockSet).toHaveBeenCalled();
+    expect(mockSadd).toHaveBeenCalledWith("backfill:jobs", expect.any(String));
+    expect(mockAddJob).toHaveBeenCalledWith(
+      "backfill-chunk",
+      expect.objectContaining({
+        assetCode: "USDC",
+        assetIssuer: expect.any(String),
+        pages: 5,
+        pageSize: 50,
+      }),
+      { priority: 1 },
+    );
+    expect(mockAuditLog).toHaveBeenCalled();
+  });
+
+  it("returns null for missing jobs", async () => {
+    mockGet.mockResolvedValue(null);
+    const result = await service.getJobStatus("missing-job");
+    expect(result).toBeNull();
+  });
+
+  it("resumes a paused backfill job and re-enqueues a chunk", async () => {
+    const jobId = "resume-job";
+    const savedState = {
+      id: jobId,
+      type: "transactions",
+      status: "failed",
+      assetCode: "USDC",
+      assetIssuer: "GDUKMGUGDZQK6YH73JJDZP4445L3MDUX44SQGDRB3QXKOS4TKYAAAAAAA",
+      bridgeName: "circle",
+      operationTypes: ["payment"],
+      cursor: "abc",
+      pageSize: 100,
+      chunkPages: 5,
+      requestedPages: 20,
+      pagesCompleted: 5,
+      pagesRemaining: 15,
+      recordsFetched: 100,
+      recordsStored: 90,
+      errorCount: 1,
+      priority: "normal",
+      providerDelayMs: 500,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    mockGet.mockResolvedValue(JSON.stringify(savedState));
+
+    const result = await service.resumeBackfillJob(jobId);
+
+    expect(result).not.toBeNull();
+    expect(result?.status).toBe("pending");
+    expect(mockSet).toHaveBeenCalledWith(expect.stringContaining(jobId), expect.any(String));
+    expect(mockAddJob).toHaveBeenCalledWith(
+      "backfill-chunk",
+      expect.objectContaining({
+        jobId,
+        cursor: "abc",
+        pages: 5,
+      }),
+      { priority: 10 },
+    );
+    expect(mockAuditLog).toHaveBeenCalled();
+  });
+
+  it("marks a job complete when no further pages are available", async () => {
+    const jobId = "complete-job";
+    const savedState = {
+      id: jobId,
+      type: "transactions",
+      status: "running",
+      assetCode: "USDC",
+      assetIssuer: "GDUKMGUGDZQK6YH73JJDZP4445L3MDUX44SQGDRB3QXKOS4TKYAAAAAAA",
+      bridgeName: "circle",
+      operationTypes: ["payment"],
+      cursor: "abc",
+      pageSize: 100,
+      chunkPages: 5,
+      requestedPages: 5,
+      pagesCompleted: 0,
+      pagesRemaining: 5,
+      recordsFetched: 0,
+      recordsStored: 0,
+      errorCount: 0,
+      priority: "normal",
+      providerDelayMs: 500,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    mockGet.mockResolvedValue(JSON.stringify(savedState));
+    mockBackfillAssetTransactions.mockResolvedValue({ fetched: 0, stored: 0, lastCursor: null });
+
+    await service.processBackfillChunk({
+      jobId,
+      assetCode: savedState.assetCode,
+      assetIssuer: savedState.assetIssuer,
+      bridgeName: savedState.bridgeName,
+      operationTypes: savedState.operationTypes,
+      cursor: savedState.cursor,
+      pages: 5,
+      pageSize: 100,
+    });
+
+    expect(mockSet).toHaveBeenCalledWith(expect.stringContaining(jobId), expect.stringContaining("\"status\":\"completed\""));
+    expect(mockAddJob).not.toHaveBeenCalledWith(
+      "backfill-chunk",
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
       ],
       "devDependencies": {
         "@playwright/test": "^1.54.2",
-        "@rollup/rollup-linux-x64-gnu": "^4.60.2"
+        "@rollup/rollup-linux-x64-gnu": "^4.60.2",
+        "es-module-lexer": "^2.1.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -57,6 +58,7 @@
         "@typescript-eslint/parser": "^7.18.0",
         "@vitest/coverage-v8": "^2.1.9",
         "eslint": "^8.57.1",
+        "pathe": "^2.0.3",
         "tsx": "^4.19.2",
         "typescript": "^5.9.3",
         "vitest": "^2.1.5"
@@ -142,7 +144,6 @@
       "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.2",
         "@vitest/mocker": "4.1.2",
@@ -252,7 +253,6 @@
       "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -457,7 +457,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -849,7 +848,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -898,7 +896,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1069,7 +1066,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -1104,17 +1100,6 @@
       },
       "peerDependencies": {
         "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -3662,7 +3647,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -3734,7 +3718,6 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -4145,7 +4128,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4660,7 +4642,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5663,9 +5644,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -5773,7 +5754,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -6969,7 +6949,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.29.2"
       },
@@ -7581,7 +7560,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -7626,7 +7604,6 @@
       "integrity": "sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.0.1",
         "@asamuzakjp/dom-selector": "^7.0.3",
@@ -8568,7 +8545,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^5.0.0",
         "@mswjs/interceptors": "^0.41.2",
@@ -9196,7 +9172,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9389,7 +9364,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9735,7 +9709,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -9748,7 +9721,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -11405,7 +11377,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11554,7 +11525,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -12064,7 +12034,6 @@
       "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "2.1.9",
         "@vitest/mocker": "2.1.9",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   ],
   "devDependencies": {
     "@playwright/test": "^1.54.2",
-    "@rollup/rollup-linux-x64-gnu": "^4.60.2"
+    "@rollup/rollup-linux-x64-gnu": "^4.60.2",
+    "es-module-lexer": "^2.1.0"
   }
 }


### PR DESCRIPTION
Close #297 

## PR Description

### Summary
Add a dedicated backfill orchestration service for historical transaction ingestion with chunked execution, progress tracking, retry support, and resume capability.

### What changed
- Added `BackfillService` to manage job state, progress, and Redis-backed job metadata
- Added `BackfillQueue` for BullMQ orchestration and job processing
- Added backfill.job.ts to initialize the worker and handle chunk execution
- Added REST endpoints under `/api/v1/backfill`:
  - `POST /` to start a backfill job
  - `GET /` to list active jobs
  - `GET /:jobId` to inspect a job
  - `POST /:jobId/resume` to resume a failed/paused job
- Registered backfill routes in index.ts
- Registered the backfill worker startup in index.ts
- Added configuration defaults for backfill behavior to index.ts
- Updated .env.example with backfill settings
- Documented the new endpoint group in API.md
- Added unit tests for backfill orchestration behavior

### Testing
- Verified backfill service behavior with unit tests:
  - `npm exec --workspace=backend vitest run tests/services/backfill.service.test.ts`
- Result: **4 tests passed**
