### PR TITLE
feat: add maintenance handoff banner with severity variants and dismi…

### DIFF
--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -167,6 +167,12 @@ const envSchema = z.object({
   HEALTH_CHECK_DISK_THRESHOLD: z.coerce.number().default(80),
   HEALTH_CHECK_EXTERNAL_APIS: z.string().default("true"),
 
+  // Maintenance & Data Handoff
+  MAINTENANCE_MODE: z.coerce.boolean().default(false),
+  MAINTENANCE_MESSAGE: z.string().default("System is under maintenance"),
+  MAINTENANCE_SEVERITY: z.enum(["info", "warning", "critical"]).default("warning"),
+  STATUS_PAGE_URL: z.string().url().optional(),
+
   // Data Validation Configuration
   VALIDATION_STRICT_MODE: z.coerce.boolean().default(false),
   VALIDATION_ADMIN_BYPASS: z.coerce.boolean().default(true),

--- a/backend/src/services/healthCheck.service.ts
+++ b/backend/src/services/healthCheck.service.ts
@@ -30,6 +30,12 @@ export interface SystemHealthResponse {
     unhealthy: number;
     degraded: number;
   };
+  maintenance?: {
+    active: boolean;
+    message: string;
+    severity: "info" | "warning" | "critical";
+    statusPageUrl?: string;
+  };
 }
 
 export interface LivenessResponse {
@@ -91,6 +97,12 @@ export class HealthCheckService {
       version: process.env.npm_package_version || "0.1.0",
       checks: results,
       summary,
+      maintenance: {
+        active: config.MAINTENANCE_MODE,
+        message: config.MAINTENANCE_MESSAGE,
+        severity: config.MAINTENANCE_SEVERITY,
+        statusPageUrl: config.STATUS_PAGE_URL,
+      },
     };
   }
 

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -4,6 +4,7 @@ import Navbar from "./Navbar";
 import { Breadcrumb } from "./Breadcrumb";
 import { ComponentErrorBoundary } from "./ErrorBoundary";
 import ShortcutHelp from "./ShortcutHelp";
+import MaintenanceBanner from "./MaintenanceBanner";
 import { useKeyboardShortcuts } from "../hooks/useKeyboardShortcuts";
 
 export default function Layout() {
@@ -30,6 +31,7 @@ export default function Layout() {
   return (
     <div className="min-h-screen bg-stellar-dark">
       <Navbar />
+      <MaintenanceBanner />
       <main
         id="main-content"
         tabIndex={-1}

--- a/frontend/src/components/MaintenanceBanner.tsx
+++ b/frontend/src/components/MaintenanceBanner.tsx
@@ -1,0 +1,114 @@
+import { useQuery } from "@tanstack/react-query";
+import { useState, useEffect } from "react";
+import { getSystemStatus, type SystemStatus } from "../services/api";
+
+const DISMISSED_KEY = "maintenance-banner-dismissed";
+
+interface SeverityConfig {
+  bgColor: string;
+  borderColor: string;
+  iconColor: string;
+  icon: string;
+}
+
+const SEVERITY_CONFIG: Record<"info" | "warning" | "critical", SeverityConfig> = {
+  info: {
+    bgColor: "bg-blue-500/15",
+    borderColor: "border-blue-500/30",
+    iconColor: "text-blue-400",
+    icon: "ℹ️",
+  },
+  warning: {
+    bgColor: "bg-amber-500/15",
+    borderColor: "border-amber-500/30",
+    iconColor: "text-amber-400",
+    icon: "⚠️",
+  },
+  critical: {
+    bgColor: "bg-rose-500/15",
+    borderColor: "border-rose-500/30",
+    iconColor: "text-rose-400",
+    icon: "🔴",
+  },
+};
+
+function MaintenanceBanner() {
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(DISMISSED_KEY);
+    if (stored) {
+      const lastDismissed = parseInt(stored, 10);
+      const oneHour = 60 * 60 * 1000;
+      if (Date.now() - lastDismissed < oneHour) {
+        setDismissed(true);
+      }
+    }
+  }, []);
+
+  const { data: systemStatus } = useQuery({
+    queryKey: ["system-status"],
+    queryFn: getSystemStatus,
+    staleTime: 60_000,
+    refetchInterval: 60_000,
+    retry: 1,
+  });
+
+  const maintenance = systemStatus?.maintenance;
+
+  if (!maintenance?.active || dismissed) {
+    return null;
+  }
+
+  const config = SEVERITY_CONFIG[maintenance.severity];
+
+  const handleDismiss = () => {
+    localStorage.setItem(DISMISSED_KEY, Date.now().toString());
+    setDismissed(true);
+  };
+
+  const BannerIcon = () => (
+    <span className="text-lg" aria-hidden="true">
+      {config.icon}
+    </span>
+  );
+
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      className={`border ${config.borderColor} ${config.bgColor} rounded-lg p-4 mb-4`}
+    >
+      <div className="flex flex-col sm:flex-row sm:items-start gap-3">
+        <div className="flex items-center gap-2">
+          <BannerIcon />
+          <p className={`font-medium ${config.iconColor}`}>
+            {maintenance.message || "System is under maintenance"}
+          </p>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3 sm:ml-auto">
+          {maintenance.statusPageUrl && (
+            <a
+              href={maintenance.statusPageUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm text-stellar-text-secondary hover:text-white underline underline-offset-2"
+            >
+              View Status Page →
+            </a>
+          )}
+          <button
+            onClick={handleDismiss}
+            className="text-sm text-stellar-text-secondary hover:text-white transition-colors"
+            aria-label="Dismiss this banner for one hour"
+          >
+            Dismiss
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default MaintenanceBanner;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -57,6 +57,27 @@ export async function getServerHealth(): Promise<{ status: string; timestamp: st
   return response.json();
 }
 
+export interface SystemStatus {
+  status: "healthy" | "unhealthy" | "degraded";
+  timestamp: string;
+  uptime: number;
+  version: string;
+  maintenance?: {
+    active: boolean;
+    message: string;
+    severity: "info" | "warning" | "critical";
+    statusPageUrl?: string;
+  };
+}
+
+export async function getSystemStatus(): Promise<SystemStatus> {
+  const response = await fetch("/health/detailed");
+  if (!response.ok) {
+    throw new Error(`System status check failed: ${response.status} ${response.statusText}`);
+  }
+  return response.json();
+}
+
 // Assets
 export function getAssets() {
   return fetchApi<{ assets: Asset[]; total: number }>("/assets");


### PR DESCRIPTION
Closes #369

## Summary
Adds a maintenance/handoff banner that appears when services are in maintenance or data handoff mode.

## Changes
- `backend/src/config/index.ts` — added `MAINTENANCE_MODE`, `MAINTENANCE_MESSAGE`, `MAINTENANCE_SEVERITY`, `STATUS_PAGE_URL` config
- `backend/src/services/healthCheck.service.ts` — extended `/health/detailed` to include maintenance info
- `frontend/src/services/api.ts` — added `getSystemStatus()` and `SystemStatus` type
- `frontend/src/components/MaintenanceBanner.tsx` — banner component with 3 severity variants, 1hr dismissal, status page link, and accessible semantics
- `frontend/src/components/Layout.tsx` — banner mounted below Navbar

## Acceptance Criteria
- [x] Maintenance messaging with severity variants (info / warning / critical)
- [x] Dismissal behavior (persisted 1 hour via localStorage)
- [x] Link to status page when configured
- [x] Responsive layout
- [x] Accessible semantics (`role="alert"`, `aria-live`)

## Type of Change
- [x] New feature

## How to Test
1. Set env vars and restart backend
2. Open the frontend — banner should appear below the navbar
3. Click dismiss — banner should hide and stay hidden for 1 hour
4. Test all 3 severity variants by changing `MAINTENANCE_SEVERITY`

## Checklist
- [x] Self-reviewed my own code
- [x] No `console.log` or debug code left in
- [x] Branch is up to date with `main`