### PR TITLE
Add mobile refresh, chart annotations, sparkline grid, and asset tags

### DIFF
--- a/frontend/src/components/PriceChart.tsx
+++ b/frontend/src/components/PriceChart.tsx
@@ -7,6 +7,7 @@ import {
   Tooltip,
   ResponsiveContainer,
   Legend,
+  ReferenceLine,
 } from "recharts";
 import ChartTooltip from "./Tooltip/ChartTooltip.js";
 import { useMemo } from "react";
@@ -17,6 +18,7 @@ import {
   getColorblindModePreference,
   getVisualizationTheme,
 } from "../styles/colors";
+import type { ChartAnnotation } from "../hooks/useChartAnnotations";
 
 interface PriceDataPoint {
   timestamp: string;
@@ -29,6 +31,7 @@ interface PriceChartProps {
   data: PriceDataPoint[];
   isLoading: boolean;
   chartId: string;
+  annotations?: ChartAnnotation[];
 }
 
 export default function PriceChart({
@@ -36,6 +39,7 @@ export default function PriceChart({
   data,
   isLoading,
   chartId,
+  annotations = [],
 }: PriceChartProps) {
   const { getEffectiveSelection } = useTimeRange();
   const selection = getEffectiveSelection(chartId);
@@ -72,6 +76,14 @@ export default function PriceChart({
   const sources = useMemo(
     () => [...new Set(filteredData.map((entry) => entry.source))],
     [filteredData]
+  );
+
+  const annotationMarks = useMemo(
+    () =>
+      annotations.filter((annotation) =>
+        filteredData.some((entry) => entry.timestamp === annotation.timestamp)
+      ),
+    [annotations, filteredData]
   );
 
   const sourceColors = useMemo(
@@ -143,6 +155,21 @@ export default function PriceChart({
               stroke={sourceColors[source]}
               dot={false}
               strokeWidth={2}
+            />
+          ))}
+          {annotationMarks.map((annotation) => (
+            <ReferenceLine
+              key={annotation.id}
+              x={annotation.timestamp}
+              stroke={annotation.color}
+              strokeDasharray="4 4"
+              ifOverflow="extendDomain"
+              label={{
+                value: annotation.label,
+                fill: annotation.color,
+                fontSize: 11,
+                position: "top",
+              }}
             />
           ))}
         </LineChart>

--- a/frontend/src/components/PullToRefresh.tsx
+++ b/frontend/src/components/PullToRefresh.tsx
@@ -1,0 +1,44 @@
+type PullToRefreshProps = {
+  isPulling: boolean;
+  pullDistance: number;
+  progress: number;
+  isRefreshing: boolean;
+};
+
+export default function PullToRefresh({
+  isPulling,
+  pullDistance,
+  progress,
+  isRefreshing,
+}: PullToRefreshProps) {
+  const visible = isPulling || isRefreshing;
+  const label = isRefreshing
+    ? "Refreshing data"
+    : progress >= 1
+      ? "Release to refresh"
+      : "Pull down to refresh";
+
+  return (
+    <div
+      className={`pointer-events-none sticky top-0 z-20 -mt-2 flex justify-center transition-all duration-200 ${
+        visible ? "opacity-100" : "opacity-0"
+      }`}
+      aria-live="polite"
+      aria-hidden={!visible}
+    >
+      <div
+        className="mt-2 inline-flex items-center gap-3 rounded-full border border-stellar-border bg-stellar-card/95 px-4 py-2 text-xs text-white shadow-lg backdrop-blur"
+        style={{
+          transform: visible ? `translateY(${Math.min(pullDistance, 24)}px)` : "translateY(-12px)",
+        }}
+      >
+        <span className={isRefreshing ? "animate-spin" : ""} aria-hidden="true">
+          ↻
+        </span>
+        <span>{label}</span>
+        <span className="text-stellar-text-secondary">{Math.round(progress * 100)}%</span>
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/src/components/analytics/ComparativeSparklineGrid.tsx
+++ b/frontend/src/components/analytics/ComparativeSparklineGrid.tsx
@@ -1,0 +1,74 @@
+import { Link } from "react-router-dom";
+import Sparkline from "../Sparkline";
+
+export type ComparativeSparklineItem = {
+  symbol: string;
+  name: string;
+  period?: "24h" | "7d" | "30d";
+};
+
+type ComparativeSparklineGridProps = {
+  items: ComparativeSparklineItem[];
+};
+
+export default function ComparativeSparklineGrid({ items }: ComparativeSparklineGridProps) {
+  if (items.length === 0) {
+    return (
+      <div className="rounded-lg border border-stellar-border bg-stellar-card p-6">
+        <h2 className="text-lg font-semibold text-white">Comparative sparklines</h2>
+        <p className="mt-2 text-sm text-stellar-text-secondary">
+          No assets available for comparison yet.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <section className="space-y-4 rounded-2xl border border-stellar-border bg-gradient-to-br from-stellar-card to-stellar-dark/35 p-6">
+      <div className="flex items-end justify-between gap-3">
+        <div>
+          <h2 className="text-xl font-semibold text-white">Comparative sparklines</h2>
+          <p className="mt-1 text-sm text-stellar-text-secondary">
+            Compare short-term health trends across the most monitored assets.
+          </p>
+        </div>
+        <p className="text-xs uppercase tracking-[0.24em] text-stellar-text-secondary">
+          Touch-friendly grid
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {items.map((item) => (
+          <article
+            key={item.symbol}
+            className="rounded-xl border border-stellar-border/80 bg-stellar-dark/30 p-4 transition-colors hover:border-stellar-blue/60"
+          >
+            <div className="mb-3 flex items-center justify-between gap-2">
+              <div>
+                <h3 className="text-base font-semibold text-white">
+                  <Link to={`/assets/${item.symbol}`} className="hover:text-stellar-blue">
+                    {item.symbol}
+                  </Link>
+                </h3>
+                <p className="text-xs text-stellar-text-secondary">{item.name}</p>
+              </div>
+              <span className="rounded-full border border-stellar-border px-2 py-1 text-[11px] uppercase tracking-wider text-stellar-text-secondary">
+                {item.period ?? "7d"}
+              </span>
+            </div>
+
+            <Sparkline
+              symbol={item.symbol}
+              metric="health"
+              period={item.period ?? "7d"}
+              height={48}
+              showMinMax={false}
+              aria-label={`${item.symbol} comparative health sparkline`}
+            />
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+

--- a/frontend/src/components/asset/AssetTagsPanel.tsx
+++ b/frontend/src/components/asset/AssetTagsPanel.tsx
@@ -1,0 +1,109 @@
+type AssetTagsPanelProps = {
+  symbol: string;
+  tags: string[];
+  draftTagInput: string;
+  onDraftTagInputChange: (value: string) => void;
+  onAddTag: () => void;
+  onRemoveTag: (tag: string) => void;
+  onSave: () => void;
+  onReset: () => void;
+  canSave: boolean;
+  isSaving: boolean;
+  statusText: string;
+};
+
+export default function AssetTagsPanel({
+  symbol,
+  tags,
+  draftTagInput,
+  onDraftTagInputChange,
+  onAddTag,
+  onRemoveTag,
+  onSave,
+  onReset,
+  canSave,
+  isSaving,
+  statusText,
+}: AssetTagsPanelProps) {
+  return (
+    <section className="rounded-lg border border-stellar-border bg-stellar-card p-6">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h3 className="text-lg font-semibold text-white">Asset tags</h3>
+          <p className="mt-1 text-sm text-stellar-text-secondary">
+            Organize {symbol} with backend-synced tags for filtering and review.
+          </p>
+        </div>
+        <span className="rounded-full border border-stellar-border px-3 py-1 text-xs text-stellar-text-secondary">
+          {statusText}
+        </span>
+      </div>
+
+      <div className="mt-4 flex flex-wrap gap-2">
+        {tags.length > 0 ? (
+          tags.map((tag) => (
+            <button
+              key={tag}
+              type="button"
+              onClick={() => onRemoveTag(tag)}
+              className="rounded-full border border-stellar-border bg-stellar-dark/40 px-3 py-1 text-sm text-white transition-colors hover:border-red-400 hover:text-red-200"
+              aria-label={`Remove tag ${tag}`}
+              title="Click to remove"
+            >
+              {tag}
+            </button>
+          ))
+        ) : (
+          <p className="text-sm text-stellar-text-secondary">No tags saved yet.</p>
+        )}
+      </div>
+
+      <div className="mt-5 flex flex-col gap-3 md:flex-row md:items-center">
+        <input
+          value={draftTagInput}
+          onChange={(event) => onDraftTagInputChange(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              event.preventDefault();
+              onAddTag();
+            }
+          }}
+          placeholder="Add a tag and press Enter"
+          className="flex-1 rounded-md border border-stellar-border bg-stellar-dark px-3 py-2 text-sm text-white placeholder:text-stellar-text-secondary focus:outline-none focus:ring-2 focus:ring-stellar-blue"
+          aria-label={`Add a tag for ${symbol}`}
+        />
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={onAddTag}
+            className="rounded-md border border-stellar-border px-3 py-2 text-sm text-white hover:bg-stellar-border"
+          >
+            Add tag
+          </button>
+          <button
+            type="button"
+            onClick={onReset}
+            className="rounded-md border border-stellar-border px-3 py-2 text-sm text-stellar-text-secondary hover:text-white"
+          >
+            Reset
+          </button>
+        </div>
+      </div>
+
+      <div className="mt-5 flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={onSave}
+          disabled={!canSave || isSaving}
+          className="rounded-md bg-stellar-blue px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-600 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {isSaving ? "Saving..." : "Save tags"}
+        </button>
+        <p className="text-xs text-stellar-text-secondary">
+          Tags persist in the asset metadata record and are safe to revisit later.
+        </p>
+      </div>
+    </section>
+  );
+}
+

--- a/frontend/src/components/asset/ChartAnnotationPanel.tsx
+++ b/frontend/src/components/asset/ChartAnnotationPanel.tsx
@@ -1,0 +1,289 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  type ChartAnnotation,
+  type ChartAnnotationInput,
+} from "../../hooks/useChartAnnotations";
+
+type ChartAnnotationPanelProps = {
+  symbol: string;
+  annotations: ChartAnnotation[];
+  defaultTimestamp: string;
+  addAnnotation: (input: ChartAnnotationInput) => ChartAnnotation;
+  updateAnnotation: (id: string, input: ChartAnnotationInput) => void;
+  removeAnnotation: (id: string) => void;
+  clearAnnotations: () => void;
+  exportAnnotations: () => string;
+};
+
+const DEFAULT_COLOR = "#3b82f6";
+
+function toLocalDateTimeInput(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+
+  return `${year}-${month}-${day}T${hours}:${minutes}`;
+}
+
+function fromLocalDateTimeInput(value: string) {
+  if (!value) {
+    return new Date().toISOString();
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return new Date().toISOString();
+  }
+
+  return date.toISOString();
+}
+
+export default function ChartAnnotationPanel({
+  symbol,
+  annotations,
+  defaultTimestamp,
+  addAnnotation,
+  updateAnnotation,
+  removeAnnotation,
+  clearAnnotations,
+  exportAnnotations,
+}: ChartAnnotationPanelProps) {
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [kind, setKind] = useState<ChartAnnotationInput["kind"]>("note");
+  const [label, setLabel] = useState("");
+  const [timestamp, setTimestamp] = useState(defaultTimestamp);
+  const [notes, setNotes] = useState("");
+  const [color, setColor] = useState(DEFAULT_COLOR);
+
+  const canSubmit = label.trim().length > 0 && timestamp.length > 0;
+
+  const editingAnnotation = useMemo(
+    () => annotations.find((annotation) => annotation.id === editingId) ?? null,
+    [annotations, editingId]
+  );
+
+  useEffect(() => {
+    if (editingId) return;
+    setTimestamp(defaultTimestamp);
+  }, [defaultTimestamp, editingId]);
+
+  function resetForm(nextTimestamp = defaultTimestamp) {
+    setEditingId(null);
+    setKind("note");
+    setLabel("");
+    setTimestamp(nextTimestamp);
+    setNotes("");
+    setColor(DEFAULT_COLOR);
+  }
+
+  function submitForm() {
+    if (!canSubmit) return;
+
+    const payload: ChartAnnotationInput = {
+      kind,
+      label: label.trim(),
+      timestamp,
+      notes,
+      color,
+    };
+
+    if (editingId) {
+      updateAnnotation(editingId, payload);
+    } else {
+      addAnnotation(payload);
+    }
+
+    resetForm(timestamp);
+  }
+
+  function startEditing(annotation: ChartAnnotation) {
+    setEditingId(annotation.id);
+    setKind(annotation.kind);
+    setLabel(annotation.label);
+    setTimestamp(annotation.timestamp);
+    setNotes(annotation.notes);
+    setColor(annotation.color);
+  }
+
+  function downloadAnnotations() {
+    const blob = new Blob([exportAnnotations()], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = `${symbol.toLowerCase()}-annotations.json`;
+    anchor.click();
+    URL.revokeObjectURL(url);
+  }
+
+  return (
+    <section className="rounded-lg border border-stellar-border bg-stellar-card p-6">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h3 className="text-lg font-semibold text-white">Chart annotations</h3>
+          <p className="mt-1 text-sm text-stellar-text-secondary">
+            Mark milestones, notes, and comparison labels directly from the asset chart.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={downloadAnnotations}
+            className="rounded-md border border-stellar-border px-3 py-2 text-sm text-white hover:bg-stellar-border"
+          >
+            Export
+          </button>
+          <button
+            type="button"
+            onClick={clearAnnotations}
+            className="rounded-md border border-stellar-border px-3 py-2 text-sm text-stellar-text-secondary hover:text-white"
+          >
+            Clear all
+          </button>
+        </div>
+      </div>
+
+      <div className="mt-5 grid gap-4 lg:grid-cols-[1.2fr_0.8fr]">
+        <div className="space-y-3">
+          <div className="grid gap-3 md:grid-cols-2">
+            <label className="space-y-2 text-sm text-stellar-text-secondary">
+              <span className="block text-white">Type</span>
+              <select
+                value={kind}
+                onChange={(event) => setKind(event.target.value as ChartAnnotationInput["kind"])}
+                className="w-full rounded-md border border-stellar-border bg-stellar-dark px-3 py-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-stellar-blue"
+              >
+                <option value="note">Note</option>
+                <option value="marker">Marker</option>
+                <option value="comparison">Comparison</option>
+              </select>
+            </label>
+            <label className="space-y-2 text-sm text-stellar-text-secondary">
+              <span className="block text-white">Anchor time</span>
+              <input
+                type="datetime-local"
+                value={toLocalDateTimeInput(timestamp)}
+                onChange={(event) => setTimestamp(fromLocalDateTimeInput(event.target.value))}
+                className="w-full rounded-md border border-stellar-border bg-stellar-dark px-3 py-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-stellar-blue"
+              />
+            </label>
+          </div>
+
+          <label className="space-y-2 text-sm text-stellar-text-secondary">
+            <span className="block text-white">Label</span>
+            <input
+              value={label}
+              onChange={(event) => setLabel(event.target.value)}
+              placeholder="Add a short annotation label"
+              className="w-full rounded-md border border-stellar-border bg-stellar-dark px-3 py-2 text-sm text-white placeholder:text-stellar-text-secondary focus:outline-none focus:ring-2 focus:ring-stellar-blue"
+            />
+          </label>
+
+          <label className="space-y-2 text-sm text-stellar-text-secondary">
+            <span className="block text-white">Notes</span>
+            <textarea
+              value={notes}
+              onChange={(event) => setNotes(event.target.value)}
+              rows={4}
+              placeholder="Add contextual notes for the chart review"
+              className="w-full rounded-md border border-stellar-border bg-stellar-dark px-3 py-2 text-sm text-white placeholder:text-stellar-text-secondary focus:outline-none focus:ring-2 focus:ring-stellar-blue"
+            />
+          </label>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <label className="flex items-center gap-2 text-sm text-stellar-text-secondary">
+              <span className="text-white">Color</span>
+              <input
+                type="color"
+                value={color}
+                onChange={(event) => setColor(event.target.value)}
+                className="h-9 w-12 rounded border border-stellar-border bg-transparent"
+              />
+            </label>
+
+            <button
+              type="button"
+              onClick={submitForm}
+              disabled={!canSubmit}
+              className="rounded-md bg-stellar-blue px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-600 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {editingId ? "Update annotation" : "Add annotation"}
+            </button>
+            {editingId ? (
+              <button
+                type="button"
+                onClick={() => resetForm(defaultTimestamp)}
+                className="rounded-md border border-stellar-border px-4 py-2 text-sm text-stellar-text-secondary hover:text-white"
+              >
+                Cancel edit
+              </button>
+            ) : null}
+          </div>
+
+          {editingAnnotation ? (
+            <p className="text-xs text-stellar-text-secondary">
+              Editing {editingAnnotation.kind} from {editingAnnotation.timestamp}
+            </p>
+          ) : null}
+        </div>
+
+        <div className="rounded-lg border border-stellar-border/80 bg-stellar-dark/30 p-4">
+          <div className="mb-3 flex items-center justify-between">
+            <h4 className="text-sm font-semibold text-white">Saved annotations</h4>
+            <span className="text-xs text-stellar-text-secondary">{annotations.length} total</span>
+          </div>
+
+          {annotations.length === 0 ? (
+            <p className="text-sm text-stellar-text-secondary">
+              Save your first note to track chart decisions over time.
+            </p>
+          ) : (
+            <ul className="space-y-3">
+              {annotations.map((annotation) => (
+                <li key={annotation.id} className="rounded-md border border-stellar-border p-3">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div className="flex items-center gap-2">
+                      <span
+                        className="h-2.5 w-2.5 rounded-full"
+                        style={{ backgroundColor: annotation.color }}
+                        aria-hidden="true"
+                      />
+                      <span className="text-sm font-medium text-white">{annotation.label}</span>
+                      <span className="rounded-full border border-stellar-border px-2 py-0.5 text-[11px] uppercase tracking-wider text-stellar-text-secondary">
+                        {annotation.kind}
+                      </span>
+                    </div>
+                    <div className="flex gap-2">
+                      <button
+                        type="button"
+                        onClick={() => startEditing(annotation)}
+                        className="text-xs text-stellar-blue hover:underline"
+                      >
+                        Edit
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => removeAnnotation(annotation.id)}
+                        className="text-xs text-red-300 hover:underline"
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  </div>
+                  {annotation.notes ? (
+                    <p className="mt-2 text-sm text-stellar-text-secondary">{annotation.notes}</p>
+                  ) : null}
+                  <p className="mt-2 text-xs text-stellar-text-secondary">{annotation.timestamp}</p>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/hooks/useChartAnnotations.ts
+++ b/frontend/src/hooks/useChartAnnotations.ts
@@ -1,0 +1,99 @@
+import { useCallback, useMemo } from "react";
+import { useLocalStorageState } from "./useLocalStorageState";
+
+export type ChartAnnotationKind = "note" | "marker" | "comparison";
+
+export interface ChartAnnotation {
+  id: string;
+  kind: ChartAnnotationKind;
+  label: string;
+  timestamp: string;
+  notes: string;
+  color: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ChartAnnotationInput {
+  kind: ChartAnnotationKind;
+  label: string;
+  timestamp: string;
+  notes?: string;
+  color?: string;
+}
+
+function createId() {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function normalizeAnnotation(input: ChartAnnotationInput, existing?: ChartAnnotation): ChartAnnotation {
+  const now = new Date().toISOString();
+  return {
+    id: existing?.id ?? createId(),
+    kind: input.kind,
+    label: input.label.trim(),
+    timestamp: input.timestamp,
+    notes: input.notes?.trim() ?? "",
+    color: input.color ?? "#3b82f6",
+    createdAt: existing?.createdAt ?? now,
+    updatedAt: now,
+  };
+}
+
+export function useChartAnnotations(symbol: string) {
+  const [annotations, setAnnotations] = useLocalStorageState<ChartAnnotation[]>(
+    `bridge-watch:chart-annotations:${symbol.toUpperCase()}:v1`,
+    []
+  );
+
+  const sortedAnnotations = useMemo(
+    () =>
+      [...annotations].sort(
+        (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+      ),
+    [annotations]
+  );
+
+  const addAnnotation = useCallback(
+    (input: ChartAnnotationInput) => {
+      const next = normalizeAnnotation(input);
+      setAnnotations((current) => [next, ...current]);
+      return next;
+    },
+    [setAnnotations]
+  );
+
+  const updateAnnotation = useCallback(
+    (id: string, input: ChartAnnotationInput) => {
+      setAnnotations((current) =>
+        current.map((annotation) =>
+          annotation.id === id ? normalizeAnnotation(input, annotation) : annotation
+        )
+      );
+    },
+    [setAnnotations]
+  );
+
+  const removeAnnotation = useCallback(
+    (id: string) => {
+      setAnnotations((current) => current.filter((annotation) => annotation.id !== id));
+    },
+    [setAnnotations]
+  );
+
+  const clearAnnotations = useCallback(() => {
+    setAnnotations([]);
+  }, [setAnnotations]);
+
+  const exportAnnotations = useCallback(() => JSON.stringify(sortedAnnotations, null, 2), [sortedAnnotations]);
+
+  return {
+    annotations: sortedAnnotations,
+    addAnnotation,
+    updateAnnotation,
+    removeAnnotation,
+    clearAnnotations,
+    exportAnnotations,
+  };
+}
+

--- a/frontend/src/hooks/usePullToRefresh.ts
+++ b/frontend/src/hooks/usePullToRefresh.ts
@@ -1,0 +1,148 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+type PullToRefreshOptions = {
+  enabled: boolean;
+  onRefresh: () => void | Promise<void>;
+  thresholdPx?: number;
+};
+
+type PullState = {
+  isPulling: boolean;
+  pullDistance: number;
+  progress: number;
+  isRefreshing: boolean;
+  shouldTrigger: boolean;
+};
+
+const DEFAULT_THRESHOLD_PX = 84;
+
+export function usePullToRefresh({
+  enabled,
+  onRefresh,
+  thresholdPx = DEFAULT_THRESHOLD_PX,
+}: PullToRefreshOptions) {
+  const [state, setState] = useState<PullState>({
+    isPulling: false,
+    pullDistance: 0,
+    progress: 0,
+    isRefreshing: false,
+    shouldTrigger: false,
+  });
+  const startPointRef = useRef<{ x: number; y: number } | null>(null);
+  const activeRef = useRef(false);
+  const refreshingRef = useRef(false);
+  const shouldTriggerRef = useRef(false);
+
+  const reset = useCallback(() => {
+    startPointRef.current = null;
+    activeRef.current = false;
+    shouldTriggerRef.current = false;
+    setState({
+      isPulling: false,
+      pullDistance: 0,
+      progress: 0,
+      isRefreshing: refreshingRef.current,
+      shouldTrigger: false,
+    });
+  }, []);
+
+  const runRefresh = useCallback(async () => {
+    if (refreshingRef.current) return;
+    refreshingRef.current = true;
+    setState((current) => ({ ...current, isRefreshing: true, shouldTrigger: false }));
+    shouldTriggerRef.current = false;
+
+    try {
+      await onRefresh();
+    } finally {
+      refreshingRef.current = false;
+      reset();
+    }
+  }, [onRefresh, reset]);
+
+  useEffect(() => {
+    if (!enabled) {
+      reset();
+      return;
+    }
+
+    const canStart = () => window.scrollY <= 0 && !refreshingRef.current;
+
+    const handleTouchStart = (event: TouchEvent) => {
+      if (!canStart()) return;
+
+      const touch = event.touches[0];
+      if (!touch) return;
+
+      startPointRef.current = { x: touch.clientX, y: touch.clientY };
+      activeRef.current = true;
+      setState((current) => ({
+        ...current,
+        isPulling: false,
+        pullDistance: 0,
+        progress: 0,
+        shouldTrigger: false,
+      }));
+    };
+
+    const handleTouchMove = (event: TouchEvent) => {
+      if (!activeRef.current || !startPointRef.current) return;
+
+      const touch = event.touches[0];
+      if (!touch) return;
+
+      const deltaX = Math.abs(touch.clientX - startPointRef.current.x);
+      const deltaY = touch.clientY - startPointRef.current.y;
+
+      if (deltaY <= 0 || deltaX > deltaY) {
+        return;
+      }
+
+      if (window.scrollY > 0) {
+        reset();
+        return;
+      }
+
+      event.preventDefault();
+
+      const pullDistance = Math.min(deltaY, thresholdPx * 1.5);
+      const progress = Math.min(pullDistance / thresholdPx, 1);
+
+      setState({
+        isPulling: true,
+        pullDistance,
+        progress,
+        isRefreshing: refreshingRef.current,
+        shouldTrigger: pullDistance >= thresholdPx,
+      });
+      shouldTriggerRef.current = pullDistance >= thresholdPx;
+    };
+
+    const handleTouchEnd = () => {
+      if (shouldTriggerRef.current) {
+        void runRefresh();
+        return;
+      }
+
+      reset();
+    };
+
+    window.addEventListener("touchstart", handleTouchStart, { passive: true });
+    window.addEventListener("touchmove", handleTouchMove, { passive: false });
+    window.addEventListener("touchend", handleTouchEnd, { passive: true });
+    window.addEventListener("touchcancel", handleTouchEnd, { passive: true });
+
+    return () => {
+      window.removeEventListener("touchstart", handleTouchStart);
+      window.removeEventListener("touchmove", handleTouchMove);
+      window.removeEventListener("touchend", handleTouchEnd);
+      window.removeEventListener("touchcancel", handleTouchEnd);
+    };
+  }, [enabled, reset, runRefresh, thresholdPx]);
+
+  return {
+    ...state,
+    isSupported: enabled,
+    refresh: runRefresh,
+  };
+}

--- a/frontend/src/pages/AssetDetail.tsx
+++ b/frontend/src/pages/AssetDetail.tsx
@@ -1,60 +1,209 @@
+import { useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useParams } from "react-router-dom";
 import { usePrices } from "../hooks/usePrices";
 import { useLiquidity } from "../hooks/useLiquidity";
+import { useAssetHealth } from "../hooks/useAssets";
+import { useChartAnnotations } from "../hooks/useChartAnnotations";
+import { usePullToRefresh } from "../hooks/usePullToRefresh";
+import {
+  getAssetMetadataBySymbol,
+  upsertAssetMetadata,
+} from "../services/api";
 import HealthScoreCard from "../components/HealthScoreCard";
 import PriceChart from "../components/PriceChart";
 import LiquidityDepthChart from "../components/LiquidityDepthChart";
 import { TimeRangeSelector } from "../components/TimeRangeSelector";
 import AddToWatchlistButton from "../components/watchlist/AddToWatchlistButton";
+import PullToRefresh from "../components/PullToRefresh";
+import AssetTagsPanel from "../components/asset/AssetTagsPanel";
+import ChartAnnotationPanel from "../components/asset/ChartAnnotationPanel";
+
+const USER_NAME = "xqcxx";
+
+function normalizeTags(raw: string[]) {
+  return Array.from(
+    new Set(
+      raw
+        .map((tag) => tag.trim().toLowerCase())
+        .filter((tag) => tag.length > 0)
+    )
+  );
+}
+
+function addDraftTags(current: string[], draft: string) {
+  const nextTags = draft
+    .split(/[,\n]/)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+
+  return normalizeTags([...current, ...nextTags]);
+}
 
 export default function AssetDetail() {
   const { symbol } = useParams<{ symbol: string }>();
-  const { data: priceData, isLoading: priceLoading } = usePrices(symbol ?? "");
-  const { data: liquidityData, isLoading: liquidityLoading } = useLiquidity(
+  const queryClient = useQueryClient();
+  const [draftTags, setDraftTags] = useState<string[]>([]);
+  const [tagInput, setTagInput] = useState("");
+
+  const health = useAssetHealth(symbol ?? "");
+  const { data: priceData, isLoading: priceLoading, refetch: refetchPrices } = usePrices(
     symbol ?? ""
   );
+  const { data: liquidityData, isLoading: liquidityLoading, refetch: refetchLiquidity } =
+    useLiquidity(symbol ?? "");
+
+  const metadataQuery = useQuery({
+    queryKey: ["asset-metadata", symbol],
+    queryFn: async () => {
+      if (!symbol) return null;
+      try {
+        return await getAssetMetadataBySymbol(symbol);
+      } catch {
+        return null;
+      }
+    },
+    enabled: !!symbol,
+  });
+
+  const annotations = useChartAnnotations(symbol ?? "");
+  const latestPriceTimestamp =
+    priceData?.history && priceData.history.length > 0
+      ? priceData.history[priceData.history.length - 1].timestamp
+      : new Date().toISOString();
+
+  useEffect(() => {
+    setDraftTags(normalizeTags(metadataQuery.data?.tags ?? []));
+    setTagInput("");
+  }, [metadataQuery.data?.asset_id, metadataQuery.data?.tags]);
+
+  const saveTags = useMutation({
+    mutationFn: async () => {
+      if (!symbol) {
+        throw new Error("Missing asset symbol");
+      }
+
+      const assetId =
+        metadataQuery.data?.asset_id ?? `asset_${symbol.toLowerCase().replace(/[^a-z0-9]+/g, "_")}`;
+
+      return upsertAssetMetadata({
+        assetId,
+        symbol,
+        metadata: {
+          tags: draftTags,
+          category: metadataQuery.data?.category ?? null,
+          description: metadataQuery.data?.description ?? null,
+        },
+        updatedBy: USER_NAME,
+      });
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["asset-metadata", symbol] });
+    },
+  });
+
+  const pullToRefresh = usePullToRefresh({
+    enabled: true,
+    onRefresh: async () => {
+      await Promise.all([
+        health.refetch(),
+        refetchPrices(),
+        refetchLiquidity(),
+        metadataQuery.refetch(),
+      ]);
+    },
+  });
+
+  const canSaveTags = useMemo(() => {
+    const currentTags = normalizeTags(metadataQuery.data?.tags ?? []);
+    const nextTags = normalizeTags(draftTags);
+    return currentTags.join("|") !== nextTags.join("|") && (nextTags.length > 0 || Boolean(metadataQuery.data));
+  }, [draftTags, metadataQuery.data]);
+
+  const statusText = metadataQuery.isLoading
+    ? "Loading metadata"
+    : saveTags.isPending
+      ? "Saving"
+      : metadataQuery.data
+        ? "Synced"
+        : "Draft";
 
   if (!symbol) {
-    return (
-      <div className="text-stellar-text-secondary">
-        No asset symbol provided.
-      </div>
-    );
+    return <div className="text-stellar-text-secondary">No asset symbol provided.</div>;
   }
+
+  const onAddDraftTag = () => {
+    setDraftTags((current) => addDraftTags(current, tagInput));
+    setTagInput("");
+  };
+
+  const onRemoveDraftTag = (tag: string) => {
+    setDraftTags((current) => current.filter((entry) => entry !== tag));
+  };
 
   return (
     <div className="space-y-8">
-      {/* Header */}
-      <div>
+      <PullToRefresh
+        isPulling={pullToRefresh.isPulling}
+        pullDistance={pullToRefresh.pullDistance}
+        progress={pullToRefresh.progress}
+        isRefreshing={pullToRefresh.isRefreshing}
+      />
+
+      <div className="rounded-2xl border border-stellar-border bg-gradient-to-br from-stellar-card via-stellar-card to-stellar-dark/35 p-6">
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <h1 className="text-3xl font-bold text-white">{symbol}</h1>
-          <AddToWatchlistButton symbol={symbol} className="text-sm" />
+          <div>
+            <h1 className="text-3xl font-bold text-white">{symbol}</h1>
+            <p className="mt-2 text-stellar-text-secondary">
+              Detailed monitoring for {symbol} on the Stellar network
+            </p>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              onClick={() => {
+                void pullToRefresh.refresh();
+              }}
+              className="rounded-md border border-stellar-border px-4 py-2 text-sm text-white hover:bg-stellar-border"
+            >
+              Refresh views
+            </button>
+            <AddToWatchlistButton symbol={symbol} className="text-sm" />
+          </div>
         </div>
-        <p className="mt-2 text-stellar-text-secondary">
-          Detailed monitoring for {symbol} on the Stellar network
-        </p>
       </div>
 
-      {/* Health Score */}
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
         <HealthScoreCard
           symbol={symbol}
-          overallScore={null}
-          factors={null}
-          trend={null}
+          overallScore={health.data?.overallScore ?? null}
+          factors={health.data?.factors ?? null}
+          trend={health.data?.trend ?? null}
         />
-        <div className="lg:col-span-2">
+        <div className="space-y-3 lg:col-span-2">
           <TimeRangeSelector chartId={`price-${symbol}`} title="Price chart range" />
           <PriceChart
             symbol={symbol}
             data={priceData?.history ?? []}
             isLoading={priceLoading}
             chartId={`price-${symbol}`}
+            annotations={annotations.annotations}
           />
         </div>
       </div>
 
-      {/* Liquidity Depth */}
+      <ChartAnnotationPanel
+        symbol={symbol}
+        annotations={annotations.annotations}
+        defaultTimestamp={latestPriceTimestamp}
+        addAnnotation={annotations.addAnnotation}
+        updateAnnotation={annotations.updateAnnotation}
+        removeAnnotation={annotations.removeAnnotation}
+        clearAnnotations={annotations.clearAnnotations}
+        exportAnnotations={annotations.exportAnnotations}
+      />
+
       <div className="space-y-3">
         <TimeRangeSelector
           chartId={`liquidity-${symbol}`}
@@ -69,11 +218,27 @@ export default function AssetDetail() {
         />
       </div>
 
-      {/* Price Sources Table */}
+      <AssetTagsPanel
+        symbol={symbol}
+        tags={draftTags}
+        draftTagInput={tagInput}
+        onDraftTagInputChange={setTagInput}
+        onAddTag={onAddDraftTag}
+        onRemoveTag={onRemoveDraftTag}
+        onSave={() => {
+          void saveTags.mutateAsync();
+        }}
+        onReset={() => {
+          setDraftTags(normalizeTags(metadataQuery.data?.tags ?? []));
+          setTagInput("");
+        }}
+        canSave={canSaveTags}
+        isSaving={saveTags.isPending}
+        statusText={statusText}
+      />
+
       <div className="bg-stellar-card border border-stellar-border rounded-lg p-6">
-        <h3 className="text-lg font-semibold text-white mb-4">
-          Price Sources
-        </h3>
+        <h3 className="text-lg font-semibold text-white mb-4">Price Sources</h3>
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <thead>
@@ -92,27 +257,17 @@ export default function AssetDetail() {
                     price: number;
                     timestamp: string;
                   }) => (
-                    <tr
-                      key={source.source}
-                      className="border-b border-stellar-border"
-                    >
+                    <tr key={source.source} className="border-b border-stellar-border">
                       <td className="py-3 pr-4">{source.source}</td>
-                      <td className="py-3 pr-4">
-                        ${source.price.toFixed(4)}
-                      </td>
-                      <td className="py-3 pr-4 text-stellar-text-secondary">
-                        {source.timestamp}
-                      </td>
+                      <td className="py-3 pr-4">${source.price.toFixed(4)}</td>
+                      <td className="py-3 pr-4 text-stellar-text-secondary">{source.timestamp}</td>
                       <td className="py-3">--</td>
                     </tr>
                   )
                 )
               ) : (
                 <tr>
-                  <td
-                    colSpan={4}
-                    className="py-6 text-center text-stellar-text-secondary"
-                  >
+                  <td colSpan={4} className="py-6 text-center text-stellar-text-secondary">
                     No price source data available
                   </td>
                 </tr>
@@ -123,14 +278,4 @@ export default function AssetDetail() {
       </div>
     </div>
   );
-}
-
-function PriceImpactCalculatorWrapper({ symbol }: { symbol: string }) {
-  // Most assets are traded against XLM in this app
-  const pair: TradingPair = symbol === "XLM" ? "USDC/XLM" : (`${symbol}/XLM` as any);
-  const { depth, isLoading } = useLiquidity(pair);
-
-  if (isLoading && !depth) return <LoadingSpinner message="Loading liquidity data..." />;
-
-  return <PriceImpactCalculator depth={depth} />;
 }

--- a/frontend/src/pages/Bridges.tsx
+++ b/frontend/src/pages/Bridges.tsx
@@ -1,8 +1,10 @@
 import { Suspense } from "react";
 import { useBridges } from "../hooks/useBridges";
 import { useRefreshControls } from "../hooks/useRefreshControls";
+import { usePullToRefresh } from "../hooks/usePullToRefresh";
 import BridgeStatusCard from "../components/BridgeStatusCard";
 import RefreshControls from "../components/RefreshControls";
+import PullToRefresh from "../components/PullToRefresh";
 import { SkeletonCard, ErrorBoundary } from "../components/Skeleton";
 
 export default function Bridges() {
@@ -18,9 +20,20 @@ export default function Bridges() {
       : false,
     refetchOnWindowFocus: refreshControls.preferences.refreshOnFocus,
   });
+  const pullToRefresh = usePullToRefresh({
+    enabled: true,
+    onRefresh: refreshControls.refreshNow,
+  });
 
   return (
     <div className="space-y-8">
+      <PullToRefresh
+        isPulling={pullToRefresh.isPulling}
+        pullDistance={pullToRefresh.pullDistance}
+        progress={pullToRefresh.progress}
+        isRefreshing={pullToRefresh.isRefreshing}
+      />
+
       <div>
         <h1 className="text-3xl font-bold text-stellar-text-primary">Bridges</h1>
         <p className="mt-2 text-stellar-text-secondary">
@@ -43,6 +56,18 @@ export default function Bridges() {
         isRefreshing={refreshControls.isRefreshing}
         lastUpdatedAt={refreshControls.lastUpdatedAt}
       />
+
+      <div className="flex justify-end">
+        <button
+          type="button"
+          onClick={() => {
+            void pullToRefresh.refresh();
+          }}
+          className="rounded-md border border-stellar-border px-4 py-2 text-sm text-white hover:bg-stellar-border"
+        >
+          Refresh now
+        </button>
+      </div>
 
       <ErrorBoundary onRetry={() => window.location.reload()}>
         <Suspense

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -2,11 +2,14 @@ import { useMemo } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { useAssets } from "../hooks/useAssets";
 import { useBridges } from "../hooks/useBridges";
+import { usePullToRefresh } from "../hooks/usePullToRefresh";
 import HealthScoreCard from "../components/HealthScoreCard";
 import BridgeStatusCard from "../components/BridgeStatusCard";
 import AddToWatchlistButton from "../components/watchlist/AddToWatchlistButton";
 import WatchlistWidget from "../components/watchlist/WatchlistWidget";
 import ExternalDependencyPanel from "../components/dashboard/ExternalDependencyPanel";
+import PullToRefresh from "../components/PullToRefresh";
+import ComparativeSparklineGrid from "../components/analytics/ComparativeSparklineGrid";
 
 type DashboardView = "overview" | "assets" | "bridges";
 type BridgeStatusFilter = "all" | "healthy" | "degraded" | "down" | "unknown";
@@ -78,9 +81,23 @@ function useDashboardUrlState() {
 }
 
 export default function Dashboard() {
-  const { data: assetsData, isLoading: assetsLoading } = useAssets();
-  const { data: bridgesData, isLoading: bridgesLoading } = useBridges();
+  const {
+    data: assetsData,
+    isLoading: assetsLoading,
+    refetch: refetchAssets,
+  } = useAssets();
+  const {
+    data: bridgesData,
+    isLoading: bridgesLoading,
+    refetch: refetchBridges,
+  } = useBridges();
   const dashboard = useDashboardUrlState();
+  const pullToRefresh = usePullToRefresh({
+    enabled: true,
+    onRefresh: async () => {
+      await Promise.all([refetchAssets(), refetchBridges()]);
+    },
+  });
 
   const filteredBridges = useMemo(() => {
     const bridges = bridgesData?.bridges ?? [];
@@ -93,9 +110,25 @@ export default function Dashboard() {
 
   const showAssets = dashboard.state.view !== "bridges";
   const showBridges = dashboard.state.view !== "assets";
+  const sparklineItems = useMemo(
+    () =>
+      (assetsData?.assets ?? []).slice(0, 6).map((asset: { symbol: string; name?: string }) => ({
+        symbol: asset.symbol,
+        name: asset.name ?? asset.symbol,
+        period: "7d" as const,
+      })),
+    [assetsData?.assets]
+  );
 
   return (
     <div className="space-y-8">
+      <PullToRefresh
+        isPulling={pullToRefresh.isPulling}
+        pullDistance={pullToRefresh.pullDistance}
+        progress={pullToRefresh.progress}
+        isRefreshing={pullToRefresh.isRefreshing}
+      />
+
       <div className="space-y-4 rounded-2xl border border-stellar-border bg-gradient-to-br from-stellar-card via-stellar-card to-stellar-dark/40 p-6">
         <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
           <div>
@@ -106,7 +139,16 @@ export default function Dashboard() {
             </p>
           </div>
 
-          <div className="flex flex-wrap gap-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={() => {
+                void pullToRefresh.refresh();
+              }}
+              className="rounded-full border border-stellar-border px-4 py-2 text-sm text-white transition-colors hover:bg-stellar-border"
+            >
+              Refresh data
+            </button>
             {dashboardViews.map((view) => (
               <button
                 key={view.id}
@@ -148,6 +190,8 @@ export default function Dashboard() {
           </select>
         </div>
       </div>
+
+      {showAssets ? <ComparativeSparklineGrid items={sparklineItems} /> : null}
 
       {showAssets ? (
         <section>

--- a/frontend/src/pages/Transactions.tsx
+++ b/frontend/src/pages/Transactions.tsx
@@ -1,7 +1,9 @@
 import { Suspense } from "react";
 import { useRefreshControls } from "../hooks/useRefreshControls";
+import { usePullToRefresh } from "../hooks/usePullToRefresh";
 import TransactionHistory from "../components/TransactionHistory";
 import RefreshControls from "../components/RefreshControls";
+import PullToRefresh from "../components/PullToRefresh";
 import { ErrorBoundary, LoadingSpinner } from "../components/Skeleton";
 
 export default function Transactions() {
@@ -10,9 +12,20 @@ export default function Transactions() {
     targets: [{ id: "transactions", label: "Transactions", queryKey: ["transactions"] }],
     defaultIntervalMs: 30_000,
   });
+  const pullToRefresh = usePullToRefresh({
+    enabled: true,
+    onRefresh: refreshControls.refreshNow,
+  });
 
   return (
     <div className="space-y-8">
+      <PullToRefresh
+        isPulling={pullToRefresh.isPulling}
+        pullDistance={pullToRefresh.pullDistance}
+        progress={pullToRefresh.progress}
+        isRefreshing={pullToRefresh.isRefreshing}
+      />
+
       <header>
         <h1 className="text-3xl font-bold text-white">Transaction History</h1>
         <p className="mt-2 text-stellar-text-secondary">
@@ -35,6 +48,18 @@ export default function Transactions() {
         isRefreshing={refreshControls.isRefreshing}
         lastUpdatedAt={refreshControls.lastUpdatedAt}
       />
+
+      <div className="flex justify-end">
+        <button
+          type="button"
+          onClick={() => {
+            void pullToRefresh.refresh();
+          }}
+          className="rounded-md border border-stellar-border px-4 py-2 text-sm text-white hover:bg-stellar-border"
+        >
+          Refresh now
+        </button>
+      </div>
 
       <ErrorBoundary onRetry={() => window.location.reload()}>
         <Suspense

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,6 +1,7 @@
 import type {
   ApiKeyRecord,
   Asset,
+  AssetMetadata,
   AssetInfo,
   AssetWithHealth,
   Bridge,
@@ -122,6 +123,26 @@ export function getAssetPrice(symbol: string) {
 
 export function getAssetInfo(symbol: string) {
   return fetchApi<AssetInfo | null>(`/assets/${symbol}/info`);
+}
+
+export function getAssetMetadataBySymbol(symbol: string) {
+  return fetchApi<AssetMetadata>(`/metadata/symbol/${symbol}`);
+}
+
+export function upsertAssetMetadata(payload: {
+  assetId: string;
+  symbol: string;
+  metadata: {
+    category?: string | null;
+    tags?: string[];
+    description?: string | null;
+  };
+  updatedBy: string;
+}) {
+  return fetchApi<AssetMetadata>("/metadata", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
 }
 
 export function getAssetPriceHistory(symbol: string, timeframe: string) {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -148,6 +148,17 @@ export interface AssetInfo {
   sourceChain?: string;
 }
 
+export interface AssetMetadata {
+  id: string;
+  asset_id: string;
+  symbol: string;
+  category: string | null;
+  tags: string[];
+  description?: string | null;
+  updated_at?: string;
+  version?: number;
+}
+
 export interface PriceSource {
   source: string;
   price: number;


### PR DESCRIPTION
Adds a shared pull-to-refresh interaction for mobile views, a comparative sparkline grid on the dashboard, chart annotation tooling on asset detail, and backend-synced asset tag editing.

Closes #313
Closes #314
Closes #312
Closes #311