### PR TITLE
feat: backfill orchestration, aggregation windows, integrity checks, alert history search

### DIFF
--- a/backend/src/api/routes/alertHistory.routes.ts
+++ b/backend/src/api/routes/alertHistory.routes.ts
@@ -1,0 +1,52 @@
+import type { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
+import {
+  AlertHistorySearchService,
+  type RawAlertHistoryQuery,
+} from "../../services/alertHistorySearch.service.js";
+import { logger } from "../../utils/logger.js";
+
+const service = new AlertHistorySearchService();
+
+export async function alertHistoryRoutes(server: FastifyInstance) {
+  // GET / — paginated, filtered search over historical alerts.
+  server.get(
+    "/",
+    async (
+      request: FastifyRequest<{ Querystring: RawAlertHistoryQuery }>,
+      reply: FastifyReply,
+    ) => {
+      try {
+        const data = await service.search(request.query);
+        return { success: true, data };
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "Failed to search alert history";
+        logger.warn({ err: error }, "alert history search failed");
+        reply.code(400);
+        return { success: false, error: message };
+      }
+    },
+  );
+
+  // GET /export — same filters, returned as a CSV attachment.
+  server.get(
+    "/export",
+    async (
+      request: FastifyRequest<{ Querystring: RawAlertHistoryQuery }>,
+      reply: FastifyReply,
+    ) => {
+      try {
+        const csv = await service.exportCsv(request.query);
+        reply.header("Content-Type", "text/csv");
+        reply.header("Content-Disposition", 'attachment; filename="alert-history.csv"');
+        return csv;
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "Failed to export alert history";
+        logger.warn({ err: error }, "alert history export failed");
+        reply.code(400);
+        return { success: false, error: message };
+      }
+    },
+  );
+}

--- a/backend/src/api/routes/index.ts
+++ b/backend/src/api/routes/index.ts
@@ -3,6 +3,7 @@ import { assetsRoutes } from "./assets.js";
 import { bridgesRoutes } from "./bridges.js";
 import { websocketRoutes } from "./websocket.js";
 import { alertsRoutes } from "./alerts.routes.js";
+import { alertHistoryRoutes } from "./alertHistory.routes.js";
 import { exportsRoutes } from "./exports.js";
 import { circuitBreakerRoutes } from "./circuitBreaker.js";
 import { preferencesRoutes } from "./preferences.js";
@@ -47,6 +48,7 @@ export async function registerRoutes(server: FastifyInstance) {
   server.register(bridgesRoutes, { prefix: "/api/v1/bridges" });
   server.register(websocketRoutes, { prefix: "/api/v1/ws" });
   server.register(alertsRoutes, { prefix: "/api/v1/alerts" });
+  server.register(alertHistoryRoutes, { prefix: "/api/v1/alerts/search" });
   server.register(exportsRoutes, { prefix: "/api/v1/exports" });
   server.register(circuitBreakerRoutes, { prefix: "/api/v1/circuit-breaker" });
   server.register(preferencesRoutes, { prefix: "/api/v1/preferences" });

--- a/backend/src/services/aggregationWindow.ts
+++ b/backend/src/services/aggregationWindow.ts
@@ -1,0 +1,138 @@
+/**
+ * Configurable aggregation window functions for contract statistics and rollups.
+ *
+ * Pure and read-only: given a set of timestamped data points and a window
+ * configuration, these helpers bucket the points into tumbling or sliding
+ * windows and compute deterministic per-window aggregates. No I/O, no clock —
+ * the same input always yields the same output, which keeps rollups reproducible.
+ *
+ * Windows are half-open intervals `[start, end)`, so a point landing exactly on
+ * a boundary belongs to the later window (never double-counted).
+ */
+
+export type WindowType = "tumbling" | "sliding";
+
+export interface WindowConfig {
+  /** Window length in milliseconds (> 0). */
+  sizeMs: number;
+  /**
+   * Step between consecutive window starts in milliseconds (> 0). Defaults to
+   * `sizeMs` (i.e. non-overlapping tumbling windows). For sliding windows use a
+   * step smaller than `sizeMs`.
+   */
+  stepMs?: number;
+  /** Epoch origin (ms) that window boundaries align to. Defaults to 0. */
+  originMs?: number;
+}
+
+export interface DataPoint {
+  /** Unix timestamp in milliseconds. */
+  timestamp: number;
+  value: number;
+}
+
+export interface AggregatedWindow {
+  /** Inclusive window start (ms). */
+  start: number;
+  /** Exclusive window end (ms). */
+  end: number;
+  count: number;
+  sum: number;
+  min: number | null;
+  max: number | null;
+  avg: number | null;
+}
+
+function validateConfig(config: WindowConfig): Required<WindowConfig> {
+  const { sizeMs } = config;
+  const stepMs = config.stepMs ?? sizeMs;
+  const originMs = config.originMs ?? 0;
+
+  if (!Number.isFinite(sizeMs) || sizeMs <= 0) {
+    throw new Error(`aggregationWindow: sizeMs must be a positive number, got ${sizeMs}`);
+  }
+  if (!Number.isFinite(stepMs) || stepMs <= 0) {
+    throw new Error(`aggregationWindow: stepMs must be a positive number, got ${stepMs}`);
+  }
+  if (!Number.isFinite(originMs)) {
+    throw new Error(`aggregationWindow: originMs must be a finite number, got ${originMs}`);
+  }
+  return { sizeMs, stepMs, originMs };
+}
+
+/**
+ * Start (ms) of the tumbling window that contains `timestamp`, aligned to the
+ * configured origin. Exposed so callers can label points consistently.
+ */
+export function windowStartFor(timestamp: number, config: WindowConfig): number {
+  const { sizeMs, originMs } = validateConfig(config);
+  const offset = timestamp - originMs;
+  return originMs + Math.floor(offset / sizeMs) * sizeMs;
+}
+
+function aggregate(points: DataPoint[], start: number, end: number): AggregatedWindow {
+  let count = 0;
+  let sum = 0;
+  let min: number | null = null;
+  let max: number | null = null;
+  for (const p of points) {
+    if (p.timestamp >= start && p.timestamp < end) {
+      count += 1;
+      sum += p.value;
+      min = min === null || p.value < min ? p.value : min;
+      max = max === null || p.value > max ? p.value : max;
+    }
+  }
+  return { start, end, count, sum, min, max, avg: count > 0 ? sum / count : null };
+}
+
+/** Non-overlapping windows covering the span of the data, in ascending order. */
+export function aggregateTumbling(
+  points: DataPoint[],
+  config: WindowConfig,
+): AggregatedWindow[] {
+  const { sizeMs, originMs } = validateConfig(config);
+  if (points.length === 0) return [];
+
+  const timestamps = points.map((p) => p.timestamp);
+  const minTs = Math.min(...timestamps);
+  const maxTs = Math.max(...timestamps);
+
+  const firstStart = windowStartFor(minTs, { sizeMs, originMs });
+  const windows: AggregatedWindow[] = [];
+  for (let start = firstStart; start <= maxTs; start += sizeMs) {
+    windows.push(aggregate(points, start, start + sizeMs));
+  }
+  return windows;
+}
+
+/** Overlapping windows advancing by `stepMs`, in ascending order. */
+export function aggregateSliding(
+  points: DataPoint[],
+  config: WindowConfig,
+): AggregatedWindow[] {
+  const { sizeMs, stepMs, originMs } = validateConfig(config);
+  if (points.length === 0) return [];
+
+  const timestamps = points.map((p) => p.timestamp);
+  const minTs = Math.min(...timestamps);
+  const maxTs = Math.max(...timestamps);
+
+  const firstStart = windowStartFor(minTs, { sizeMs, originMs });
+  const windows: AggregatedWindow[] = [];
+  for (let start = firstStart; start <= maxTs; start += stepMs) {
+    windows.push(aggregate(points, start, start + sizeMs));
+  }
+  return windows;
+}
+
+/** Dispatch to the tumbling or sliding aggregator. */
+export function aggregateWindows(
+  points: DataPoint[],
+  type: WindowType,
+  config: WindowConfig,
+): AggregatedWindow[] {
+  return type === "sliding"
+    ? aggregateSliding(points, config)
+    : aggregateTumbling(points, config);
+}

--- a/backend/src/services/alertHistorySearch.service.ts
+++ b/backend/src/services/alertHistorySearch.service.ts
@@ -1,0 +1,169 @@
+import type { Knex } from "knex";
+import { getDatabase } from "../database/connection.js";
+
+/**
+ * Search and filtering over historical alert events (`alert_events`) so
+ * operators can investigate prior incidents: time-range, severity, source and
+ * alert-type filters, full-text matching, pagination and CSV export.
+ *
+ * Query normalisation and CSV serialisation are pure exported helpers so they
+ * can be unit-tested without a database.
+ */
+
+export interface RawAlertHistoryQuery {
+  from?: string;
+  to?: string;
+  /** Severity == alert priority. Accepts a single value or comma list/array. */
+  severity?: string | string[];
+  /** Source == asset code. Accepts a single value or comma list/array. */
+  source?: string | string[];
+  alertType?: string | string[];
+  /** Full-text term matched against alert_type / metric / asset_code. */
+  q?: string;
+  page?: number | string;
+  pageSize?: number | string;
+}
+
+export interface AlertHistoryQuery {
+  from?: Date;
+  to?: Date;
+  severities: string[];
+  sources: string[];
+  alertTypes: string[];
+  text?: string;
+  page: number;
+  pageSize: number;
+}
+
+export interface AlertHistoryPage {
+  results: Record<string, unknown>[];
+  total: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+}
+
+export const MAX_PAGE_SIZE = 500;
+const DEFAULT_PAGE_SIZE = 50;
+const EXPORT_CAP = 10_000;
+
+function toArray(value: string | string[] | undefined): string[] {
+  if (value === undefined) return [];
+  const raw = Array.isArray(value) ? value : value.split(",");
+  return raw.map((v) => v.trim()).filter((v) => v.length > 0);
+}
+
+function parseDate(label: string, value: string | undefined): Date | undefined {
+  if (value === undefined || value === "") return undefined;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`alertHistory: ${label} is not a valid date: "${value}"`);
+  }
+  return date;
+}
+
+function toPositiveInt(label: string, value: number | string | undefined, fallback: number): number {
+  if (value === undefined || value === "") return fallback;
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isInteger(n) || n < 1) {
+    throw new Error(`alertHistory: ${label} must be a positive integer, got "${value}"`);
+  }
+  return n;
+}
+
+/** Validate + normalise raw request query into a typed, defaulted query. */
+export function normalizeAlertHistoryQuery(raw: RawAlertHistoryQuery): AlertHistoryQuery {
+  const from = parseDate("from", raw.from);
+  const to = parseDate("to", raw.to);
+  if (from && to && from > to) {
+    throw new Error("alertHistory: 'from' must be before or equal to 'to'");
+  }
+  const text = raw.q?.trim();
+  return {
+    from,
+    to,
+    severities: toArray(raw.severity),
+    sources: toArray(raw.source),
+    alertTypes: toArray(raw.alertType),
+    text: text && text.length > 0 ? text : undefined,
+    page: toPositiveInt("page", raw.page, 1),
+    pageSize: Math.min(toPositiveInt("pageSize", raw.pageSize, DEFAULT_PAGE_SIZE), MAX_PAGE_SIZE),
+  };
+}
+
+const CSV_COLUMNS = [
+  "time",
+  "rule_id",
+  "asset_code",
+  "alert_type",
+  "priority",
+  "metric",
+  "triggered_value",
+  "threshold",
+] as const;
+
+function csvEscape(value: unknown): string {
+  const s = value === null || value === undefined ? "" : String(value);
+  return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+}
+
+/** Serialise alert event rows to CSV with a stable column order and escaping. */
+export function alertEventsToCsv(rows: Record<string, unknown>[]): string {
+  const header = CSV_COLUMNS.join(",");
+  const lines = rows.map((row) => CSV_COLUMNS.map((col) => csvEscape(row[col])).join(","));
+  return [header, ...lines].join("\n");
+}
+
+export class AlertHistorySearchService {
+  private readonly db: Knex = getDatabase();
+
+  private applyFilters(qb: Knex.QueryBuilder, q: AlertHistoryQuery): Knex.QueryBuilder {
+    if (q.from) qb.where("time", ">=", q.from);
+    if (q.to) qb.where("time", "<=", q.to);
+    if (q.severities.length) qb.whereIn("priority", q.severities);
+    if (q.sources.length) qb.whereIn("asset_code", q.sources);
+    if (q.alertTypes.length) qb.whereIn("alert_type", q.alertTypes);
+    if (q.text) {
+      const like = `%${q.text}%`;
+      qb.where((b) =>
+        b
+          .whereILike("alert_type", like)
+          .orWhereILike("metric", like)
+          .orWhereILike("asset_code", like),
+      );
+    }
+    return qb;
+  }
+
+  /** Paginated search over alert history, newest first. */
+  async search(raw: RawAlertHistoryQuery): Promise<AlertHistoryPage> {
+    const q = normalizeAlertHistoryQuery(raw);
+
+    const countRow = await this.applyFilters(this.db("alert_events"), q).count<{ count: string }[]>(
+      "* as count",
+    );
+    const total = Number(countRow[0]?.count ?? 0);
+
+    const results = await this.applyFilters(this.db("alert_events"), q)
+      .orderBy("time", "desc")
+      .limit(q.pageSize)
+      .offset((q.page - 1) * q.pageSize);
+
+    return {
+      results,
+      total,
+      page: q.page,
+      pageSize: q.pageSize,
+      totalPages: total === 0 ? 0 : Math.ceil(total / q.pageSize),
+    };
+  }
+
+  /** Export matching alert history as CSV (capped to avoid unbounded exports). */
+  async exportCsv(raw: RawAlertHistoryQuery): Promise<string> {
+    const q = normalizeAlertHistoryQuery(raw);
+    const rows = await this.applyFilters(this.db("alert_events"), q)
+      .orderBy("time", "desc")
+      .limit(EXPORT_CAP);
+    return alertEventsToCsv(rows as Record<string, unknown>[]);
+  }
+}

