### PR TITLE
[375] Implement Retry Policy Service

### DIFF
--- a/backend/src/services/retryPolicy.service.ts
+++ b/backend/src/services/retryPolicy.service.ts
@@ -1,0 +1,90 @@
+import { config } from "../config/index.js";
+import { getMetricsService } from "../utils/metrics.js";
+
+export type RetryFailureClass = "transient" | "rate_limit" | "timeout" | "permanent";
+
+export interface RetryPolicyConfig {
+  maxRetries: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+  backoffMultiplier: number;
+  jitterRatio: number;
+}
+
+export interface RetryOperationOverride {
+  operation: string;
+  maxRetries?: number;
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+  backoffMultiplier?: number;
+  jitterRatio?: number;
+}
+
+export class RetryPolicyService {
+  private readonly metrics = getMetricsService();
+  private readonly defaults: RetryPolicyConfig;
+
+  constructor(defaults?: Partial<RetryPolicyConfig>) {
+    this.defaults = {
+      maxRetries: defaults?.maxRetries ?? Math.max(0, config.RETRY_MAX ?? 3),
+      baseDelayMs: defaults?.baseDelayMs ?? 1000,
+      maxDelayMs: defaults?.maxDelayMs ?? 60_000,
+      backoffMultiplier: defaults?.backoffMultiplier ?? 2,
+      jitterRatio: defaults?.jitterRatio ?? 0.2,
+    };
+  }
+
+  getPolicy(override?: Partial<RetryOperationOverride>): RetryPolicyConfig {
+    return {
+      maxRetries: Math.max(0, override?.maxRetries ?? this.defaults.maxRetries),
+      baseDelayMs: Math.max(1, override?.baseDelayMs ?? this.defaults.baseDelayMs),
+      maxDelayMs: Math.max(1, override?.maxDelayMs ?? this.defaults.maxDelayMs),
+      backoffMultiplier: Math.max(1, override?.backoffMultiplier ?? this.defaults.backoffMultiplier),
+      jitterRatio: Math.max(0, Math.min(1, override?.jitterRatio ?? this.defaults.jitterRatio)),
+    };
+  }
+
+  classifyFailure(error: unknown): RetryFailureClass {
+    const message = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+    if (message.includes("429") || message.includes("rate limit")) return "rate_limit";
+    if (message.includes("timeout")) return "timeout";
+    if (message.includes("validation") || message.includes("forbidden") || message.includes("unauthorized")) {
+      return "permanent";
+    }
+    return "transient";
+  }
+
+  isRetryable(error: unknown): boolean {
+    return this.classifyFailure(error) !== "permanent";
+  }
+
+  getDelayMs(attempt: number, override?: Partial<RetryOperationOverride>): number {
+    const policy = this.getPolicy(override);
+    const exponential = Math.min(
+      policy.maxDelayMs,
+      Math.floor(policy.baseDelayMs * policy.backoffMultiplier ** Math.max(0, attempt - 1)),
+    );
+    const jitterWindow = Math.floor(exponential * policy.jitterRatio);
+    const jitter = jitterWindow > 0 ? Math.floor((Math.random() * (jitterWindow * 2 + 1)) - jitterWindow) : 0;
+    return Math.max(1, exponential + jitter);
+  }
+
+  recordRetryMetric(operation: string, status: "scheduled" | "exhausted", attempt: number, failureClass: RetryFailureClass): void {
+    this.metrics.recordCustomMetric("retry_attempt_total", 1, "count", {
+      operation,
+      status,
+      attempt: String(attempt),
+      failureClass,
+    });
+  }
+
+  getBullMQBackoff(override?: Partial<RetryOperationOverride>): { type: "exponential"; delay: number } {
+    const policy = this.getPolicy(override);
+    return {
+      type: "exponential",
+      delay: policy.baseDelayMs,
+    };
+  }
+}
+
+export const retryPolicyService = new RetryPolicyService();

