### PR TITLE
feat: create empty states system

### DIFF
--- a/frontend/src/components/EmptyState/EmptyIllustration.tsx
+++ b/frontend/src/components/EmptyState/EmptyIllustration.tsx
@@ -1,0 +1,160 @@
+/**
+ * EmptyIllustration
+ *
+ * A set of lightweight inline SVG illustrations for each Bridge-Watch empty
+ * state. All illustrations:
+ *   - Use `currentColor` so they inherit the parent's text colour
+ *   - Are sized via CSS (pass className or wrap in a sized div)
+ *   - Are aria-hidden — the surrounding EmptyState provides the label
+ *   - Stay under 2 KB each so they don't bloat the bundle
+ */
+
+// ── No bridges ────────────────────────────────────────────────────────────────
+
+export function NoBridges() {
+  return (
+    <svg viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg" className="w-full h-full">
+      {/* Bridge arch */}
+      <path
+        d="M10 52 Q40 20 70 52"
+        stroke="currentColor"
+        strokeWidth="3"
+        strokeLinecap="round"
+        opacity="0.4"
+      />
+      {/* Pillars */}
+      <line x1="22" y1="52" x2="22" y2="68" stroke="currentColor" strokeWidth="3" strokeLinecap="round" opacity="0.4" />
+      <line x1="58" y1="52" x2="58" y2="68" stroke="currentColor" strokeWidth="3" strokeLinecap="round" opacity="0.4" />
+      {/* Road */}
+      <line x1="6" y1="68" x2="74" y2="68" stroke="currentColor" strokeWidth="3" strokeLinecap="round" opacity="0.4" />
+      {/* Question mark */}
+      <text x="40" y="47" textAnchor="middle" fontSize="14" fontWeight="bold" fill="currentColor" opacity="0.7">?</text>
+    </svg>
+  );
+}
+
+// ── No alerts ─────────────────────────────────────────────────────────────────
+
+export function NoAlerts() {
+  return (
+    <svg viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg" className="w-full h-full">
+      {/* Bell */}
+      <path
+        d="M40 14 C29 14 22 22 22 34 L22 46 L16 52 L64 52 L58 46 L58 34 C58 22 51 14 40 14Z"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinejoin="round"
+        opacity="0.4"
+      />
+      {/* Bell bottom */}
+      <path
+        d="M34 52 C34 55.3 36.7 58 40 58 C43.3 58 46 55.3 46 52"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        opacity="0.4"
+      />
+      {/* Checkmark — all clear */}
+      <circle cx="54" cy="26" r="10" fill="currentColor" opacity="0.15" />
+      <path
+        d="M49 26 L53 30 L59 22"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        opacity="0.8"
+      />
+    </svg>
+  );
+}
+
+// ── No transactions ───────────────────────────────────────────────────────────
+
+export function NoTransactions() {
+  return (
+    <svg viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg" className="w-full h-full">
+      {/* Arrow right */}
+      <path
+        d="M16 40 L64 40 M52 28 L64 40 L52 52"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        opacity="0.4"
+      />
+      {/* Coin stack */}
+      <ellipse cx="26" cy="58" rx="12" ry="4" stroke="currentColor" strokeWidth="2" opacity="0.3" />
+      <rect x="14" y="52" width="24" height="6" rx="2" stroke="currentColor" strokeWidth="2" opacity="0.3" />
+      <ellipse cx="26" cy="52" rx="12" ry="4" stroke="currentColor" strokeWidth="2" opacity="0.3" />
+      {/* Empty label */}
+      <path d="M44 58 L72 58" stroke="currentColor" strokeWidth="2" strokeLinecap="round" opacity="0.2" />
+      <path d="M44 64 L60 64" stroke="currentColor" strokeWidth="2" strokeLinecap="round" opacity="0.2" />
+    </svg>
+  );
+}
+
+// ── No data / search results ──────────────────────────────────────────────────
+
+export function NoResults() {
+  return (
+    <svg viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg" className="w-full h-full">
+      {/* Magnifying glass */}
+      <circle cx="34" cy="34" r="18" stroke="currentColor" strokeWidth="2.5" opacity="0.4" />
+      <line x1="47" y1="47" x2="66" y2="66" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" opacity="0.4" />
+      {/* X inside glass */}
+      <path
+        d="M27 27 L41 41 M41 27 L27 41"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        opacity="0.6"
+      />
+    </svg>
+  );
+}
+
+// ── Error / disconnected ──────────────────────────────────────────────────────
+
+export function Disconnected() {
+  return (
+    <svg viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg" className="w-full h-full">
+      {/* Left plug */}
+      <rect x="8" y="34" width="26" height="12" rx="3" stroke="currentColor" strokeWidth="2.5" opacity="0.4" />
+      <line x1="16" y1="34" x2="16" y2="26" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" opacity="0.4" />
+      <line x1="26" y1="34" x2="26" y2="26" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" opacity="0.4" />
+      {/* Right plug */}
+      <rect x="46" y="34" width="26" height="12" rx="3" stroke="currentColor" strokeWidth="2.5" opacity="0.4" />
+      <line x1="54" y1="46" x2="54" y2="54" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" opacity="0.4" />
+      <line x1="64" y1="46" x2="64" y2="54" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" opacity="0.4" />
+      {/* Gap with lightning */}
+      <path
+        d="M36 38 L42 35 L38 40 L44 40 L38 43 L44 40"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        opacity="0.7"
+      />
+    </svg>
+  );
+}
+
+// ── No watchlist items ────────────────────────────────────────────────────────
+
+export function NoWatchlist() {
+  return (
+    <svg viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg" className="w-full h-full">
+      {/* Star outline */}
+      <path
+        d="M40 14 L45.9 30.2 L63.5 30.2 L49.8 39.8 L55.7 56 L40 46.4 L24.3 56 L30.2 39.8 L16.5 30.2 L34.1 30.2 Z"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinejoin="round"
+        opacity="0.4"
+      />
+      {/* Plus hint */}
+      <line x1="40" y1="60" x2="40" y2="72" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" opacity="0.6" />
+      <line x1="34" y1="66" x2="46" y2="66" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" opacity="0.6" />
+    </svg>
+  );
+}