--- a/backend/src/services/backfillOrchestrator.ts
+++ b/backend/src/services/backfillOrchestrator.ts
@@ -1,0 +1,172 @@
+/**
+ * Backfill orchestration: drive large historical backfills without overwhelming
+ * upstream providers or local infrastructure.
+ *
+ * The orchestrator is transport-agnostic — the caller injects a `processChunk`
+ * worker (which hits Horizon, the DB, etc.) and the orchestrator handles
+ * chunking, a concurrency limit, per-chunk retries with error recovery, resume
+ * from already-completed chunks, a rate-limit delay between dispatches, and
+ * progress/audit events. `sleep` is injectable so the logic is fully unit-testable.
+ */
+
+export interface BackfillChunk {
+  index: number;
+  /** Inclusive lower bound of the chunk (ledger / block / timestamp). */
+  from: number;
+  /** Exclusive upper bound of the chunk. */
+  to: number;
+}
+
+export interface BackfillJobConfig {
+  /** Inclusive start of the overall range to backfill. */
+  rangeStart: number;
+  /** Exclusive end of the overall range to backfill. */
+  rangeEnd: number;
+  /** Size of each chunk in range units (> 0). */
+  chunkSize: number;
+  /** Max chunks processed concurrently (>= 1). Default 1. */
+  concurrency?: number;
+  /** Retries attempted after the first failure, per chunk. Default 3. */
+  maxRetries?: number;
+  /** Delay (ms) before dispatching each chunk, to respect provider limits. Default 0. */
+  minDelayMs?: number;
+  /** Chunk indexes already completed in a previous run (resume support). */
+  completedChunks?: number[];
+}
+
+export interface BackfillProgress {
+  total: number;
+  completed: number;
+  failed: number;
+  inFlight: number;
+  percent: number;
+}
+
+export type BackfillEvent =
+  | { type: "chunk-start"; chunk: BackfillChunk; attempt: number }
+  | { type: "chunk-success"; chunk: BackfillChunk }
+  | { type: "chunk-error"; chunk: BackfillChunk; attempt: number; error: string }
+  | { type: "chunk-failed"; chunk: BackfillChunk; error: string }
+  | { type: "progress"; progress: BackfillProgress };
+
+export interface BackfillDeps {
+  /** Processes a single chunk; throw to signal a retryable failure. */
+  processChunk: (chunk: BackfillChunk) => Promise<void>;
+  /** Audit / progress sink. */
+  onEvent?: (event: BackfillEvent) => void;
+  /** Injectable sleep (defaults to setTimeout) for rate limiting + tests. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export interface BackfillResult {
+  completedChunks: number[];
+  failedChunks: number[];
+  total: number;
+}
+
+function validate(config: BackfillJobConfig): void {
+  if (!Number.isFinite(config.rangeStart) || !Number.isFinite(config.rangeEnd)) {
+    throw new Error("backfill: rangeStart and rangeEnd must be finite numbers");
+  }
+  if (config.rangeEnd <= config.rangeStart) {
+    throw new Error("backfill: rangeEnd must be greater than rangeStart");
+  }
+  if (!Number.isFinite(config.chunkSize) || config.chunkSize <= 0) {
+    throw new Error(`backfill: chunkSize must be a positive number, got ${config.chunkSize}`);
+  }
+  if (config.concurrency !== undefined && config.concurrency < 1) {
+    throw new Error(`backfill: concurrency must be >= 1, got ${config.concurrency}`);
+  }
+}
+
+/** Split the configured range into ordered, non-overlapping chunks. */
+export function planChunks(config: BackfillJobConfig): BackfillChunk[] {
+  validate(config);
+  const { rangeStart, rangeEnd, chunkSize } = config;
+  const chunks: BackfillChunk[] = [];
+  let index = 0;
+  for (let from = rangeStart; from < rangeEnd; from += chunkSize) {
+    chunks.push({ index, from, to: Math.min(from + chunkSize, rangeEnd) });
+    index += 1;
+  }
+  return chunks;
+}
+
+/**
+ * Run a backfill. Resolves once every chunk has either succeeded or exhausted
+ * its retries. Chunks already in `completedChunks` are skipped (resume).
+ */
+export async function runBackfill(
+  config: BackfillJobConfig,
+  deps: BackfillDeps,
+): Promise<BackfillResult> {
+  const concurrency = config.concurrency ?? 1;
+  const maxRetries = config.maxRetries ?? 3;
+  const minDelayMs = config.minDelayMs ?? 0;
+  const sleep = deps.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+
+  const allChunks = planChunks(config);
+  const done = new Set<number>(config.completedChunks ?? []);
+  const pending = allChunks.filter((c) => !done.has(c.index));
+
+  const completed: number[] = [...(config.completedChunks ?? [])];
+  const failed: number[] = [];
+  let inFlight = 0;
+
+  const emitProgress = () => {
+    const settled = completed.length + failed.length;
+    deps.onEvent?.({
+      type: "progress",
+      progress: {
+        total: allChunks.length,
+        completed: completed.length,
+        failed: failed.length,
+        inFlight,
+        percent: allChunks.length === 0 ? 100 : Math.round((settled / allChunks.length) * 100),
+      },
+    });
+  };
+
+  async function processOne(chunk: BackfillChunk): Promise<void> {
+    inFlight += 1;
+    let attempt = 0;
+    for (;;) {
+      attempt += 1;
+      deps.onEvent?.({ type: "chunk-start", chunk, attempt });
+      try {
+        await deps.processChunk(chunk);
+        deps.onEvent?.({ type: "chunk-success", chunk });
+        completed.push(chunk.index);
+        break;
+      } catch (err) {
+        const error = err instanceof Error ? err.message : String(err);
+        deps.onEvent?.({ type: "chunk-error", chunk, attempt, error });
+        if (attempt > maxRetries) {
+          deps.onEvent?.({ type: "chunk-failed", chunk, error });
+          failed.push(chunk.index);
+          break;
+        }
+      }
+    }
+    inFlight -= 1;
+    emitProgress();
+  }
+
+  // Ordered dispatch (ascending index = priority) across a fixed worker pool,
+  // with a rate-limit delay before each chunk is picked up.
+  let cursor = 0;
+  async function worker(): Promise<void> {
+    while (cursor < pending.length) {
+      const chunk = pending[cursor++];
+      if (minDelayMs > 0) await sleep(minDelayMs);
+      await processOne(chunk);
+    }
+  }
+
+  const poolSize = Math.max(1, Math.min(concurrency, pending.length || 1));
+  await Promise.all(Array.from({ length: poolSize }, () => worker()));
+
+  completed.sort((a, b) => a - b);
+  failed.sort((a, b) => a - b);
+  return { completedChunks: completed, failedChunks: failed, total: allChunks.length };
+}

--- a/backend/src/services/stateIntegrity.ts
+++ b/backend/src/services/stateIntegrity.ts
@@ -1,0 +1,120 @@
+/**
+ * State integrity checks for stored contract/bridge reserve data.
+ *
+ * Read-only, pure helpers that verify a captured reserve snapshot is internally
+ * consistent (supply = reserve + circulating, balances reconcile, no negative
+ * amounts, …). They never touch the chain or the DB themselves; a caller passes
+ * in a snapshot and gets back a structured report with clear, actionable
+ * messages. An optional `onViolation` hook fires per violation so monitors can
+ * raise alerts as broken state is detected.
+ */
+
+export interface IntegrityViolation {
+  /** Stable machine-readable code, e.g. "CIRCULATING_MISMATCH". */
+  code: string;
+  /** Human-readable explanation of what invariant was broken. */
+  message: string;
+  context?: Record<string, string>;
+}
+
+export interface IntegrityReport {
+  ok: boolean;
+  violations: IntegrityViolation[];
+}
+
+export interface IntegrityCheckOptions {
+  /** Called once for each violation as it is detected (event hook). */
+  onViolation?: (violation: IntegrityViolation) => void;
+}
+
+export interface HolderBalance {
+  address: string;
+  balance: bigint;
+}
+
+export interface ReserveStateSnapshot {
+  assetCode: string;
+  /** Total units ever issued (base units / stroops). */
+  totalSupply: bigint;
+  /** Units locked in the bridge reserve. */
+  lockedReserve: bigint;
+  /** Circulating supply the contract reports. */
+  reportedCirculating: bigint;
+  /** Optional per-holder balances; when present they must sum to circulating. */
+  holderBalances?: HolderBalance[];
+}
+
+/**
+ * Validate the key invariants of a reserve snapshot. Returns `{ ok, violations }`;
+ * `ok` is true only when no invariant is broken.
+ */
+export function checkReserveIntegrity(
+  snapshot: ReserveStateSnapshot,
+  options: IntegrityCheckOptions = {},
+): IntegrityReport {
+  const violations: IntegrityViolation[] = [];
+  const add = (code: string, message: string, context?: Record<string, string>) => {
+    const violation: IntegrityViolation = { code, message, context };
+    violations.push(violation);
+    options.onViolation?.(violation);
+  };
+
+  const { assetCode, totalSupply, lockedReserve, reportedCirculating } = snapshot;
+  const ctx = { assetCode };
+
+  if (totalSupply < 0n) {
+    add("NEGATIVE_SUPPLY", `${assetCode}: total supply is negative (${totalSupply})`, ctx);
+  }
+  if (lockedReserve < 0n) {
+    add("NEGATIVE_RESERVE", `${assetCode}: locked reserve is negative (${lockedReserve})`, ctx);
+  }
+  if (reportedCirculating < 0n) {
+    add("NEGATIVE_CIRCULATING", `${assetCode}: circulating supply is negative (${reportedCirculating})`, ctx);
+  }
+  if (lockedReserve > totalSupply) {
+    add(
+      "RESERVE_EXCEEDS_SUPPLY",
+      `${assetCode}: locked reserve (${lockedReserve}) exceeds total supply (${totalSupply})`,
+      ctx,
+    );
+  }
+
+  const expectedCirculating = totalSupply - lockedReserve;
+  if (reportedCirculating !== expectedCirculating) {
+    add(
+      "CIRCULATING_MISMATCH",
+      `${assetCode}: reported circulating (${reportedCirculating}) != supply - reserve (${expectedCirculating})`,
+      ctx,
+    );
+  }
+
+  if (snapshot.holderBalances) {
+    const seen = new Set<string>();
+    let holderSum = 0n;
+    for (const holder of snapshot.holderBalances) {
+      if (seen.has(holder.address)) {
+        add("DUPLICATE_HOLDER", `${assetCode}: holder ${holder.address} appears more than once`, {
+          ...ctx,
+          address: holder.address,
+        });
+      }
+      seen.add(holder.address);
+      if (holder.balance < 0n) {
+        add("NEGATIVE_HOLDER_BALANCE", `${assetCode}: holder ${holder.address} has negative balance (${holder.balance})`, {
+          ...ctx,
+          address: holder.address,
+        });
+      }
+      holderSum += holder.balance;
+    }
+    if (holderSum !== reportedCirculating) {
+      add(
+        "HOLDER_SUM_MISMATCH",
+        `${assetCode}: holder balances sum to ${holderSum} but circulating is ${reportedCirculating}`,
+        ctx,
+      );
+    }
+  }
+
+  return { ok: violations.length === 0, violations };
+}

--- a/backend/tests/services/aggregationWindow.test.ts
+++ b/backend/tests/services/aggregationWindow.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import {
+  windowStartFor,
+  aggregateTumbling,
+  aggregateSliding,
+  aggregateWindows,
+  type DataPoint,
+} from "../../src/services/aggregationWindow.js";
+
+const points: DataPoint[] = [
+  { timestamp: 0, value: 10 },
+  { timestamp: 500, value: 20 },
+  { timestamp: 1000, value: 30 }, // boundary → next window
+  { timestamp: 1500, value: 40 },
+  { timestamp: 2500, value: 50 }, // gap leaves window [2000,3000) with only this
+];
+
+describe("aggregationWindow", () => {
+  it("aligns window starts to the origin and floors deterministically", () => {
+    expect(windowStartFor(1499, { sizeMs: 1000 })).toBe(1000);
+    expect(windowStartFor(1000, { sizeMs: 1000 })).toBe(1000);
+    expect(windowStartFor(1700, { sizeMs: 1000, originMs: 200 })).toBe(1200);
+  });
+
+  it("buckets points into tumbling windows with half-open boundaries", () => {
+    const windows = aggregateTumbling(points, { sizeMs: 1000 });
+    expect(windows.map((w) => [w.start, w.end, w.count])).toEqual([
+      [0, 1000, 2],
+      [1000, 2000, 2],
+      [2000, 3000, 1],
+    ]);
+    expect(windows[0]).toMatchObject({ sum: 30, min: 10, max: 20, avg: 15 });
+    expect(windows[2]).toMatchObject({ sum: 50, min: 50, max: 50, avg: 50 });
+  });
+
+  it("produces overlapping sliding windows that advance by stepMs", () => {
+    const windows = aggregateSliding(points, { sizeMs: 1000, stepMs: 500 });
+    // First window covers [0,1000): the two sub-second points.
+    expect(windows[0]).toMatchObject({ start: 0, end: 1000, count: 2, sum: 30 });
+    // Second window covers [500,1500): the 500 and 1000 points.
+    expect(windows[1]).toMatchObject({ start: 500, end: 1500, count: 2, sum: 50 });
+    expect(windows.length).toBeGreaterThan(aggregateTumbling(points, { sizeMs: 1000 }).length);
+  });
+
+  it("returns an empty array for no points and dispatches by type", () => {
+    expect(aggregateWindows([], "tumbling", { sizeMs: 1000 })).toEqual([]);
+    expect(aggregateWindows(points, "sliding", { sizeMs: 1000, stepMs: 500 })[0].count).toBe(2);
+  });
+
+  it("validates the window configuration", () => {
+    expect(() => aggregateTumbling(points, { sizeMs: 0 })).toThrow(/sizeMs/);
+    expect(() => aggregateSliding(points, { sizeMs: 1000, stepMs: -1 })).toThrow(/stepMs/);
+  });
+});

--- a/backend/tests/services/alertHistorySearch.test.ts
+++ b/backend/tests/services/alertHistorySearch.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import {
+  normalizeAlertHistoryQuery,
+  alertEventsToCsv,
+  MAX_PAGE_SIZE,
+} from "../../src/services/alertHistorySearch.service.js";
+
+describe("normalizeAlertHistoryQuery", () => {
+  it("applies defaults for an empty query", () => {
+    const q = normalizeAlertHistoryQuery({});
+    expect(q).toMatchObject({ severities: [], sources: [], alertTypes: [], page: 1, pageSize: 50 });
+    expect(q.from).toBeUndefined();
+    expect(q.text).toBeUndefined();
+  });
+
+  it("parses comma lists and arrays for filters", () => {
+    const q = normalizeAlertHistoryQuery({ severity: "high,critical", source: ["USDC", "EURC"] });
+    expect(q.severities).toEqual(["high", "critical"]);
+    expect(q.sources).toEqual(["USDC", "EURC"]);
+  });
+
+  it("parses dates and trims the full-text term", () => {
+    const q = normalizeAlertHistoryQuery({ from: "2026-01-01", to: "2026-02-01", q: "  depeg  " });
+    expect(q.from?.toISOString()).toContain("2026-01-01");
+    expect(q.text).toBe("depeg");
+  });
+
+  it("clamps pageSize to the maximum", () => {
+    expect(normalizeAlertHistoryQuery({ pageSize: 10_000 }).pageSize).toBe(MAX_PAGE_SIZE);
+  });
+
+  it("rejects invalid dates, ranges and pagination", () => {
+    expect(() => normalizeAlertHistoryQuery({ from: "not-a-date" })).toThrow(/from/);
+    expect(() => normalizeAlertHistoryQuery({ from: "2026-02-01", to: "2026-01-01" })).toThrow(/before/);
+    expect(() => normalizeAlertHistoryQuery({ page: 0 })).toThrow(/page/);
+  });
+});
+
+describe("alertEventsToCsv", () => {
+  it("emits a header and a row per event", () => {
+    const csv = alertEventsToCsv([
+      {
+        time: "2026-01-01T00:00:00Z",
+        rule_id: "r1",
+        asset_code: "USDC",
+        alert_type: "depeg",
+        priority: "high",
+        metric: "price",
+        triggered_value: "0.95",
+        threshold: "0.98",
+      },
+    ]);
+    const [header, row] = csv.split("\n");
+    expect(header).toBe("time,rule_id,asset_code,alert_type,priority,metric,triggered_value,threshold");
+    expect(row).toContain("USDC");
+    expect(row).toContain("depeg");
+  });
+
+  it("escapes values containing commas or quotes", () => {
+    const csv = alertEventsToCsv([{ asset_code: "A,B", metric: 'say "hi"' }]);
+    const row = csv.split("\n")[1];
+    expect(row).toContain('"A,B"');
+    expect(row).toContain('"say ""hi"""');
+  });
+});

--- a/backend/tests/services/backfillOrchestrator.test.ts
+++ b/backend/tests/services/backfillOrchestrator.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  planChunks,
+  runBackfill,
+  type BackfillChunk,
+  type BackfillEvent,
+} from "../../src/services/backfillOrchestrator.js";
+
+const noSleep = () => Promise.resolve();
+
+describe("planChunks", () => {
+  it("splits the range into ordered chunks and clamps the last one", () => {
+    expect(planChunks({ rangeStart: 0, rangeEnd: 250, chunkSize: 100 })).toEqual([
+      { index: 0, from: 0, to: 100 },
+      { index: 1, from: 100, to: 200 },
+      { index: 2, from: 200, to: 250 },
+    ]);
+  });
+
+  it("validates the range and chunk size", () => {
+    expect(() => planChunks({ rangeStart: 10, rangeEnd: 5, chunkSize: 1 })).toThrow(/rangeEnd/);
+    expect(() => planChunks({ rangeStart: 0, rangeEnd: 5, chunkSize: 0 })).toThrow(/chunkSize/);
+  });
+});
+
+describe("runBackfill", () => {
+  it("processes every chunk and reports completion", async () => {
+    const processed: number[] = [];
+    const result = await runBackfill(
+      { rangeStart: 0, rangeEnd: 300, chunkSize: 100, concurrency: 2 },
+      { processChunk: async (c) => void processed.push(c.index), sleep: noSleep },
+    );
+    expect(result.completedChunks).toEqual([0, 1, 2]);
+    expect(result.failedChunks).toEqual([]);
+    expect(processed.sort()).toEqual([0, 1, 2]);
+  });
+
+  it("skips already-completed chunks (resume support)", async () => {
+    const processChunk = vi.fn(async () => {});
+    const result = await runBackfill(
+      { rangeStart: 0, rangeEnd: 300, chunkSize: 100, completedChunks: [0] },
+      { processChunk, sleep: noSleep },
+    );
+    expect(processChunk).toHaveBeenCalledTimes(2); // chunks 1 and 2 only
+    expect(result.completedChunks).toEqual([0, 1, 2]);
+  });
+
+  it("retries a transient failure then succeeds", async () => {
+    let attempts = 0;
+    const result = await runBackfill(
+      { rangeStart: 0, rangeEnd: 100, chunkSize: 100, maxRetries: 2 },
+      {
+        processChunk: async () => {
+          attempts += 1;
+          if (attempts < 2) throw new Error("flaky provider");
+        },
+        sleep: noSleep,
+      },
+    );
+    expect(attempts).toBe(2);
+    expect(result.completedChunks).toEqual([0]);
+    expect(result.failedChunks).toEqual([]);
+  });
+
+  it("gives up after maxRetries and records the chunk as failed", async () => {
+    const events: BackfillEvent[] = [];
+    const result = await runBackfill(
+      { rangeStart: 0, rangeEnd: 100, chunkSize: 100, maxRetries: 1 },
+      {
+        processChunk: async () => {
+          throw new Error("permanent");
+        },
+        sleep: noSleep,
+        onEvent: (e) => events.push(e),
+      },
+    );
+    expect(result.failedChunks).toEqual([0]);
+    expect(events.some((e) => e.type === "chunk-failed")).toBe(true);
+    // 1 initial attempt + 1 retry = 2 chunk-start events
+    expect(events.filter((e) => e.type === "chunk-start").length).toBe(2);
+  });
+
+  it("never exceeds the concurrency limit", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    await runBackfill(
+      { rangeStart: 0, rangeEnd: 1000, chunkSize: 100, concurrency: 3 },
+      {
+        processChunk: async () => {
+          inFlight += 1;
+          maxInFlight = Math.max(maxInFlight, inFlight);
+          await Promise.resolve();
+          inFlight -= 1;
+        },
+        sleep: noSleep,
+      },
+    );
+    expect(maxInFlight).toBeLessThanOrEqual(3);
+  });
+
+  it("applies the rate-limit delay before dispatching chunks", async () => {
+    const sleep = vi.fn(async () => {});
+    await runBackfill(
+      { rangeStart: 0, rangeEnd: 200, chunkSize: 100, minDelayMs: 50 },
+      { processChunk: async () => {}, sleep },
+    );
+    expect(sleep).toHaveBeenCalledWith(50);
+  });
+});

