### PR TITLE
[374] Build Provider Health Registry

### DIFF
--- a/backend/src/api/routes/index.ts
+++ b/backend/src/api/routes/index.ts
@@ -38,6 +38,7 @@ import { adminRotationRoutes } from "./adminRotation.js";
 import { digestSchedulerRoutes } from "./digestScheduler.js";
 import { alertSuppressionRoutes } from "./alertSuppression.js";
 import { externalDependenciesRoutes } from "./externalDependencies.routes.js";
+import { providerHealthRegistryRoutes } from "./providerHealthRegistry.routes.js";
 
 export async function registerRoutes(server: FastifyInstance) {
   server.register(assetsRoutes, { prefix: "/api/v1/assets" });
@@ -81,4 +82,5 @@ export async function registerRoutes(server: FastifyInstance) {
   server.register(digestSchedulerRoutes, { prefix: "/api/v1/digest" });
   server.register(alertSuppressionRoutes, { prefix: "/api/v1/alert-suppression" });
   server.register(externalDependenciesRoutes, { prefix: "/api/v1/external-dependencies" });
+  server.register(providerHealthRegistryRoutes, { prefix: "/api/v1/providers/health" });
 }

--- a/backend/src/api/routes/providerHealthRegistry.routes.ts
+++ b/backend/src/api/routes/providerHealthRegistry.routes.ts
@@ -1,0 +1,51 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { z } from "zod";
+import { authMiddleware } from "../middleware/auth.js";
+import { logger } from "../../utils/logger.js";
+import { providerHealthRegistryService } from "../../services/providerHealthRegistry.service.js";
+
+const overrideSchema = z.object({
+  enabled: z.boolean(),
+  note: z.string().max(500).optional().nullable(),
+});
+
+export async function providerHealthRegistryRoutes(server: FastifyInstance) {
+  server.get("/", async (_request: FastifyRequest, reply: FastifyReply) => {
+    try {
+      return await providerHealthRegistryService.listRegistry();
+    } catch (error) {
+      logger.error(error, "Failed to list provider health registry");
+      reply.code(500);
+      return { error: "Failed to list provider health registry" };
+    }
+  });
+
+  server.patch(
+    "/:providerKey/override",
+    { preHandler: authMiddleware({ requiredScopes: ["jobs:trigger"] }) },
+    async (
+      request: FastifyRequest<{ Params: { providerKey: string }; Body: z.infer<typeof overrideSchema> }>,
+      reply: FastifyReply
+    ) => {
+      try {
+        const body = overrideSchema.parse(request.body);
+        const updated = await providerHealthRegistryService.setManualOverride(
+          request.params.providerKey,
+          body.enabled,
+          body.note
+        );
+
+        if (!updated) {
+          reply.code(404);
+          return { error: "Provider not found" };
+        }
+
+        return { success: true };
+      } catch (error) {
+        logger.error(error, "Failed to update provider override");
+        reply.code(500);
+        return { success: false, error: "Failed to update provider override" };
+      }
+    }
+  );
+}

--- a/backend/src/services/providerHealthRegistry.service.ts
+++ b/backend/src/services/providerHealthRegistry.service.ts
@@ -1,0 +1,89 @@
+import { getDatabase } from "../database/connection.js";
+import { ExternalDependencyMonitorService } from "./externalDependencyMonitor.service.js";
+
+export interface ProviderHealthSnapshot {
+  providerKey: string;
+  displayName: string;
+  category: string;
+  status: string;
+  uptimeRatio24h: number;
+  avgLatencyMs24h: number | null;
+  p95LatencyMs24h: number | null;
+  failureCount24h: number;
+  manualOverride: {
+    enabled: boolean;
+    note: string | null;
+  };
+  alertState: "none" | "firing" | "suppressed";
+  lastCheckedAt: string | null;
+}
+
+export class ProviderHealthRegistryService {
+  private readonly db = getDatabase();
+  private readonly dependencies = new ExternalDependencyMonitorService();
+
+  async listRegistry(): Promise<{ providers: ProviderHealthSnapshot[]; totalProviders: number }> {
+    const { dependencies } = await this.dependencies.listDependencies();
+    const checks = await this.db("external_dependency_checks")
+      .where("checked_at", ">=", this.db.raw("now() - interval '24 hours'"))
+      .orderBy("checked_at", "desc");
+
+    const checksByProvider = new Map<string, Record<string, unknown>[]>();
+    for (const row of checks) {
+      const key = String(row.provider_key);
+      const entries = checksByProvider.get(key) ?? [];
+      entries.push(row);
+      checksByProvider.set(key, entries);
+    }
+
+    const providers = dependencies.map((provider) => {
+      const providerChecks = checksByProvider.get(provider.providerKey) ?? [];
+      const totalChecks = providerChecks.length;
+      const healthyChecks = providerChecks.filter((row) => String(row.status) === "healthy").length;
+      const failureCount = providerChecks.filter((row) => {
+        const status = String(row.status);
+        return status === "down" || status === "degraded";
+      }).length;
+      const latencySamples = providerChecks
+        .map((row) => (row.latency_ms === null || row.latency_ms === undefined ? null : Number(row.latency_ms)))
+        .filter((value): value is number => value !== null)
+        .sort((a, b) => a - b);
+
+      const avgLatencyMs24h = latencySamples.length
+        ? Math.round(latencySamples.reduce((sum, value) => sum + value, 0) / latencySamples.length)
+        : null;
+      const p95LatencyMs24h = latencySamples.length
+        ? latencySamples[Math.min(latencySamples.length - 1, Math.ceil(latencySamples.length * 0.95) - 1)]
+        : null;
+
+      return {
+        providerKey: provider.providerKey,
+        displayName: provider.displayName,
+        category: provider.category,
+        status: provider.status,
+        uptimeRatio24h: totalChecks === 0 ? 0 : Number((healthyChecks / totalChecks).toFixed(4)),
+        avgLatencyMs24h,
+        p95LatencyMs24h,
+        failureCount24h: failureCount,
+        manualOverride: {
+          enabled: provider.maintenanceMode,
+          note: provider.maintenanceNote,
+        },
+        alertState: provider.alertState,
+        lastCheckedAt: provider.lastCheckedAt,
+      } satisfies ProviderHealthSnapshot;
+    });
+
+    return {
+      providers,
+      totalProviders: providers.length,
+    };
+  }
+
+  async setManualOverride(providerKey: string, enabled: boolean, note?: string | null): Promise<boolean> {
+    const updated = await this.dependencies.setMaintenanceMode(providerKey, enabled, note ?? null);
+    return Boolean(updated);
+  }
+}
+
+export const providerHealthRegistryService = new ProviderHealthRegistryService();

--- a/backend/src/services/search.service.ts
+++ b/backend/src/services/search.service.ts
@@ -619,13 +619,13 @@ export class SearchService {
     }
 
     if (filters.status) {
-      query = query.andWhereRaw("metadata::text ILIKE ?", [`%\"status\":\"${String(filters.status)}\"%`]);
+      query = query.andWhereRaw("metadata::text ILIKE ?", [`%"status":"${String(filters.status)}"%`]);
     }
     if (filters.severity) {
-      query = query.andWhereRaw("metadata::text ILIKE ?", [`%\"severity\":\"${String(filters.severity)}\"%`]);
+      query = query.andWhereRaw("metadata::text ILIKE ?", [`%"severity":"${String(filters.severity)}"%`]);
     }
     if (filters.priority) {
-      query = query.andWhereRaw("metadata::text ILIKE ?", [`%\"priority\":\"${String(filters.priority)}\"%`]);
+      query = query.andWhereRaw("metadata::text ILIKE ?", [`%"priority":"${String(filters.priority)}"%`]);
     }
 
     query = query.andWhere(function searchMatcher() {


### PR DESCRIPTION
## What changed
- Added a `ProviderHealthRegistryService` that aggregates provider uptime, latency, failure counts, manual overrides, and alert state.
- Exposed a new registry API at `/api/v1/providers/health` for provider health snapshots.
- Added manual override endpoint at `/api/v1/providers/health/:providerKey/override` for operational controls.

## Notes
- Registry data is built from existing external dependency checks and provider metadata.
- Uptime and latency metrics are computed over a rolling 24-hour window.

Closes #374