--- a/backend/src/services/search.service.ts
+++ b/backend/src/services/search.service.ts
@@ -619,13 +619,13 @@ export class SearchService {
     }
 
     if (filters.status) {
-      query = query.andWhereRaw("metadata::text ILIKE ?", [`%\"status\":\"${String(filters.status)}\"%`]);
+      query = query.andWhereRaw("metadata::text ILIKE ?", [`%"status":"${String(filters.status)}"%`]);
     }
     if (filters.severity) {
-      query = query.andWhereRaw("metadata::text ILIKE ?", [`%\"severity\":\"${String(filters.severity)}\"%`]);
+      query = query.andWhereRaw("metadata::text ILIKE ?", [`%"severity":"${String(filters.severity)}"%`]);
     }
     if (filters.priority) {
-      query = query.andWhereRaw("metadata::text ILIKE ?", [`%\"priority\":\"${String(filters.priority)}\"%`]);
+      query = query.andWhereRaw("metadata::text ILIKE ?", [`%"priority":"${String(filters.priority)}"%`]);
     }
 
     query = query.andWhere(function searchMatcher() {

--- a/backend/src/services/stellar/horizon.client.ts
+++ b/backend/src/services/stellar/horizon.client.ts
@@ -310,7 +310,11 @@ export class HorizonClient {
     };
 
     try {
-      const result = await withRetry(attempt, this.retries, this.retryDelayMs);
+      const result = await withRetry(attempt, this.retries, this.retryDelayMs, {
+        operation: `horizon:${label}`,
+        maxRetries: this.retries,
+        baseDelayMs: this.retryDelayMs,
+      });
       this.metrics.successfulRequests++;
       this.metrics.totalLatencyMs += Date.now() - start;
       logger.debug({ label, latencyMs: Date.now() - start }, "Horizon request succeeded");

--- a/backend/src/utils/retry.ts
+++ b/backend/src/utils/retry.ts
@@ -1,4 +1,5 @@
 import { logger } from "./logger.js";
+import { retryPolicyService, type RetryOperationOverride } from "../services/retryPolicy.service.js";
 
 /**
  * Execute a promise-returning function with retry logic and exponential backoff.
@@ -12,26 +13,37 @@ import { logger } from "./logger.js";
 export async function withRetry<T>(
     fn: () => Promise<T>,
     retries: number = 3,
-    delayMs: number = 1000
+    delayMs: number = 1000,
+    override?: Partial<RetryOperationOverride>
 ): Promise<T> {
     let lastError: Error | undefined;
+    const operation = override?.operation ?? "generic";
+    const policyOverride: Partial<RetryOperationOverride> = {
+        ...override,
+        maxRetries: retries,
+        baseDelayMs: delayMs,
+    };
 
     for (let attempt = 1; attempt <= retries + 1; attempt++) {
         try {
             return await fn();
         } catch (error) {
             lastError = error instanceof Error ? error : new Error(String(error));
+            const failureClass = retryPolicyService.classifyFailure(lastError);
+            const retryable = retryPolicyService.isRetryable(lastError);
 
-            if (attempt <= retries) {
+            if (attempt <= retries && retryable) {
+                const nextDelayMs = retryPolicyService.getDelayMs(attempt, policyOverride);
+                retryPolicyService.recordRetryMetric(operation, "scheduled", attempt, failureClass);
                 logger.warn(
-                    { attempt, maxRetries: retries, delayMs, error: lastError.message },
+                    { attempt, maxRetries: retries, delayMs: nextDelayMs, failureClass, error: lastError.message },
                     "Operation failed, retrying..."
                 );
-                await new Promise((resolve) => setTimeout(resolve, delayMs));
-                delayMs *= 2; // Exponential backoff
+                await new Promise((resolve) => setTimeout(resolve, nextDelayMs));
             }
         }
     }
 
+    retryPolicyService.recordRetryMetric(operation, "exhausted", retries + 1, retryPolicyService.classifyFailure(lastError));
     throw new Error(`Exhausted all ${retries} retries. Last error: ${lastError?.message}`);
 }

--- a/backend/src/workers/queue.ts
+++ b/backend/src/workers/queue.ts
@@ -1,6 +1,7 @@
 import { Queue, Worker, Job, ConnectionOptions } from "bullmq";
 import { config } from "../config/index.js";
 import { logger } from "../utils/logger.js";
+import { retryPolicyService } from "../services/retryPolicy.service.js";
 
 const connection: ConnectionOptions = {
   host: config.REDIS_HOST,
@@ -16,14 +17,12 @@ export class JobQueue {
   private worker: Worker | null = null;
 
   private constructor() {
+    const retryPolicy = retryPolicyService.getPolicy({ operation: "queue:default" });
     this.queue = new Queue(QUEUE_NAME, {
       connection,
       defaultJobOptions: {
-        attempts: config.RETRY_MAX || 3,
-        backoff: {
-          type: "exponential",
-          delay: 1000,
-        },
+        attempts: retryPolicy.maxRetries + 1,
+        backoff: retryPolicyService.getBullMQBackoff({ operation: "queue:default" }),
         removeOnComplete: true,
         removeOnFail: false,
       },

--- a/backend/src/workers/webhookDelivery.worker.ts
+++ b/backend/src/workers/webhookDelivery.worker.ts
@@ -3,6 +3,7 @@ import { ConnectionOptions } from "bullmq";
 import { config } from "../config/index.js";
 import { logger } from "../utils/logger.js";
 import { webhookService } from "../services/webhook.service.js";
+import { retryPolicyService } from "../services/retryPolicy.service.js";
 
 // =============================================================================
 // WEBHOOK DELIVERY WORKER
@@ -16,9 +17,12 @@ const webhookConnection: ConnectionOptions = {
   password: config.REDIS_PASSWORD,
 };
 
-// Retry delays for backoff (in ms)
-const RETRY_DELAYS = [1000, 5000, 15000, 60000, 300000, 900000, 3600000];
-const MAX_RETRY_ATTEMPTS = 7;
+const WEBHOOK_RETRY_POLICY = retryPolicyService.getPolicy({
+  operation: "webhook:delivery",
+  maxRetries: 7,
+  baseDelayMs: 1000,
+  maxDelayMs: 3_600_000,
+});
 
 let webhookWorker: Worker | null = null;
 
@@ -42,9 +46,11 @@ export async function initWebhookWorker(): Promise<void> {
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : "Unknown error";
 
-        // Calculate next retry delay
-        const delayIndex = Math.min(job.attemptsMade, RETRY_DELAYS.length - 1);
-        const delay = RETRY_DELAYS[delayIndex];
+        // Estimate next retry delay for observability.
+        const delay = retryPolicyService.getDelayMs(job.attemptsMade + 1, {
+          operation: "webhook:delivery",
+          ...WEBHOOK_RETRY_POLICY,
+        });
 
         logger.error(
           { jobId: job.id, attempt: job.attemptsMade + 1, error: errorMessage, nextRetryIn: delay },
@@ -79,7 +85,7 @@ export async function initWebhookWorker(): Promise<void> {
     const errorMessage = err.message;
 
     // Check if we've exceeded max attempts
-    if (job.attemptsMade >= MAX_RETRY_ATTEMPTS) {
+    if (job.attemptsMade >= WEBHOOK_RETRY_POLICY.maxRetries) {
       logger.error(
         { jobId: job.id, webhookEndpointId: job.data.webhookEndpointId, attempts: job.attemptsMade },
         "Webhook delivery failed permanently after max retries"


### PR DESCRIPTION
## What changed
- Added a centralized `RetryPolicyService` for retry counts, backoff, jitter, failure classification, and retry metrics.
- Updated shared `withRetry` utility to use policy-driven delay calculation and retryability checks.
- Applied centralized retry policy to BullMQ queue defaults and webhook worker behavior.
- Wired API-client retry execution to tag operation-level retry context.

## Notes
- Per-operation overrides are supported through `RetryOperationOverride`.
- Retry metrics are emitted via existing metrics service for observability.

Closes #375