--- a/backend/tests/services/stateIntegrity.test.ts
+++ b/backend/tests/services/stateIntegrity.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  checkReserveIntegrity,
+  type ReserveStateSnapshot,
+} from "../../src/services/stateIntegrity.js";
+
+const consistent: ReserveStateSnapshot = {
+  assetCode: "USDC",
+  totalSupply: 1000n,
+  lockedReserve: 400n,
+  reportedCirculating: 600n,
+  holderBalances: [
+    { address: "GA...1", balance: 250n },
+    { address: "GA...2", balance: 350n },
+  ],
+};
+
+describe("checkReserveIntegrity", () => {
+  it("reports ok for an internally consistent snapshot", () => {
+    const report = checkReserveIntegrity(consistent);
+    expect(report.ok).toBe(true);
+    expect(report.violations).toEqual([]);
+  });
+
+  it("detects a circulating-vs-(supply-reserve) mismatch", () => {
+    const report = checkReserveIntegrity({ ...consistent, reportedCirculating: 590n, holderBalances: undefined });
+    expect(report.ok).toBe(false);
+    expect(report.violations.map((v) => v.code)).toContain("CIRCULATING_MISMATCH");
+  });
+
+  it("flags reserve exceeding supply and negative amounts", () => {
+    const report = checkReserveIntegrity({
+      assetCode: "EURC",
+      totalSupply: 100n,
+      lockedReserve: 150n,
+      reportedCirculating: -50n,
+    });
+    const codes = report.violations.map((v) => v.code);
+    expect(codes).toContain("RESERVE_EXCEEDS_SUPPLY");
+    expect(codes).toContain("NEGATIVE_CIRCULATING");
+  });
+
+  it("reconciles holder balances and detects duplicates", () => {
+    const report = checkReserveIntegrity({
+      ...consistent,
+      holderBalances: [
+        { address: "GA...1", balance: 250n },
+        { address: "GA...1", balance: 300n }, // duplicate address AND sums to 550 != 600
+      ],
+    });
+    const codes = report.violations.map((v) => v.code);
+    expect(codes).toContain("DUPLICATE_HOLDER");
+    expect(codes).toContain("HOLDER_SUM_MISMATCH");
+  });
+
+  it("invokes the onViolation event hook for each violation", () => {
+    const onViolation = vi.fn();
+    checkReserveIntegrity(
+      { assetCode: "X", totalSupply: -1n, lockedReserve: 0n, reportedCirculating: 0n },
+      { onViolation },
+    );
+    expect(onViolation).toHaveBeenCalled();
+    expect(onViolation.mock.calls[0][0]).toHaveProperty("code", "NEGATIVE_SUPPLY");
+  });
+});