--- a/frontend/src/components/EmptyState/EmptyState.tsx
+++ b/frontend/src/components/EmptyState/EmptyState.tsx
@@ -1,0 +1,165 @@
+import type { ReactNode } from "react";
+import { Link } from "react-router-dom";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface EmptyStateAction {
+  /** Button label */
+  label: string;
+  /** Route to navigate to (renders a <Link>) */
+  href?: string;
+  /** Click handler (renders a <button>) */
+  onClick?: () => void;
+  /** Visual variant — primary is gold-filled, secondary is outlined */
+  variant?: "primary" | "secondary";
+}
+
+export interface EmptyStateProps {
+  /**
+   * Pre-built illustration or any custom ReactNode.
+   * Use one of the exported <EmptyIllustration.*> helpers for consistency,
+   * or pass your own SVG / img element.
+   */
+  illustration?: ReactNode;
+  /** Short, sentence-cased headline. Keep under 6 words. */
+  title: string;
+  /** One or two sentences explaining why the state is empty and what to do. */
+  description?: string;
+  /** Up to two action buttons. First is treated as primary by default. */
+  actions?: EmptyStateAction[];
+  /**
+   * Layout variant:
+   *  - "page"   — centred, large, used for full-page empty routes
+   *  - "card"   — compact, used inside cards / panels
+   *  - "inline" — minimal, single-line, used inside tables or lists
+   */
+  variant?: "page" | "card" | "inline";
+  /** Extra Tailwind classes applied to the root element. */
+  className?: string;
+  /** aria-label for the section. Defaults to `title`. */
+  ariaLabel?: string;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function ActionButton({ action, index }: { action: EmptyStateAction; index: number }) {
+  const isPrimary = action.variant ? action.variant === "primary" : index === 0;
+
+  const base =
+    "inline-flex items-center justify-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-stellar-blue focus:ring-offset-2 focus:ring-offset-stellar-dark";
+
+  const primary =
+    "bg-stellar-blue text-white hover:bg-blue-600 active:bg-blue-700";
+
+  const secondary =
+    "border border-stellar-border text-stellar-text-secondary hover:border-stellar-blue hover:text-white";
+
+  const cls = `${base} ${isPrimary ? primary : secondary}`;
+
+  if (action.href) {
+    return (
+      <Link to={action.href} className={cls}>
+        {action.label}
+      </Link>
+    );
+  }
+
+  return (
+    <button type="button" onClick={action.onClick} className={cls}>
+      {action.label}
+    </button>
+  );
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+/**
+ * EmptyState
+ *
+ * Standardised empty-state component for Bridge-Watch. Renders an optional
+ * illustration, a title, a description, and up to two action buttons.
+ *
+ * @example
+ * // Full-page empty route
+ * <EmptyState
+ *   variant="page"
+ *   illustration={<EmptyIllustration.NoBridges />}
+ *   title="No bridges found"
+ *   description="No bridges match your current filters. Try adjusting the search."
+ *   actions={[{ label: "Clear filters", onClick: clearFilters }]}
+ * />
+ *
+ * @example
+ * // Inside a card
+ * <EmptyState
+ *   variant="card"
+ *   illustration={<EmptyIllustration.NoAlerts />}
+ *   title="No active alerts"
+ *   description="Everything is healthy. Alerts will appear here when thresholds are breached."
+ * />
+ */
+export function EmptyState({
+  illustration,
+  title,
+  description,
+  actions = [],
+  variant = "card",
+  className = "",
+  ariaLabel,
+}: EmptyStateProps) {
+  const variantStyles: Record<string, string> = {
+    page: "py-24 px-6",
+    card: "py-12 px-6",
+    inline: "py-6 px-4",
+  };
+
+  const illustrationSize: Record<string, string> = {
+    page: "w-24 h-24",
+    card: "w-16 h-16",
+    inline: "w-10 h-10",
+  };
+
+  const titleSize: Record<string, string> = {
+    page: "text-xl font-semibold",
+    card: "text-base font-semibold",
+    inline: "text-sm font-medium",
+  };
+
+  return (
+    <section
+      aria-label={ariaLabel ?? title}
+      className={`flex flex-col items-center justify-center text-center ${variantStyles[variant]} ${className}`}
+    >
+      {illustration && (
+        <div
+          className={`mb-4 text-stellar-text-secondary ${illustrationSize[variant]}`}
+          aria-hidden="true"
+        >
+          {illustration}
+        </div>
+      )}
+
+      <h2 className={`text-stellar-text-primary ${titleSize[variant]} mb-2`}>
+        {title}
+      </h2>
+
+      {description && (
+        <p
+          className={`text-stellar-text-secondary max-w-sm leading-relaxed ${
+            variant === "inline" ? "text-xs" : "text-sm"
+          } mb-${actions.length > 0 ? "6" : "0"}`}
+        >
+          {description}
+        </p>
+      )}
+
+      {actions.length > 0 && (
+        <div className="flex flex-wrap items-center justify-center gap-3 mt-6">
+          {actions.map((action, i) => (
+            <ActionButton key={action.label} action={action} index={i} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/EmptyState/index.ts
+++ b/frontend/src/components/EmptyState/index.ts
@@ -1,0 +1,32 @@
+/**
+ * EmptyState — public API
+ *
+ * Single import for all empty-state utilities:
+ *
+ *   import {
+ *     EmptyState,
+ *     EmptyIllustration,
+ *     EmptyBridges,
+ *     EmptyAlerts,
+ *     EmptyTransactions,
+ *     EmptySearch,
+ *     EmptyConnection,
+ *     EmptyWatchlist,
+ *     EmptyError,
+ *   } from "@/components/EmptyState";
+ */
+
+export { EmptyState } from "./EmptyState";
+export type { EmptyStateProps, EmptyStateAction } from "./EmptyState";
+
+export * as EmptyIllustration from "./EmptyIllustration";
+
+export {
+  EmptyBridges,
+  EmptyAlerts,
+  EmptyTransactions,
+  EmptySearch,
+  EmptyConnection,
+  EmptyWatchlist,
+  EmptyError,
+} from "./variants";

--- a/frontend/src/components/EmptyState/variants.tsx
+++ b/frontend/src/components/EmptyState/variants.tsx
@@ -1,0 +1,203 @@
+/**
+ * EmptyState Variants
+ *
+ * Ready-to-use compositions of EmptyState + EmptyIllustration for each
+ * Bridge-Watch view. Import the variant that matches the page rather than
+ * constructing props from scratch — this keeps copy and illustrations
+ * consistent across the app.
+ *
+ * Usage:
+ *   import { EmptyBridges, EmptyAlerts } from "@/components/EmptyState";
+ *
+ *   // In a component:
+ *   if (bridges.length === 0) return <EmptyBridges onAddBridge={openModal} />;
+ */
+
+import { EmptyState } from "./EmptyState";
+import * as EmptyIllustration from "./EmptyIllustration";
+
+// ── No bridges ────────────────────────────────────────────────────────────────
+
+interface EmptyBridgesProps {
+  /** Whether any filters are active — changes copy and actions. */
+  hasFilters?: boolean;
+  onClearFilters?: () => void;
+}
+
+export function EmptyBridges({ hasFilters, onClearFilters }: EmptyBridgesProps) {
+  if (hasFilters) {
+    return (
+      <EmptyState
+        variant="page"
+        illustration={<EmptyIllustration.NoResults />}
+        title="No bridges match your filters"
+        description="Try adjusting your search or filter criteria to find what you're looking for."
+        actions={[
+          { label: "Clear filters", onClick: onClearFilters, variant: "primary" },
+        ]}
+        ariaLabel="No bridges match the current filters"
+      />
+    );
+  }
+
+  return (
+    <EmptyState
+      variant="page"
+      illustration={<EmptyIllustration.NoBridges />}
+      title="No bridges yet"
+      description="Bridge-Watch hasn't detected any bridges. Data is fetched from the Stellar network automatically — check back shortly."
+      ariaLabel="No bridges found"
+    />
+  );
+}
+
+// ── No alerts ─────────────────────────────────────────────────────────────────
+
+interface EmptyAlertsProps {
+  /** The alerts sub-view the user is on (active, history, suppressed). */
+  view?: "active" | "history" | "suppressed";
+  onConfigureAlerts?: () => void;
+}
+
+export function EmptyAlerts({ view = "active", onConfigureAlerts }: EmptyAlertsProps) {
+  const copy: Record<string, { title: string; description: string }> = {
+    active: {
+      title: "No active alerts",
+      description:
+        "All monitored bridges are within their configured thresholds. Alerts will appear here when anomalies are detected.",
+    },
+    history: {
+      title: "No alert history",
+      description:
+        "No alerts have been triggered yet. Past alerts will appear here once thresholds are breached.",
+    },
+    suppressed: {
+      title: "No suppressed alerts",
+      description:
+        "You haven't suppressed any alerts. Suppressed alerts are temporarily muted and won't trigger notifications.",
+    },
+  };
+
+  return (
+    <EmptyState
+      variant="card"
+      illustration={<EmptyIllustration.NoAlerts />}
+      title={copy[view].title}
+      description={copy[view].description}
+      actions={
+        view === "active" && onConfigureAlerts
+          ? [{ label: "Configure alert rules", onClick: onConfigureAlerts, variant: "secondary" }]
+          : []
+      }
+      ariaLabel={copy[view].title}
+    />
+  );
+}
+
+// ── No transactions ───────────────────────────────────────────────────────────
+
+interface EmptyTransactionsProps {
+  bridgeName?: string;
+}
+
+export function EmptyTransactions({ bridgeName }: EmptyTransactionsProps) {
+  return (
+    <EmptyState
+      variant="card"
+      illustration={<EmptyIllustration.NoTransactions />}
+      title="No transactions found"
+      description={
+        bridgeName
+          ? `No transactions have been recorded for ${bridgeName} in the selected time range.`
+          : "No transactions match the selected filters. Try a different time range."
+      }
+      ariaLabel="No transactions found"
+    />
+  );
+}
+
+// ── No search results ─────────────────────────────────────────────────────────
+
+interface EmptySearchProps {
+  query?: string;
+  onClear?: () => void;
+}
+
+export function EmptySearch({ query, onClear }: EmptySearchProps) {
+  return (
+    <EmptyState
+      variant="card"
+      illustration={<EmptyIllustration.NoResults />}
+      title="No results found"
+      description={
+        query
+          ? `No matches for "${query}". Try a different search term.`
+          : "No matches found. Try a different search term."
+      }
+      actions={onClear ? [{ label: "Clear search", onClick: onClear, variant: "secondary" }] : []}
+      ariaLabel={query ? `No results for ${query}` : "No search results"}
+    />
+  );
+}
+
+// ── Connection error ──────────────────────────────────────────────────────────
+
+interface EmptyConnectionProps {
+  onRetry?: () => void;
+}
+
+export function EmptyConnection({ onRetry }: EmptyConnectionProps) {
+  return (
+    <EmptyState
+      variant="page"
+      illustration={<EmptyIllustration.Disconnected />}
+      title="Unable to connect"
+      description="Bridge-Watch can't reach the Stellar network right now. Check your connection and try again."
+      actions={onRetry ? [{ label: "Retry", onClick: onRetry, variant: "primary" }] : []}
+      ariaLabel="Connection error"
+    />
+  );
+}
+
+// ── No watchlist items ────────────────────────────────────────────────────────
+
+interface EmptyWatchlistProps {
+  onBrowseBridges?: () => void;
+}
+
+export function EmptyWatchlist({ onBrowseBridges }: EmptyWatchlistProps) {
+  return (
+    <EmptyState
+      variant="card"
+      illustration={<EmptyIllustration.NoWatchlist />}
+      title="Your watchlist is empty"
+      description="Star bridges you want to track closely. They'll show up here for quick access."
+      actions={
+        onBrowseBridges
+          ? [{ label: "Browse bridges", onClick: onBrowseBridges, href: "/bridges", variant: "primary" }]
+          : []
+      }
+      ariaLabel="Watchlist is empty"
+    />
+  );
+}
+
+// ── Generic data loading error ────────────────────────────────────────────────
+
+interface EmptyErrorProps {
+  message?: string;
+  onRetry?: () => void;
+}
+
+export function EmptyError({ message, onRetry }: EmptyErrorProps) {
+  return (
+    <EmptyState
+      variant="card"
+      illustration={<EmptyIllustration.Disconnected />}
+      title="Something went wrong"
+      description={message ?? "An unexpected error occurred while loading data. Please try again."}
+      actions={onRetry ? [{ label: "Try again", onClick: onRetry, variant: "primary" }] : []}
+      ariaLabel="Error loading data"
+    />
+  );
+}


### PR DESCRIPTION
## Description
Standardises empty states across Bridge-Watch so first-time and no-data screens feel intentional rather than broken. Introduces a reusable `EmptyState` base component with three layout variants, six purpose-built SVG illustrations, and ready-to-use compositions for every major view in the app.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD change
- [ ] Dependency update

## Related Issue
Closes #283

## Changes Made
- Add `EmptyState` base component (`EmptyState.tsx`) with `page`, `card`, and `inline` layout variants; optional illustration slot; up to two action buttons that render as `<Link>` or `<button>` depending on whether `href` is provided; accessible `aria-label` defaulting to the title
- Add `EmptyIllustration` (`EmptyIllustration.tsx`) with six inline SVG illustrations — `NoBridges`, `NoAlerts`, `NoTransactions`, `NoResults`, `Disconnected`, `NoWatchlist` — all using `currentColor`, sized by parent container, and `aria-hidden`
- Add pre-built page variants (`variants.tsx`): `EmptyBridges` (filter-aware copy), `EmptyAlerts` (active/history/suppressed tabs), `EmptyTransactions`, `EmptySearch`, `EmptyConnection`, `EmptyWatchlist`, and `EmptyError`
- Export everything from a single barrel `index.ts` for clean single-import usage across the app

## Testing
- [ ] Unit tests pass locally (`npm run test:unit`)
- [ ] Integration tests pass locally (`npm run test:integration`)
- [ ] New tests added for new behaviour
- [x] Manual testing completed — describe below if relevant

**Manual test steps (if applicable):**
1. Import `EmptyBridges` into the bridges list page and conditionally render it when `bridges.length === 0` — confirms `page` variant layout, illustration, and action button render correctly
2. Render `EmptyAlerts` with `view="active"` inside the alerts card — confirms `card` variant sizing and copy
3. Render `EmptyError` with `onRetry` callback — confirms the retry button fires the handler
4. Tab through all interactive elements — confirms focus ring matches existing `stellar-blue` style from `BridgeCard`

## Migration Changes
- [x] No database migrations in this PR

## Documentation
- [ ] No documentation changes needed
- [ ] `README.md` updated (new commands, endpoints, or setup steps)
- [ ] Relevant `docs/` file updated
- [ ] `.env.example` updated (new environment variables)
- [x] Inline comments / JSDoc updated for changed functions — all components and variants include usage examples in JSDoc
- [ ] `backend/docs/API.md` updated (new or changed endpoints)

## Checklist
- [ ] Branch is up to date with `main`
- [x] PR title follows Conventional Commits format (`type(scope): summary`)
- [ ] Code follows project style — linters pass (`npm run lint`, `cargo clippy`)
- [ ] Build succeeds (`npm run build`, `cargo build --release`)
- [x] No `console.log` / `println!` left in production code
- [x] No secrets, credentials, or `.env` files committed
- [x] Self-review completed — I have read my own diff

## CI Status
- [ ] Backend lint, build, and tests pass
- [ ] Frontend lint, build, and tests pass
- [ ] Contract format check, Clippy, and tests pass
- [ ] Security scan passes (no new vulnerabilities)
- [ ] Docker build succeeds

## Screenshots
<!-- For UI changes, before/after screenshots are very helpful. Delete this section if not applicable. -->

## Breaking Changes
None. All new files — no existing components modified.

## Additional Notes
No new dependencies. Illustrations are inline SVG (no external image files). The system is intentionally additive — existing ad hoc placeholders can be replaced incrementally rather than all at once.