### PR TITLE
feat: build notifications drawer

### DIFF
--- a/frontend/src/components/Navbar.test.tsx
+++ b/frontend/src/components/Navbar.test.tsx
@@ -1,44 +1,62 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { NotificationProvider } from "../context/NotificationContext";
-import { WebSocketProvider } from "../contexts/WebSocketContext";
-import ThemeProvider from "../theme/ThemeProvider";
+import { WatchlistProvider } from "../hooks/useWatchlist";
 import Navbar from "./Navbar";
+import { useNotificationStore } from "../stores/notificationStore";
 
-const queryClient = new QueryClient({
-  defaultOptions: { queries: { retry: false } },
-});
+function resetNotifications() {
+  useNotificationStore.setState(useNotificationStore.getInitialState(), true);
+}
 
 describe("Navbar", () => {
-  it("opens and closes the mobile navigation drawer", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    resetNotifications();
+  });
+
+  it("opens notifications drawer and keeps trigger ARIA state in sync", () => {
+    useNotificationStore.getState().addNotification({
+      id: "n1",
+      type: "info",
+      priority: "medium",
+      title: "One",
+      message: "One",
+      timestamp: 1,
+    });
+
     render(
       <MemoryRouter>
-        <QueryClientProvider client={queryClient}>
-          <ThemeProvider>
-            <WebSocketProvider>
-              <NotificationProvider>
-                <Navbar />
-              </NotificationProvider>
-            </WebSocketProvider>
-          </ThemeProvider>
-        </QueryClientProvider>
+        <WatchlistProvider>
+          <Navbar />
+        </WatchlistProvider>
       </MemoryRouter>
     );
 
-    const openButton = screen.getByRole("button", {
-      name: /open navigation menu/i,
-    });
+    const trigger = screen.getByRole("button", { name: /open notifications/i });
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(trigger).toHaveAttribute("aria-controls", "notifications-drawer");
+    expect(screen.getByText("1")).toBeInTheDocument();
 
-    fireEvent.click(openButton);
-    expect(
-      screen.getByRole("dialog", { name: /mobile navigation/i })
-    ).toBeInTheDocument();
-    expect(screen.getByText(/control surface/i)).toBeInTheDocument();
+    fireEvent.click(trigger);
+    expect(screen.getByRole("dialog", { name: "Notifications" })).toBeInTheDocument();
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+  });
 
-    fireEvent.click(screen.getByRole("button", { name: /close mobile menu/i }));
-    expect(
-      screen.getByRole("button", { name: /open navigation menu/i })
-    ).toBeInTheDocument();
+  it("closes on Escape and restores focus to trigger", () => {
+    render(
+      <MemoryRouter>
+        <WatchlistProvider>
+          <Navbar />
+        </WatchlistProvider>
+      </MemoryRouter>
+    );
+
+    const trigger = screen.getByRole("button", { name: /open notifications/i });
+    fireEvent.click(trigger);
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(screen.queryByRole("dialog", { name: "Notifications" })).not.toBeInTheDocument();
+    expect(document.activeElement).toBe(trigger);
   });
 });

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,5 +1,10 @@
+import { useEffect, useRef, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { useWatchlist } from "../hooks/useWatchlist";
+import NotificationsDrawer from "./NotificationsDrawer";
+import UnreadCountBadge from "./UnreadCountBadge";
+import { useNotificationLiveUpdates } from "../hooks/useNotificationLiveUpdates";
+import { selectUnreadCount, useNotificationStore } from "../stores/notificationStore";
 
 const navLinks = [
   { to: "/", label: "Dashboard" },
@@ -11,49 +16,108 @@ const navLinks = [
 export default function Navbar() {
   const location = useLocation();
   const { activeSymbols } = useWatchlist();
+  const [isNotificationsOpen, setIsNotificationsOpen] = useState(false);
+  const notificationTriggerRef = useRef<HTMLButtonElement | null>(null);
+  const previousDrawerOpen = useRef(false);
+  const unreadCount = useNotificationStore(selectUnreadCount);
+
+  useNotificationLiveUpdates();
+
+  useEffect(() => {
+    if (previousDrawerOpen.current && !isNotificationsOpen) {
+      notificationTriggerRef.current?.focus();
+    }
+    previousDrawerOpen.current = isNotificationsOpen;
+  }, [isNotificationsOpen]);
 
   return (
-    <nav className="border-b border-stellar-border bg-stellar-card">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="flex items-center justify-between h-16">
-          <div className="flex items-center space-x-8">
-            <Link to="/" className="text-xl font-bold text-white">
-              Bridge Watch
-            </Link>
-            <div className="hidden md:flex space-x-4">
-              {navLinks.map((link) => (
-                <Link
-                  key={link.to}
-                  to={link.to}
-                  className={`px-3 py-2 rounded-md text-sm font-medium transition-colors ${
-                    location.pathname === link.to
-                      ? "bg-stellar-blue text-white"
-                      : "text-stellar-text-secondary hover:text-white"
-                  }`}
-                >
-                  {link.label}
-                </Link>
-              ))}
+    <>
+      <nav className="border-b border-stellar-border bg-stellar-card">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex items-center justify-between h-16 gap-3">
+            <div className="flex items-center space-x-8 min-w-0">
+              <Link to="/" className="text-xl font-bold text-white shrink-0">
+                Bridge Watch
+              </Link>
+              <div className="hidden md:flex space-x-4">
+                {navLinks.map((link) => (
+                  <Link
+                    key={link.to}
+                    to={link.to}
+                    className={`px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+                      location.pathname === link.to
+                        ? "bg-stellar-blue text-white"
+                        : "text-stellar-text-secondary hover:text-white"
+                    }`}
+                  >
+                    {link.label}
+                  </Link>
+                ))}
+              </div>
+            </div>
+
+            <div className="flex items-center gap-3">
+              <div className="hidden lg:flex items-center gap-2 text-xs text-stellar-text-secondary">
+                <span>Quick:</span>
+                {activeSymbols.length === 0 ? (
+                  <span>No watchlist assets</span>
+                ) : (
+                  activeSymbols.slice(0, 3).map((symbol) => (
+                    <Link
+                      key={symbol}
+                      to={`/assets/${symbol}`}
+                      className="rounded border border-stellar-border px-2 py-1 hover:text-white"
+                    >
+                      {symbol}
+                    </Link>
+                  ))
+                )}
+              </div>
+
+              {/*
+                ARIA contract:
+                - aria-expanded mirrors drawer open state.
+                - aria-controls points to the drawer dialog id.
+                Keyboard contract:
+                - Enter/Space toggles drawer.
+                - Escape closes drawer (handled in drawer) and focus returns here.
+              */}
+              <button
+                ref={notificationTriggerRef}
+                type="button"
+                onClick={() => setIsNotificationsOpen((open) => !open)}
+                className={`relative rounded-full p-2 transition-colors focus:outline-none focus:ring-2 focus:ring-stellar-blue ${
+                  isNotificationsOpen
+                    ? "bg-stellar-blue/20 text-white"
+                    : "text-stellar-text-secondary hover:text-white"
+                }`}
+                aria-label={
+                  isNotificationsOpen
+                    ? "Close notifications"
+                    : `Open notifications (${unreadCount} unread)`
+                }
+                aria-expanded={isNotificationsOpen}
+                aria-controls="notifications-drawer"
+              >
+                <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
+                  />
+                </svg>
+                <UnreadCountBadge unreadCount={unreadCount} />
+              </button>
             </div>
           </div>
-          <div className="hidden lg:flex items-center gap-2 text-xs text-stellar-text-secondary">
-            <span>Quick:</span>
-            {activeSymbols.length === 0 ? (
-              <span>No watchlist assets</span>
-            ) : (
-              activeSymbols.slice(0, 3).map((symbol) => (
-                <Link
-                  key={symbol}
-                  to={`/assets/${symbol}`}
-                  className="rounded border border-stellar-border px-2 py-1 hover:text-white"
-                >
-                  {symbol}
-                </Link>
-              ))
-            )}
-          </div>
         </div>
-      </div>
-    </nav>
+      </nav>
+      <NotificationsDrawer
+        open={isNotificationsOpen}
+        drawerId="notifications-drawer"
+        onClose={() => setIsNotificationsOpen(false)}
+      />
+    </>
   );
 }

--- a/frontend/src/components/NotificationsDrawer.test.tsx
+++ b/frontend/src/components/NotificationsDrawer.test.tsx
@@ -1,0 +1,164 @@
+import { axe } from "vitest-axe";
+import { fireEvent, render, screen } from "@testing-library/react";
+import NotificationsDrawer from "./NotificationsDrawer";
+import { useNotificationStore } from "../stores/notificationStore";
+
+function resetNotifications() {
+  useNotificationStore.setState(useNotificationStore.getInitialState(), true);
+}
+
+function seedNotifications() {
+  const store = useNotificationStore.getState();
+  store.addNotification({
+    id: "critical-1",
+    type: "system",
+    priority: "critical",
+    title: "Critical issue",
+    message: "Critical body",
+    timestamp: 3,
+  });
+  store.addNotification({
+    id: "high-1",
+    type: "system",
+    priority: "high",
+    title: "High issue",
+    message: "High body",
+    timestamp: 2,
+  });
+  store.addNotification({
+    id: "low-1",
+    type: "info",
+    priority: "low",
+    title: "Low issue",
+    message: "Low body",
+    timestamp: 1,
+  });
+}
+
+describe("NotificationsDrawer", () => {
+  beforeEach(() => {
+    resetNotifications();
+    localStorage.clear();
+  });
+
+  it("opens and closes", () => {
+    const onClose = vi.fn();
+    const { rerender } = render(
+      <NotificationsDrawer open={false} drawerId="notifications-drawer" onClose={onClose} />
+    );
+
+    expect(screen.queryByRole("dialog", { name: "Notifications" })).not.toBeInTheDocument();
+
+    rerender(<NotificationsDrawer open drawerId="notifications-drawer" onClose={onClose} />);
+    expect(screen.getByRole("dialog", { name: "Notifications" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Close notifications" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes on Escape", () => {
+    const onClose = vi.fn();
+    render(<NotificationsDrawer open drawerId="notifications-drawer" onClose={onClose} />);
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("traps focus with Tab navigation", () => {
+    seedNotifications();
+    render(<NotificationsDrawer open drawerId="notifications-drawer" onClose={vi.fn()} />);
+
+    const closeButton = screen.getByRole("button", { name: "Close notifications" });
+    const clearReadButton = screen.getByRole("button", { name: "Clear read" });
+    clearReadButton.focus();
+
+    fireEvent.keyDown(document, { key: "Tab" });
+    expect(document.activeElement).toBe(closeButton);
+  });
+
+  it("renders severity groups and omits empty ones", () => {
+    seedNotifications();
+
+    render(<NotificationsDrawer open drawerId="notifications-drawer" onClose={vi.fn()} />);
+
+    expect(screen.getByLabelText("Critical notifications")).toBeInTheDocument();
+    expect(screen.getByLabelText("High notifications")).toBeInTheDocument();
+    expect(screen.getByLabelText("Low notifications")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Medium notifications")).not.toBeInTheDocument();
+  });
+
+  it("marks a single notification as read", () => {
+    seedNotifications();
+
+    render(<NotificationsDrawer open drawerId="notifications-drawer" onClose={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /mark critical issue as read/i }));
+
+    const updated = useNotificationStore
+      .getState()
+      .notifications.find((notification) => notification.id === "critical-1");
+
+    expect(updated?.read).toBe(true);
+  });
+
+  it("marks all as read and disables the action", () => {
+    seedNotifications();
+
+    render(<NotificationsDrawer open drawerId="notifications-drawer" onClose={vi.fn()} />);
+
+    const markAll = screen.getByRole("button", { name: "Mark all as read" });
+    fireEvent.click(markAll);
+
+    expect(useNotificationStore.getState().unreadCount).toBe(0);
+    expect(markAll).toBeDisabled();
+  });
+
+  it("clears read notifications and disables clear button when none exist", () => {
+    seedNotifications();
+    useNotificationStore.getState().markAsRead("critical-1");
+
+    render(<NotificationsDrawer open drawerId="notifications-drawer" onClose={vi.fn()} />);
+
+    const clearRead = screen.getByRole("button", { name: "Clear read" });
+    fireEvent.click(clearRead);
+
+    expect(
+      useNotificationStore.getState().notifications.some((notification) => notification.id === "critical-1")
+    ).toBe(false);
+    expect(clearRead).toBeDisabled();
+  });
+
+  it("renders new notifications while open and announces updates", () => {
+    render(<NotificationsDrawer open drawerId="notifications-drawer" onClose={vi.fn()} />);
+
+    useNotificationStore.getState().addNotification({
+      id: "live-1",
+      type: "system",
+      priority: "high",
+      title: "Live event",
+      message: "Live body",
+      timestamp: 100,
+    });
+
+    expect(screen.getByText("Live event")).toBeInTheDocument();
+    expect(screen.getAllByRole("status")[0]).toHaveTextContent(/new high notification/i);
+  });
+
+  it("exposes dialog aria attributes", () => {
+    render(<NotificationsDrawer open drawerId="notifications-drawer" onClose={vi.fn()} />);
+
+    const dialog = screen.getByRole("dialog", { name: "Notifications" });
+    expect(dialog).toHaveAttribute("id", "notifications-drawer");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+  });
+
+  it("has no accessibility violations when open", async () => {
+    seedNotifications();
+    const { container } = render(
+      <NotificationsDrawer open drawerId="notifications-drawer" onClose={vi.fn()} />
+    );
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/frontend/src/components/NotificationsDrawer.tsx
+++ b/frontend/src/components/NotificationsDrawer.tsx
@@ -1,0 +1,314 @@
+import { useEffect, useMemo, useRef } from "react";
+import {
+  NOTIFICATION_PRIORITY_ORDER,
+  selectNotificationsGroupedByPriority,
+  useNotificationStore,
+  type Notification,
+  type NotificationPriority,
+} from "../stores/notificationStore";
+
+interface NotificationsDrawerProps {
+  open: boolean;
+  drawerId: string;
+  onClose: () => void;
+}
+
+const FOCUSABLE_SELECTOR =
+  'button,[href],input,select,textarea,[tabindex]:not([tabindex="-1"])';
+
+const priorityLabelMap: Record<NotificationPriority, string> = {
+  critical: "Critical",
+  high: "High",
+  medium: "Medium",
+  low: "Low",
+};
+
+const priorityTextColorMap: Record<NotificationPriority, string> = {
+  critical: "text-red-400",
+  high: "text-orange-400",
+  medium: "text-blue-400",
+  low: "text-stellar-text-secondary",
+};
+
+const priorityDotColorMap: Record<NotificationPriority, string> = {
+  critical: "bg-red-500",
+  high: "bg-orange-500",
+  medium: "bg-blue-500",
+  low: "bg-stellar-border",
+};
+
+const formatNotificationTime = (timestamp: number) =>
+  new Date(timestamp).toLocaleString("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+
+/**
+ * Renders the notifications drawer and provides keyboard/focus interactions
+ * consistent with the existing mobile drawer patterns in this codebase.
+ */
+export default function NotificationsDrawer({
+  open,
+  drawerId,
+  onClose,
+}: NotificationsDrawerProps) {
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const liveRegionRef = useRef<HTMLParagraphElement | null>(null);
+  const previousTopNotificationIdRef = useRef<string | null>(null);
+
+  const groupedNotifications = useNotificationStore(selectNotificationsGroupedByPriority);
+  const markAsRead = useNotificationStore((state) => state.markAsRead);
+  const markAllAsRead = useNotificationStore((state) => state.markAllAsRead);
+  const clearReadNotifications = useNotificationStore(
+    (state) => state.clearReadNotifications
+  );
+
+  const allNotifications = useMemo(
+    () => NOTIFICATION_PRIORITY_ORDER.flatMap((priority) => groupedNotifications[priority]),
+    [groupedNotifications]
+  );
+
+  const unreadCount = allNotifications.filter((notification) => !notification.read).length;
+  const hasReadNotifications = allNotifications.some((notification) => notification.read);
+  const hasAnyNotifications = allNotifications.length > 0;
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    window.setTimeout(() => {
+      const firstFocusable = panelRef.current?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
+      firstFocusable?.focus();
+    }, 0);
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (!panelRef.current) {
+        return;
+      }
+
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+
+      if (event.key === "Tab") {
+        const focusable = Array.from(
+          panelRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+        ).filter((element) => !element.hasAttribute("disabled"));
+
+        if (!focusable.length) {
+          return;
+        }
+
+        const currentIndex = focusable.indexOf(document.activeElement as HTMLElement);
+        const nextIndex = event.shiftKey
+          ? currentIndex <= 0
+            ? focusable.length - 1
+            : currentIndex - 1
+          : currentIndex === focusable.length - 1
+            ? 0
+            : currentIndex + 1;
+
+        if (currentIndex !== -1) {
+          event.preventDefault();
+          focusable[nextIndex]?.focus();
+        }
+      }
+
+      if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+        const navigationButtons = Array.from(
+          panelRef.current.querySelectorAll<HTMLButtonElement>(
+            "[data-notification-item-action='mark-as-read']"
+          )
+        ).filter((button) => !button.disabled);
+
+        if (!navigationButtons.length) {
+          return;
+        }
+
+        const currentIndex = navigationButtons.indexOf(
+          document.activeElement as HTMLButtonElement
+        );
+
+        if (currentIndex === -1) {
+          return;
+        }
+
+        event.preventDefault();
+
+        const nextIndex =
+          event.key === "ArrowDown"
+            ? (currentIndex + 1) % navigationButtons.length
+            : (currentIndex - 1 + navigationButtons.length) % navigationButtons.length;
+
+        navigationButtons[nextIndex]?.focus();
+      }
+    };
+
+    document.addEventListener("keydown", onKeyDown);
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open, onClose]);
+
+  useEffect(() => {
+    if (!open || !allNotifications.length || !liveRegionRef.current) {
+      return;
+    }
+
+    const topNotification = allNotifications[0];
+    if (topNotification.id !== previousTopNotificationIdRef.current) {
+      liveRegionRef.current.textContent = `New ${topNotification.priority} notification: ${topNotification.title}`;
+      previousTopNotificationIdRef.current = topNotification.id;
+    }
+  }, [allNotifications, open]);
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50" aria-hidden={!open}>
+      <button
+        type="button"
+        aria-label="Close notifications drawer"
+        onClick={onClose}
+        className="absolute inset-0 bg-slate-950/70 backdrop-blur-sm"
+      />
+
+      <div
+        id={drawerId}
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Notifications"
+        className="absolute right-0 top-0 flex h-full w-full flex-col border-l border-stellar-border bg-stellar-dark/95 shadow-2xl shadow-black/40 transition-transform duration-300 sm:w-[24rem]"
+      >
+        <div className="border-b border-stellar-border bg-stellar-card/80 px-4 py-4">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <h2 className="text-lg font-semibold text-stellar-text-primary">Notifications</h2>
+              <p className="text-sm text-stellar-text-secondary">{unreadCount} unread</p>
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-md px-2 py-1 text-sm text-stellar-text-secondary transition hover:text-stellar-text-primary focus:outline-none focus:ring-2 focus:ring-stellar-blue"
+              aria-label="Close notifications"
+            >
+              ✕
+            </button>
+          </div>
+          <div className="mt-3 flex items-center gap-2">
+            <button
+              type="button"
+              onClick={markAllAsRead}
+              disabled={unreadCount === 0}
+              className="rounded-md border border-stellar-border px-3 py-1.5 text-xs font-medium text-stellar-text-primary transition hover:border-stellar-blue disabled:cursor-not-allowed disabled:opacity-40 focus:outline-none focus:ring-2 focus:ring-stellar-blue"
+            >
+              Mark all as read
+            </button>
+            <button
+              type="button"
+              onClick={clearReadNotifications}
+              disabled={!hasReadNotifications}
+              className="rounded-md border border-stellar-border px-3 py-1.5 text-xs font-medium text-stellar-text-primary transition hover:border-stellar-blue disabled:cursor-not-allowed disabled:opacity-40 focus:outline-none focus:ring-2 focus:ring-stellar-blue"
+            >
+              Clear read
+            </button>
+          </div>
+        </div>
+
+        <p ref={liveRegionRef} className="sr-only" role="status" aria-live="polite" aria-atomic="true" />
+
+        <div className="flex-1 overflow-y-auto p-4">
+          {!hasAnyNotifications && (
+            <p className="rounded-lg border border-stellar-border bg-stellar-card/60 p-4 text-sm text-stellar-text-secondary">
+              You have no notifications.
+            </p>
+          )}
+
+          <div className="space-y-4">
+            {NOTIFICATION_PRIORITY_ORDER.map((priority) => {
+              const notificationsForPriority = groupedNotifications[priority];
+              if (!notificationsForPriority.length) {
+                return null;
+              }
+
+              return (
+                <section key={priority} aria-label={`${priorityLabelMap[priority]} notifications`}>
+                  <h3
+                    className={`mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.15em] ${priorityTextColorMap[priority]}`}
+                  >
+                    <span
+                      className={`inline-block h-2 w-2 rounded-full ${priorityDotColorMap[priority]}`}
+                      aria-hidden="true"
+                    />
+                    {priorityLabelMap[priority]}
+                  </h3>
+                  <ul className="space-y-2" role="list">
+                    {notificationsForPriority
+                      .slice()
+                      .sort((a, b) => b.timestamp - a.timestamp)
+                      .map((notification) => (
+                        <NotificationRow
+                          key={notification.id}
+                          notification={notification}
+                          onMarkAsRead={markAsRead}
+                        />
+                      ))}
+                  </ul>
+                </section>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface NotificationRowProps {
+  notification: Notification;
+  onMarkAsRead: (id: string) => void;
+}
+
+function NotificationRow({ notification, onMarkAsRead }: NotificationRowProps) {
+  return (
+    <li
+      className={`rounded-xl border p-3 ${
+        notification.read
+          ? "border-stellar-border bg-stellar-card/50"
+          : "border-stellar-blue/40 bg-stellar-blue/10"
+      }`}
+      role="listitem"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-medium text-stellar-text-primary">{notification.title}</p>
+          <p className="mt-1 text-sm text-stellar-text-secondary">{notification.message}</p>
+          <p className="mt-2 text-xs text-stellar-text-secondary">
+            {formatNotificationTime(notification.timestamp)}
+          </p>
+        </div>
+        <button
+          type="button"
+          data-notification-item-action="mark-as-read"
+          onClick={() => onMarkAsRead(notification.id)}
+          disabled={notification.read}
+          className="rounded-md border border-stellar-border px-2 py-1 text-xs font-medium text-stellar-text-primary transition hover:border-stellar-blue disabled:cursor-not-allowed disabled:opacity-40 focus:outline-none focus:ring-2 focus:ring-stellar-blue"
+          aria-label={`Mark ${notification.title} as read`}
+        >
+          Mark as read
+        </button>
+      </div>
+    </li>
+  );
+}

--- a/frontend/src/components/UnreadCountBadge.test.tsx
+++ b/frontend/src/components/UnreadCountBadge.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import UnreadCountBadge from "./UnreadCountBadge";
+
+describe("UnreadCountBadge", () => {
+  it("renders count when non-zero", () => {
+    render(<UnreadCountBadge unreadCount={5} />);
+
+    expect(screen.getByText("5")).toBeInTheDocument();
+  });
+
+  it("is hidden when count is zero", () => {
+    const { container } = render(<UnreadCountBadge unreadCount={0} />);
+
+    expect(container.querySelector(".bg-red-500")).not.toBeInTheDocument();
+  });
+
+  it("truncates count above threshold", () => {
+    render(<UnreadCountBadge unreadCount={25} maxVisibleCount={9} />);
+
+    expect(screen.getByText("9+")).toBeInTheDocument();
+  });
+
+  it("announces count changes via aria-live", () => {
+    const { rerender } = render(<UnreadCountBadge unreadCount={0} />);
+    expect(screen.getByRole("status")).toHaveTextContent("No unread notifications");
+
+    rerender(<UnreadCountBadge unreadCount={1} />);
+    expect(screen.getByRole("status")).toHaveTextContent("1 unread notifications");
+  });
+});

--- a/frontend/src/components/UnreadCountBadge.tsx
+++ b/frontend/src/components/UnreadCountBadge.tsx
@@ -1,0 +1,31 @@
+interface UnreadCountBadgeProps {
+  unreadCount: number;
+  maxVisibleCount?: number;
+}
+
+export default function UnreadCountBadge({
+  unreadCount,
+  maxVisibleCount = 9,
+}: UnreadCountBadgeProps) {
+  const visibleLabel = unreadCount > maxVisibleCount ? `${maxVisibleCount}+` : String(unreadCount);
+  const announcement =
+    unreadCount === 0
+      ? "No unread notifications"
+      : `${unreadCount} unread notifications`;
+
+  return (
+    <>
+      <span className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+        {announcement}
+      </span>
+      {unreadCount > 0 && (
+        <span
+          className="absolute top-1.5 right-1.5 block h-4 min-w-4 px-1 rounded-full bg-red-500 text-[10px] font-bold text-white border-2 border-stellar-card leading-none flex items-center justify-center"
+          aria-hidden="true"
+        >
+          {visibleLabel}
+        </span>
+      )}
+    </>
+  );
+}

--- a/frontend/src/hooks/useNotificationLiveUpdates.test.tsx
+++ b/frontend/src/hooks/useNotificationLiveUpdates.test.tsx
@@ -1,0 +1,53 @@
+import { render } from "@testing-library/react";
+import { useNotificationStore } from "../stores/notificationStore";
+import { useNotificationLiveUpdates } from "./useNotificationLiveUpdates";
+
+const subscribeSpy = vi.fn();
+
+vi.mock("./useWebSocketEnhanced", () => ({
+  useWebSocket: (channel: string, handler: (payload: unknown) => void) => {
+    subscribeSpy(channel, handler);
+    return {
+      send: vi.fn(),
+      isConnected: true,
+      isSubscribed: true,
+    };
+  },
+}));
+
+function TestHarness() {
+  useNotificationLiveUpdates();
+  return null;
+}
+
+describe("useNotificationLiveUpdates", () => {
+  beforeEach(() => {
+    subscribeSpy.mockClear();
+    useNotificationStore.setState(useNotificationStore.getInitialState(), true);
+  });
+
+  it("subscribes to notifications channel and stores incoming events", () => {
+    render(<TestHarness />);
+
+    expect(subscribeSpy).toHaveBeenCalledTimes(1);
+    expect(subscribeSpy.mock.calls[0]?.[0]).toBe("notifications");
+
+    const handler = subscribeSpy.mock.calls[0]?.[1] as (payload: unknown) => void;
+
+    handler({
+      type: "notification",
+      data: {
+        id: "live-hook-1",
+        title: "Live Hook",
+        message: "Received from socket",
+        priority: "high",
+      },
+    });
+
+    const notification = useNotificationStore
+      .getState()
+      .notifications.find((entry) => entry.id === "live-hook-1");
+    expect(notification).toBeDefined();
+    expect(notification?.priority).toBe("high");
+  });
+});

--- a/frontend/src/hooks/useNotificationLiveUpdates.ts
+++ b/frontend/src/hooks/useNotificationLiveUpdates.ts
@@ -1,0 +1,86 @@
+import { useCallback } from "react";
+import { useWebSocket } from "./useWebSocketEnhanced";
+import { useNotificationStore, type NotificationPriority, type NotificationType } from "../stores/notificationStore";
+
+interface NotificationEventPayload {
+  id?: string;
+  title: string;
+  message: string;
+  priority?: NotificationPriority;
+  severity?: "critical" | "warning" | "info";
+  notificationType?: NotificationType;
+  assetCode?: string;
+  bridgeId?: string;
+  actionUrl?: string;
+  actionLabel?: string;
+  timestamp?: number;
+}
+
+interface RawNotificationEvent {
+  type?: string;
+  channel?: string;
+  data?: NotificationEventPayload;
+}
+
+const severityToPriority: Record<"critical" | "warning" | "info", NotificationPriority> = {
+  critical: "critical",
+  warning: "high",
+  info: "medium",
+};
+
+const fallbackTypeByPriority: Record<NotificationPriority, NotificationType> = {
+  critical: "system",
+  high: "system",
+  medium: "info",
+  low: "info",
+};
+
+/**
+ * Subscribes to the app's existing notifications channel and forwards incoming
+ * notification events into the Zustand notification store.
+ *
+ * Notification lifecycle:
+ * 1) Events arrive from the notifications channel.
+ * 2) Payloads are normalized to the store's notification schema.
+ * 3) Notifications are inserted and grouped by priority in the drawer selector.
+ * 4) Read state is managed by store actions and persisted by identifier.
+ * 5) Read notifications can be bulk-cleared from the active list.
+ */
+export function useNotificationLiveUpdates() {
+  const addNotification = useNotificationStore((state) => state.addNotification);
+
+  const handleIncomingMessage = useCallback(
+    (payload: unknown) => {
+      const event = payload as RawNotificationEvent;
+      const eventPayload = event.data;
+
+      if ((event.type !== "notification" && event.channel !== "notifications") || !eventPayload) {
+        return;
+      }
+
+      if (!eventPayload.title || !eventPayload.message) {
+        return;
+      }
+
+      const derivedPriority =
+        eventPayload.priority ??
+        (eventPayload.severity ? severityToPriority[eventPayload.severity] : "medium");
+
+      addNotification({
+        id: eventPayload.id,
+        type: eventPayload.notificationType ?? fallbackTypeByPriority[derivedPriority],
+        priority: derivedPriority,
+        title: eventPayload.title,
+        message: eventPayload.message,
+        assetCode: eventPayload.assetCode,
+        bridgeId: eventPayload.bridgeId,
+        actionUrl: eventPayload.actionUrl,
+        actionLabel: eventPayload.actionLabel,
+        timestamp: eventPayload.timestamp,
+      });
+    },
+    [addNotification]
+  );
+
+  useWebSocket("notifications", handleIncomingMessage);
+}

--- a/frontend/src/stores/notificationStore.test.ts
+++ b/frontend/src/stores/notificationStore.test.ts
@@ -1,0 +1,215 @@
+import {
+  selectNotificationsGroupedByPriority,
+  useNotificationStore,
+} from "./notificationStore";
+
+const PERSIST_KEY = "bridge-watch-notification-read-state";
+
+function resetStoreState() {
+  const initialState = useNotificationStore.getInitialState();
+  useNotificationStore.setState(initialState, true);
+}
+
+describe("notificationStore", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    resetStoreState();
+  });
+
+  it("initializes with empty notifications and zero unread count", () => {
+    const state = useNotificationStore.getState();
+
+    expect(state.notifications).toEqual([]);
+    expect(state.unreadCount).toBe(0);
+  });
+
+  it("adds notification and increments unread count", () => {
+    useNotificationStore.getState().addNotification({
+      id: "notif-1",
+      type: "info",
+      priority: "medium",
+      title: "Info",
+      message: "Message",
+      timestamp: 1,
+    });
+
+    const state = useNotificationStore.getState();
+    expect(state.notifications).toHaveLength(1);
+    expect(state.notifications[0]?.id).toBe("notif-1");
+    expect(state.unreadCount).toBe(1);
+  });
+
+  it("marks one notification as read", () => {
+    const store = useNotificationStore.getState();
+    store.addNotification({
+      id: "notif-1",
+      type: "system",
+      priority: "high",
+      title: "One",
+      message: "One",
+      timestamp: 1,
+    });
+    store.addNotification({
+      id: "notif-2",
+      type: "system",
+      priority: "high",
+      title: "Two",
+      message: "Two",
+      timestamp: 2,
+    });
+
+    store.markAsRead("notif-1");
+
+    const state = useNotificationStore.getState();
+    expect(state.notifications.find((notification) => notification.id === "notif-1")?.read).toBe(
+      true
+    );
+    expect(state.notifications.find((notification) => notification.id === "notif-2")?.read).toBe(
+      false
+    );
+    expect(state.unreadCount).toBe(1);
+  });
+
+  it("marks all notifications as read", () => {
+    const store = useNotificationStore.getState();
+    store.addNotification({
+      id: "a",
+      type: "info",
+      priority: "low",
+      title: "A",
+      message: "A",
+      timestamp: 1,
+    });
+    store.addNotification({
+      id: "b",
+      type: "info",
+      priority: "medium",
+      title: "B",
+      message: "B",
+      timestamp: 2,
+    });
+    store.addNotification({
+      id: "c",
+      type: "system",
+      priority: "critical",
+      title: "C",
+      message: "C",
+      timestamp: 3,
+    });
+
+    store.markAllAsRead();
+
+    const state = useNotificationStore.getState();
+    expect(state.notifications.every((notification) => notification.read)).toBe(true);
+    expect(state.unreadCount).toBe(0);
+  });
+
+  it("clears only read notifications", () => {
+    const store = useNotificationStore.getState();
+    store.addNotification({
+      id: "read-1",
+      type: "info",
+      priority: "low",
+      title: "Read",
+      message: "Read",
+      timestamp: 1,
+    });
+    store.addNotification({
+      id: "unread-1",
+      type: "info",
+      priority: "medium",
+      title: "Unread",
+      message: "Unread",
+      timestamp: 2,
+    });
+
+    store.markAsRead("read-1");
+    store.clearReadNotifications();
+
+    const state = useNotificationStore.getState();
+    expect(state.notifications.map((notification) => notification.id)).toEqual(["unread-1"]);
+    expect(state.unreadCount).toBe(1);
+  });
+
+  it("groups notifications by priority in taxonomy order", () => {
+    const store = useNotificationStore.getState();
+    store.addNotification({
+      id: "low-1",
+      type: "info",
+      priority: "low",
+      title: "Low",
+      message: "Low",
+      timestamp: 1,
+    });
+    store.addNotification({
+      id: "critical-1",
+      type: "system",
+      priority: "critical",
+      title: "Critical",
+      message: "Critical",
+      timestamp: 3,
+    });
+    store.addNotification({
+      id: "high-1",
+      type: "system",
+      priority: "high",
+      title: "High",
+      message: "High",
+      timestamp: 2,
+    });
+
+    const grouped = selectNotificationsGroupedByPriority(useNotificationStore.getState());
+    expect(Object.keys(grouped)).toEqual(["critical", "high", "medium", "low"]);
+    expect(grouped.critical.map((notification) => notification.id)).toEqual(["critical-1"]);
+    expect(grouped.high.map((notification) => notification.id)).toEqual(["high-1"]);
+    expect(grouped.medium).toEqual([]);
+    expect(grouped.low.map((notification) => notification.id)).toEqual(["low-1"]);
+  });
+
+  it("writes read-state persistence on mutation", () => {
+    const store = useNotificationStore.getState();
+    store.addNotification({
+      id: "persist-1",
+      type: "info",
+      priority: "medium",
+      title: "Persist",
+      message: "Persist",
+      timestamp: 1,
+    });
+
+    store.markAsRead("persist-1");
+
+    const persisted = localStorage.getItem(PERSIST_KEY);
+    expect(persisted).toContain("persist-1");
+  });
+
+  it("rehydrates read-state and applies it to incoming notifications", async () => {
+    localStorage.setItem(
+      PERSIST_KEY,
+      JSON.stringify({
+        state: {
+          readStateById: {
+            "rehydrated-1": true,
+          },
+        },
+        version: 1,
+      })
+    );
+
+    await useNotificationStore.persist.rehydrate();
+
+    useNotificationStore.getState().addNotification({
+      id: "rehydrated-1",
+      type: "info",
+      priority: "medium",
+      title: "Rehydrated",
+      message: "Rehydrated",
+      timestamp: 1,
+    });
+
+    const notification = useNotificationStore
+      .getState()
+      .notifications.find((entry) => entry.id === "rehydrated-1");
+    expect(notification?.read).toBe(true);
+  });
+});

--- a/frontend/src/stores/notificationStore.ts
+++ b/frontend/src/stores/notificationStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
 import { devtools } from "zustand/middleware";
 
 export type NotificationType =
@@ -34,12 +35,29 @@ export interface NotificationState {
   highCount: number;
   notificationHistory: Notification[];
   maxHistorySize: number;
+  readStateById: Record<string, boolean>;
+}
+
+export interface NotificationInput
+  extends Omit<Notification, "id" | "timestamp" | "read" | "dismissed"> {
+  id?: string;
+  timestamp?: number;
+  read?: boolean;
+  dismissed?: boolean;
 }
 
 export interface NotificationActions {
-  addNotification: (notification: Omit<Notification, "id" | "timestamp" | "read" | "dismissed">) => void;
+  /**
+   * Adds a notification to the active list and history, preserving timestamp-desc ordering.
+   * Reuses persisted read-state by identifier when available.
+   */
+  addNotification: (notification: NotificationInput) => void;
+  /** Marks one notification as read by identifier and persists the read flag. */
   markAsRead: (id: string) => void;
+  /** Marks all current notifications as read and persists read flags for each identifier. */
   markAllAsRead: () => void;
+  /** Removes all notifications with `read=true` from the active list and read-state map. */
+  clearReadNotifications: () => void;
   dismissNotification: (id: string) => void;
   dismissAll: () => void;
   removeNotification: (id: string) => void;
@@ -52,186 +70,231 @@ export interface NotificationActions {
 }
 
 const MAX_HISTORY_DEFAULT = 100;
+const NOTIFICATION_READ_STATE_KEY = "bridge-watch-notification-read-state";
+
+export const NOTIFICATION_PRIORITY_ORDER: NotificationPriority[] = [
+  "critical",
+  "high",
+  "medium",
+  "low",
+];
 
 const createNotificationId = (): string =>
   `notif-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
 
+const sortNotificationsByTimestampDesc = (notifications: Notification[]): Notification[] =>
+  [...notifications].sort((a, b) => b.timestamp - a.timestamp);
+
 const countByPredicate = (notifications: Notification[], predicate: (n: Notification) => boolean): number =>
   notifications.filter((n) => !n.dismissed && predicate(n)).length;
 
+const deriveCounts = (notifications: Notification[]) => ({
+  unreadCount: countByPredicate(notifications, (n) => !n.read),
+  criticalCount: countByPredicate(
+    notifications,
+    (n) => n.priority === "critical" && !n.read
+  ),
+  highCount: countByPredicate(
+    notifications,
+    (n) => n.priority === "high" && !n.read
+  ),
+});
+
 export const useNotificationStore = create<NotificationState & NotificationActions>()(
   devtools(
-    (set, get) => ({
-      notifications: [],
-      unreadCount: 0,
-      criticalCount: 0,
-      highCount: 0,
-      notificationHistory: [],
-      maxHistorySize: MAX_HISTORY_DEFAULT,
+    persist(
+      (set, get) => ({
+        notifications: [],
+        unreadCount: 0,
+        criticalCount: 0,
+        highCount: 0,
+        notificationHistory: [],
+        maxHistorySize: MAX_HISTORY_DEFAULT,
+        readStateById: {},
 
-      addNotification: (notificationData) => {
-        const notification: Notification = {
-          ...notificationData,
-          id: createNotificationId(),
-          timestamp: Date.now(),
-          read: false,
-          dismissed: false,
-        };
+        addNotification: (notificationData) => {
+          const existingReadState = notificationData.id
+            ? get().readStateById[notificationData.id]
+            : undefined;
+          const notification: Notification = {
+            ...notificationData,
+            id: notificationData.id ?? createNotificationId(),
+            timestamp: notificationData.timestamp ?? Date.now(),
+            read: notificationData.read ?? existingReadState ?? false,
+            dismissed: notificationData.dismissed ?? false,
+          };
 
-        set((state) => {
-          const newNotifications = [notification, ...state.notifications];
-          const newHistory = [notification, ...state.notificationHistory].slice(
-            0,
-            state.maxHistorySize
+          set((state) => {
+            const newNotifications = sortNotificationsByTimestampDesc([
+              notification,
+              ...state.notifications.filter((existing) => existing.id !== notification.id),
+            ]);
+            const newHistory = sortNotificationsByTimestampDesc([
+              notification,
+              ...state.notificationHistory,
+            ]).slice(0, state.maxHistorySize);
+
+            return {
+              notifications: newNotifications,
+              notificationHistory: newHistory,
+              ...deriveCounts(newNotifications),
+            };
+          }, false, "addNotification");
+        },
+
+        markAsRead: (id) => {
+          set((state) => {
+            const newNotifications = state.notifications.map((n) =>
+              n.id === id ? { ...n, read: true } : n
+            );
+
+            return {
+              notifications: newNotifications,
+              readStateById: { ...state.readStateById, [id]: true },
+              ...deriveCounts(newNotifications),
+            };
+          }, false, "markAsRead");
+        },
+
+        markAllAsRead: () => {
+          set((state) => {
+            const newNotifications = state.notifications.map((n) => ({
+              ...n,
+              read: true,
+            }));
+            const readStateById = newNotifications.reduce<Record<string, boolean>>(
+              (accumulator, notification) => {
+                accumulator[notification.id] = true;
+                return accumulator;
+              },
+              { ...state.readStateById }
+            );
+
+            return {
+              notifications: newNotifications,
+              readStateById,
+              ...deriveCounts(newNotifications),
+            };
+          }, false, "markAllAsRead");
+        },
+
+        clearReadNotifications: () => {
+          set((state) => {
+            const remainingNotifications = state.notifications.filter(
+              (notification) => !notification.read
+            );
+            const remainingIds = new Set(
+              remainingNotifications.map((notification) => notification.id)
+            );
+            const readStateById = Object.fromEntries(
+              Object.entries(state.readStateById).filter(([id]) => remainingIds.has(id))
+            );
+
+            return {
+              notifications: remainingNotifications,
+              notificationHistory: state.notificationHistory.filter(
+                (notification) => !notification.read
+              ),
+              readStateById,
+              ...deriveCounts(remainingNotifications),
+            };
+          }, false, "clearReadNotifications");
+        },
+
+        dismissNotification: (id) => {
+          set((state) => {
+            const newNotifications = state.notifications.map((n) =>
+              n.id === id ? { ...n, dismissed: true } : n
+            );
+
+            return {
+              notifications: newNotifications,
+              ...deriveCounts(newNotifications),
+            };
+          }, false, "dismissNotification");
+        },
+
+        dismissAll: () => {
+          set((state) => {
+            const notifications = state.notifications.map((n) => ({
+              ...n,
+              dismissed: true,
+            }));
+
+            return {
+              notifications,
+              ...deriveCounts(notifications),
+            };
+          }, false, "dismissAll");
+        },
+
+        removeNotification: (id) => {
+          set((state) => {
+            const newNotifications = state.notifications.filter((n) => n.id !== id);
+            const readStateById = Object.fromEntries(
+              Object.entries(state.readStateById).filter(([entryId]) => entryId !== id)
+            );
+
+            return {
+              notifications: newNotifications,
+              readStateById,
+              ...deriveCounts(newNotifications),
+            };
+          }, false, "removeNotification");
+        },
+
+        clearAll: () => {
+          set(
+            {
+              notifications: [],
+              unreadCount: 0,
+              criticalCount: 0,
+              highCount: 0,
+              readStateById: {},
+            },
+            false,
+            "clearAll"
           );
+        },
 
-          return {
-            notifications: newNotifications,
-            notificationHistory: newHistory,
-            unreadCount: countByPredicate(newNotifications, (n) => !n.read),
-            criticalCount: countByPredicate(
-              newNotifications,
-              (n) => n.priority === "critical" && !n.read
-            ),
-            highCount: countByPredicate(
-              newNotifications,
-              (n) => n.priority === "high" && !n.read
-            ),
-          };
-        }, false, "addNotification");
-      },
+        getUnreadNotifications: () => {
+          return get().notifications.filter((n) => !n.read && !n.dismissed);
+        },
 
-      markAsRead: (id) => {
-        set((state) => {
-          const newNotifications = state.notifications.map((n) =>
-            n.id === id ? { ...n, read: true } : n
+        getNotificationsByType: (type) => {
+          return get().notifications.filter(
+            (n) => n.type === type && !n.dismissed
           );
+        },
 
-          return {
-            notifications: newNotifications,
-            unreadCount: countByPredicate(newNotifications, (n) => !n.read),
-            criticalCount: countByPredicate(
-              newNotifications,
-              (n) => n.priority === "critical" && !n.read
-            ),
-            highCount: countByPredicate(
-              newNotifications,
-              (n) => n.priority === "high" && !n.read
-            ),
-          };
-        }, false, "markAsRead");
-      },
-
-      markAllAsRead: () => {
-        set((state) => {
-          const newNotifications = state.notifications.map((n) => ({
-            ...n,
-            read: true,
-          }));
-
-          return {
-            notifications: newNotifications,
-            unreadCount: 0,
-            criticalCount: 0,
-            highCount: 0,
-          };
-        }, false, "markAllAsRead");
-      },
-
-      dismissNotification: (id) => {
-        set((state) => {
-          const newNotifications = state.notifications.map((n) =>
-            n.id === id ? { ...n, dismissed: true } : n
+        getNotificationsByPriority: (priority) => {
+          return get().notifications.filter(
+            (n) => n.priority === priority && !n.dismissed
           );
+        },
 
-          return {
-            notifications: newNotifications,
-            unreadCount: countByPredicate(newNotifications, (n) => !n.read),
-            criticalCount: countByPredicate(
-              newNotifications,
-              (n) => n.priority === "critical" && !n.read
-            ),
-            highCount: countByPredicate(
-              newNotifications,
-              (n) => n.priority === "high" && !n.read
-            ),
-          };
-        }, false, "dismissNotification");
-      },
+        getNotificationsByAsset: (assetCode) => {
+          return get().notifications.filter(
+            (n) => n.assetCode === assetCode && !n.dismissed
+          );
+        },
 
-      dismissAll: () => {
-        set((state) => ({
-          notifications: state.notifications.map((n) => ({
-            ...n,
-            dismissed: true,
-          })),
-          unreadCount: 0,
-          criticalCount: 0,
-          highCount: 0,
-        }), false, "dismissAll");
-      },
-
-      removeNotification: (id) => {
-        set((state) => {
-          const newNotifications = state.notifications.filter((n) => n.id !== id);
-
-          return {
-            notifications: newNotifications,
-            unreadCount: countByPredicate(newNotifications, (n) => !n.read),
-            criticalCount: countByPredicate(
-              newNotifications,
-              (n) => n.priority === "critical" && !n.read
-            ),
-            highCount: countByPredicate(
-              newNotifications,
-              (n) => n.priority === "high" && !n.read
-            ),
-          };
-        }, false, "removeNotification");
-      },
-
-      clearAll: () => {
-        set(
-          {
-            notifications: [],
-            unreadCount: 0,
-            criticalCount: 0,
-            highCount: 0,
-          },
-          false,
-          "clearAll"
-        );
-      },
-
-      getUnreadNotifications: () => {
-        return get().notifications.filter((n) => !n.read && !n.dismissed);
-      },
-
-      getNotificationsByType: (type) => {
-        return get().notifications.filter(
-          (n) => n.type === type && !n.dismissed
-        );
-      },
-
-      getNotificationsByPriority: (priority) => {
-        return get().notifications.filter(
-          (n) => n.priority === priority && !n.dismissed
-        );
-      },
-
-      getNotificationsByAsset: (assetCode) => {
-        return get().notifications.filter(
-          (n) => n.assetCode === assetCode && !n.dismissed
-        );
-      },
-
-      setMaxHistorySize: (size) => {
-        set((state) => ({
-          maxHistorySize: size,
-          notificationHistory: state.notificationHistory.slice(0, size),
-        }), false, "setMaxHistorySize");
-      },
-    }),
+        setMaxHistorySize: (size) => {
+          set((state) => ({
+            maxHistorySize: size,
+            notificationHistory: state.notificationHistory.slice(0, size),
+          }), false, "setMaxHistorySize");
+        },
+      }),
+      {
+        name: NOTIFICATION_READ_STATE_KEY,
+        storage: createJSONStorage(() => localStorage),
+        version: 1,
+        partialize: (state) => ({
+          readStateById: state.readStateById,
+        }),
+      }
+    ),
     { name: "NotificationStore" }
   )
 );
@@ -255,3 +318,28 @@ export const selectNotificationStats = (state: NotificationState & NotificationA
   critical: state.criticalCount,
   high: state.highCount,
 });
+
+/**
+ * Groups visible notifications by priority using the canonical taxonomy order:
+ * critical -> high -> medium -> low.
+ */
+export const selectNotificationsGroupedByPriority = (
+  state: NotificationState & NotificationActions
+) => {
+  const visibleNotifications = state.notifications.filter((n) => !n.dismissed);
+
+  return NOTIFICATION_PRIORITY_ORDER.reduce<Record<NotificationPriority, Notification[]>>(
+    (accumulator, priority) => {
+      accumulator[priority] = visibleNotifications.filter(
+        (notification) => notification.priority === priority
+      );
+      return accumulator;
+    },
+    {
+      critical: [],
+      high: [],
+      medium: [],
+      low: [],
+    }
+  );
+};


### PR DESCRIPTION
Closes #280

## What changed

- frontend/src/components/Navbar.tsx
  - Replaced the previous minimal navbar action area with a notifications trigger wired to a full-screen/side notifications drawer and unread badge, including focus restoration and ARIA trigger contract (`aria-expanded`, `aria-controls`).
- frontend/src/components/Navbar.test.tsx
  - Rewrote navbar tests to validate trigger behavior, drawer open/close flow, ARIA sync, and Escape-to-close focus restoration.
- frontend/src/components/NotificationsDrawer.tsx
  - Added the new notifications drawer component with severity grouping (`critical`, `high`, `medium`, `low`), per-item mark-as-read, bulk mark-all-read, bulk clear-read, focus trap, Escape handling, and aria-live updates.
- frontend/src/components/NotificationsDrawer.test.tsx
  - Added drawer behavior and accessibility tests covering open/close, keyboard handling, grouping, action dispatch effects, disabled-state assertions, and `vitest-axe` checks.
- frontend/src/components/UnreadCountBadge.tsx
  - Added reusable unread badge component with zero-state hiding, truncation (`9+`), and screen-reader status announcement.
- frontend/src/components/UnreadCountBadge.test.tsx
  - Added tests for render/hide/truncate/live-region behavior.
- frontend/src/hooks/useNotificationLiveUpdates.ts
  - Added live notification subscriber hook that uses the existing websocket mechanism and normalizes incoming messages into the notification store shape.
- frontend/src/hooks/useNotificationLiveUpdates.test.tsx
  - Added tests to verify channel subscription and payload-to-store ingestion.
- frontend/src/stores/notificationStore.ts
  - Extended notification store with read-state persistence, read-state rehydration, `clearReadNotifications`, grouped-by-priority selector, and action/selector docs required by the feature.
- frontend/src/stores/notificationStore.test.ts
  - Added store tests for initial state, add, mark-one-read, mark-all-read, clear-read, grouping order, persistence write, and rehydration behavior.

## Notification behavior documentation

Notification lifecycle in this implementation:

1. **Ingress**: Incoming websocket messages on the `notifications` channel are handled in `useNotificationLiveUpdates`.
2. **Normalization**: Raw payload fields (`priority` or `severity`) are mapped into existing store taxonomy and a store-compatible notification object.
3. **Storage**: Notifications are inserted into `notificationStore` in timestamp-descending order.
4. **Grouping**: Drawer renders grouped sections in strict taxonomy order: `critical` → `high` → `medium` → `low`.
5. **Read management**:
   - Per-item `markAsRead(id)`
   - Bulk `markAllAsRead()`
   - Bulk `clearReadNotifications()` removes only read items
6. **Unread badge sync**: The navbar unread badge is driven from store selector `selectUnreadCount` and updates live while drawer is open or closed.
7. **Persistence**: Read state is persisted by notification identifier and rehydrated at store init.

## Live update mechanism

- **Real-time layer used**: Existing websocket hook path (`useWebSocketEnhanced` + existing websocket service/store plumbing).
- **Subscription lifecycle**:
  - Subscribes when navbar mounts via `useNotificationLiveUpdates`.
  - Relies on existing hook cleanup/unsubscribe lifecycle.
- **Error handling behavior**:
  - Invalid/malformed notification payloads are ignored safely.
  - No notification content is logged in the new subscriber code.
- **Environment variables**:
  - No new env vars were introduced; existing websocket endpoint conventions are reused.

## Persistence mechanism

- **Mechanism**: Zustand `persist` middleware with JSON storage (`localStorage`), aligned with existing store persistence pattern.
- **Persisted data**: Read-state map by notification ID (`readStateById`) only.
- **Rehydration**: On store init, persisted read-state is rehydrated and applied to incoming notifications with matching IDs.

## Keyboard interaction contract

| Key | Action | Context |
| --- | --- | --- |
| Enter / Space | Toggle drawer via trigger button | Navbar notification trigger |
| Escape | Close drawer | Drawer open |
| Tab | Move to next focusable and keep focus trapped | Drawer open |
| Shift+Tab | Move to previous focusable and keep focus trapped | Drawer open |
| ArrowDown | Move focus to next per-item action button | Drawer list action controls |
| ArrowUp | Move focus to previous per-item action button | Drawer list action controls |

## Accessibility notes

- Drawer container uses `role="dialog"` and `aria-modal="true"`.
- Trigger uses `aria-expanded` and `aria-controls` contract.
- Unread badge and new-item updates are announced via `aria-live` / `role="status"` regions.
- Added `vitest-axe` accessibility test coverage for drawer open state and populated content.

## Responsive behavior

- Desktop: right-side panel width constrained (`sm:w-[24rem]`).
- Mobile: full-width overlay drawer (`w-full`) with backdrop.
- Breakpoint behavior is implemented using existing Tailwind responsive classes already used in the codebase.

## Validation steps

Executed locally in `frontend` workspace:

1. `npm run lint`
   - **Result**: Failed due pre-existing repository issues in unrelated files (e.g. `pages/AssetDetail.tsx`, legacy watchlist/i18n typing issues).
2. `npm run type-check`
   - **Result**: Failed due pre-existing type errors unrelated to this feature.
3. `npm run test`
   - **Result**: Failed due environment-level Vitest worker ESM issue (`ERR_REQUIRE_ESM` from `html-encoding-sniffer` / `@exodus/bytes`) before tests execute.
4. `npm run build`
   - **Result**: Failed due same pre-existing type issues as type-check.
5. Targeted lint on modified files
   - **Result**: Passed.

## Bundle size delta

- No bundle-size CI check is configured in current workflows; bundle delta not available from automated tooling.

## Security notes

- Notification message content is rendered as text in React (no `dangerouslySetInnerHTML` usage introduced).
- New live-update hook does not log notification message content.
- Read-state persistence stores notification IDs only (no notification body persistence added).
- This frontend-only implementation does not introduce server-side bulk-clear API behavior; no cross-user clear path was added.

## Out-of-scope findings

- Existing frontend baseline currently contains unrelated lint/type failures (watchlist mutations typing, i18n dependency typings, asset/liquidity page type issues).
- Existing test environment has worker startup failures due ESM/CJS incompatibility in dependencies.

## Pipeline parity confirmation

- All locally reproducible frontend checks were attempted.
- Pre-existing repository/environment issues prevent full green pipeline parity at this time.
- Feature-scoped files lint clean; broader failures are unrelated and pre-existing.

## CI status confirmation