### PR DESCRIPTION
## Summary

Four backend features, each self-contained and unit-tested, bundled into one PR.

- **#297 — Backfill Orchestration Service** (`backend/src/services/backfillOrchestrator.ts`). A transport-agnostic orchestrator: `planChunks()` splits a range into ordered, boundary-clamped chunks; `runBackfill()` drives them through a fixed-size **concurrency** pool with **per-chunk retries + error recovery**, **resume** (skips `completedChunks`), a **rate-limit delay** between dispatches, and **progress/audit** events. The chunk worker and `sleep` are injected, so it's fully testable.
- **#386 — Aggregation Window Functions** (`backend/src/services/aggregationWindow.ts`). Configurable **tumbling** and **sliding** windows for contract stats/rollups. Pure and **deterministic**, half-open `[start, end)` **boundary handling**, origin alignment, and config **validation**. `windowStartFor` / `aggregateTumbling` / `aggregateSliding` / `aggregateWindows`.
- **#388 — State Integrity Checks** (`backend/src/services/stateIntegrity.ts`). Read-only `checkReserveIntegrity()` verifying reserve invariants (supply = reserve + circulating, no negative amounts, reserve ≤ supply, holder balances reconcile, no duplicate holders). Returns a structured `{ ok, violations }` report with clear messages and a per-violation **event hook**.
- **#402 — Alert History Search** (`backend/src/services/alertHistorySearch.service.ts` + `backend/src/api/routes/alertHistory.routes.ts`). Search/filter over `alert_events` by **time range, severity (priority), source (asset), alert type, and full-text**, with **pagination** and **CSV export**. Exposed at `GET /api/v1/alerts/search` and `GET /api/v1/alerts/search/export`. Query normalisation and CSV serialisation are pure, unit-tested helpers.

## Test plan

- [x] `vitest run` for the four new suites — **25 tests pass** (`backend/tests/services/{aggregationWindow,stateIntegrity,backfillOrchestrator,alertHistorySearch}.test.ts`)
- [x] `tsc --noEmit` — **no type errors in any of the new files**
- [x] New route registered behind a non-colliding prefix (`/api/v1/alerts/search`), distinct from the existing basic `/api/v1/alerts/history` listing

## Notes

- I deliberately added the rich search under `/alerts/search` because `/alerts/history` already exists as a simple page/limit listing — the two are complementary and registering on `/history` would have collided.
- The DB-touching parts of #402 are verified by type-check; the surrounding pure logic (filter normalisation, CSV) is covered by unit tests.

## Pre-existing issues (not introduced by this PR)

`tsc --noEmit` reports 151 errors on `main`, all in files I did not touch — 150 in `src/services/email.service.ts` and 1 in `src/api/routes/schemaDrift.ts`. Left out of scope.

Closes #297
Closes #386
Closes #388
Closes #402