### PR TITLE
feat: release notes, notification preferences, relationship explorer, status subscriptions

### DIFF
--- a/backend/src/api/routes/index.ts
+++ b/backend/src/api/routes/index.ts
@@ -42,6 +42,7 @@ import { alertSuppressionRoutes } from "./alertSuppression.js";
 import { externalDependenciesRoutes } from "./externalDependencies.routes.js";
 import { providerHealthRegistryRoutes } from "./providerHealthRegistry.routes.js";
 import { reconciliationRoutes } from "./reconciliation.js";
+import { statusSubscriptionsRoutes } from "./statusSubscriptions.js";
 
 export async function registerRoutes(server: FastifyInstance) {
   server.register(assetsRoutes, { prefix: "/api/v1/assets" });
@@ -89,4 +90,5 @@ export async function registerRoutes(server: FastifyInstance) {
   server.register(externalDependenciesRoutes, { prefix: "/api/v1/external-dependencies" });
   server.register(providerHealthRegistryRoutes, { prefix: "/api/v1/providers/health" });
   server.register(reconciliationRoutes, { prefix: "/api/v1/reconciliation" });
+  server.register(statusSubscriptionsRoutes, { prefix: "/api/v1/status-subscriptions" });
 }

--- a/backend/src/api/routes/statusSubscriptions.ts
+++ b/backend/src/api/routes/statusSubscriptions.ts
@@ -1,0 +1,287 @@
+import type { FastifyInstance } from "fastify";
+import {
+  StatusSubscriptionService,
+  type EntityType,
+  type TriggerStatus,
+  type DeliveryChannel,
+  type DigestFrequency,
+} from "../../services/statusSubscription.service.js";
+
+const ENTITY_TYPES: EntityType[] = ["asset", "bridge", "service"];
+const TRIGGER_STATUSES: TriggerStatus[] = ["degraded", "down", "recovered", "any"];
+const DELIVERY_CHANNELS: DeliveryChannel[] = ["in_app", "email", "webhook", "discord"];
+const DIGEST_FREQUENCIES: DigestFrequency[] = ["immediate", "hourly", "daily"];
+
+const subscriptionSchema = {
+  type: "object",
+  properties: {
+    id: { type: "string" },
+    userId: { type: "string" },
+    entityType: { type: "string", enum: ENTITY_TYPES },
+    entityId: { type: "string" },
+    triggerStatuses: { type: "array", items: { type: "string", enum: TRIGGER_STATUSES } },
+    deliveryChannels: { type: "array", items: { type: "string", enum: DELIVERY_CHANNELS } },
+    deliveryDestination: { type: "string" },
+    digestFrequency: { type: "string", enum: DIGEST_FREQUENCIES },
+    suppressDuplicatesMinutes: { type: "integer" },
+    enabled: { type: "boolean" },
+    createdAt: { type: "string" },
+    updatedAt: { type: "string" },
+  },
+} as const;
+
+export async function statusSubscriptionsRoutes(server: FastifyInstance) {
+  const service = new StatusSubscriptionService();
+
+  server.post<{
+    Params: { userId: string };
+    Body: {
+      entityType: EntityType;
+      entityId: string;
+      triggerStatuses?: TriggerStatus[];
+      deliveryChannels?: DeliveryChannel[];
+      deliveryDestination?: string;
+      digestFrequency?: DigestFrequency;
+      suppressDuplicatesMinutes?: number;
+    };
+  }>(
+    "/:userId",
+    {
+      schema: {
+        tags: ["Status Subscriptions"],
+        summary: "Create a status change subscription",
+        params: {
+          type: "object",
+          required: ["userId"],
+          properties: { userId: { type: "string", minLength: 1 } },
+        },
+        body: {
+          type: "object",
+          required: ["entityType", "entityId"],
+          properties: {
+            entityType: { type: "string", enum: ENTITY_TYPES },
+            entityId: { type: "string", minLength: 1 },
+            triggerStatuses: { type: "array", items: { type: "string", enum: TRIGGER_STATUSES } },
+            deliveryChannels: { type: "array", items: { type: "string", enum: DELIVERY_CHANNELS } },
+            deliveryDestination: { type: "string" },
+            digestFrequency: { type: "string", enum: DIGEST_FREQUENCIES },
+            suppressDuplicatesMinutes: { type: "integer", minimum: 0, maximum: 10080 },
+          },
+        },
+        response: {
+          201: { type: "object", properties: { subscription: subscriptionSchema } },
+          400: { $ref: "Error#" },
+        },
+      },
+    },
+    async (request, reply) => {
+      const { userId } = request.params;
+      const sub = service.create({ userId, ...request.body });
+      return reply.status(201).send({ subscription: sub });
+    },
+  );
+
+  server.get<{ Params: { userId: string } }>(
+    "/:userId",
+    {
+      schema: {
+        tags: ["Status Subscriptions"],
+        summary: "List all subscriptions for a user",
+        params: {
+          type: "object",
+          required: ["userId"],
+          properties: { userId: { type: "string", minLength: 1 } },
+        },
+        response: {
+          200: {
+            type: "object",
+            properties: { subscriptions: { type: "array", items: subscriptionSchema } },
+          },
+        },
+      },
+    },
+    async (request) => {
+      const subs = service.listByUser(request.params.userId);
+      return { subscriptions: subs };
+    },
+  );
+
+  server.get<{ Params: { userId: string; id: string } }>(
+    "/:userId/:id",
+    {
+      schema: {
+        tags: ["Status Subscriptions"],
+        summary: "Get a single subscription",
+        params: {
+          type: "object",
+          required: ["userId", "id"],
+          properties: {
+            userId: { type: "string" },
+            id: { type: "string" },
+          },
+        },
+        response: {
+          200: { type: "object", properties: { subscription: subscriptionSchema } },
+          404: { $ref: "Error#" },
+        },
+      },
+    },
+    async (request, reply) => {
+      const sub = service.getById(request.params.id);
+      if (!sub || sub.userId !== request.params.userId) {
+        return reply.status(404).send({ error: "Subscription not found" });
+      }
+      return { subscription: sub };
+    },
+  );
+
+  server.patch<{
+    Params: { userId: string; id: string };
+    Body: {
+      triggerStatuses?: TriggerStatus[];
+      deliveryChannels?: DeliveryChannel[];
+      deliveryDestination?: string;
+      digestFrequency?: DigestFrequency;
+      suppressDuplicatesMinutes?: number;
+      enabled?: boolean;
+    };
+  }>(
+    "/:userId/:id",
+    {
+      schema: {
+        tags: ["Status Subscriptions"],
+        summary: "Update a subscription",
+        params: {
+          type: "object",
+          required: ["userId", "id"],
+          properties: { userId: { type: "string" }, id: { type: "string" } },
+        },
+        body: {
+          type: "object",
+          properties: {
+            triggerStatuses: { type: "array", items: { type: "string", enum: TRIGGER_STATUSES } },
+            deliveryChannels: { type: "array", items: { type: "string", enum: DELIVERY_CHANNELS } },
+            deliveryDestination: { type: "string" },
+            digestFrequency: { type: "string", enum: DIGEST_FREQUENCIES },
+            suppressDuplicatesMinutes: { type: "integer", minimum: 0, maximum: 10080 },
+            enabled: { type: "boolean" },
+          },
+        },
+        response: {
+          200: { type: "object", properties: { subscription: subscriptionSchema } },
+          404: { $ref: "Error#" },
+        },
+      },
+    },
+    async (request, reply) => {
+      const updated = service.update(request.params.id, request.params.userId, request.body);
+      if (!updated) return reply.status(404).send({ error: "Subscription not found" });
+      return { subscription: updated };
+    },
+  );
+
+  server.delete<{ Params: { userId: string; id: string } }>(
+    "/:userId/:id",
+    {
+      schema: {
+        tags: ["Status Subscriptions"],
+        summary: "Delete a subscription",
+        params: {
+          type: "object",
+          required: ["userId", "id"],
+          properties: { userId: { type: "string" }, id: { type: "string" } },
+        },
+        response: {
+          200: { type: "object", properties: { deleted: { type: "boolean" } } },
+          404: { $ref: "Error#" },
+        },
+      },
+    },
+    async (request, reply) => {
+      const ok = service.delete(request.params.id, request.params.userId);
+      if (!ok) return reply.status(404).send({ error: "Subscription not found" });
+      return { deleted: true };
+    },
+  );
+
+  server.get<{ Params: { userId: string; id: string } }>(
+    "/:userId/:id/audit",
+    {
+      schema: {
+        tags: ["Status Subscriptions"],
+        summary: "Get audit trail for a subscription",
+        params: {
+          type: "object",
+          required: ["userId", "id"],
+          properties: { userId: { type: "string" }, id: { type: "string" } },
+        },
+        response: {
+          200: {
+            type: "object",
+            properties: {
+              audit: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    id: { type: "string" },
+                    subscriptionId: { type: "string" },
+                    userId: { type: "string" },
+                    action: { type: "string" },
+                    detail: { type: "string" },
+                    timestamp: { type: "string" },
+                  },
+                },
+              },
+            },
+          },
+          404: { $ref: "Error#" },
+        },
+      },
+    },
+    async (request, reply) => {
+      const sub = service.getById(request.params.id);
+      if (!sub || sub.userId !== request.params.userId) {
+        return reply.status(404).send({ error: "Subscription not found" });
+      }
+      return { audit: service.getAuditTrail(request.params.id) };
+    },
+  );
+
+  // Internal endpoint — called by the status-change event pipeline
+  server.post<{
+    Body: { entityType: string; entityId: string; newStatus: string };
+  }>(
+    "/notify",
+    {
+      schema: {
+        tags: ["Status Subscriptions"],
+        summary: "Trigger subscription notifications for a status change (internal)",
+        body: {
+          type: "object",
+          required: ["entityType", "entityId", "newStatus"],
+          properties: {
+            entityType: { type: "string", enum: ENTITY_TYPES },
+            entityId: { type: "string" },
+            newStatus: { type: "string" },
+          },
+        },
+        response: {
+          200: {
+            type: "object",
+            properties: { notified: { type: "integer" } },
+          },
+          400: { $ref: "Error#" },
+        },
+      },
+    },
+    async (request, reply) => {
+      const { entityType, entityId, newStatus } = request.body;
+      if (!ENTITY_TYPES.includes(entityType as EntityType)) {
+        return reply.status(400).send({ error: "Invalid entityType" });
+      }
+      const matched = service.getSubscriptionsToNotify(entityType as EntityType, entityId, newStatus);
+      return { notified: matched.length };
+    },
+  );
+}

--- a/backend/src/services/statusSubscription.service.ts
+++ b/backend/src/services/statusSubscription.service.ts
@@ -1,0 +1,172 @@
+import { randomUUID } from "node:crypto";
+import { logger } from "../utils/logger.js";
+
+export type EntityType = "asset" | "bridge" | "service";
+export type TriggerStatus = "degraded" | "down" | "recovered" | "any";
+export type DeliveryChannel = "in_app" | "email" | "webhook" | "discord";
+export type DigestFrequency = "immediate" | "hourly" | "daily";
+
+export interface StatusSubscription {
+  id: string;
+  userId: string;
+  entityType: EntityType;
+  entityId: string;
+  triggerStatuses: TriggerStatus[];
+  deliveryChannels: DeliveryChannel[];
+  deliveryDestination?: string;
+  digestFrequency: DigestFrequency;
+  suppressDuplicatesMinutes: number;
+  enabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SubscriptionCreateInput {
+  userId: string;
+  entityType: EntityType;
+  entityId: string;
+  triggerStatuses?: TriggerStatus[];
+  deliveryChannels?: DeliveryChannel[];
+  deliveryDestination?: string;
+  digestFrequency?: DigestFrequency;
+  suppressDuplicatesMinutes?: number;
+}
+
+export interface SubscriptionUpdateInput {
+  triggerStatuses?: TriggerStatus[];
+  deliveryChannels?: DeliveryChannel[];
+  deliveryDestination?: string;
+  digestFrequency?: DigestFrequency;
+  suppressDuplicatesMinutes?: number;
+  enabled?: boolean;
+}
+
+interface AuditEntry {
+  id: string;
+  subscriptionId: string;
+  userId: string;
+  action: "created" | "updated" | "deleted" | "triggered";
+  detail: string;
+  timestamp: string;
+}
+
+// In-memory store — replace with a DB-backed implementation when a migration is added.
+const subscriptions = new Map<string, StatusSubscription>();
+const auditLog: AuditEntry[] = [];
+const lastTriggered = new Map<string, string>(); // subscriptionId → ISO timestamp
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function addAudit(
+  subscriptionId: string,
+  userId: string,
+  action: AuditEntry["action"],
+  detail: string,
+): void {
+  auditLog.push({ id: randomUUID(), subscriptionId, userId, action, detail, timestamp: now() });
+  if (auditLog.length > 5000) auditLog.splice(0, 1000);
+}
+
+export class StatusSubscriptionService {
+  create(input: SubscriptionCreateInput): StatusSubscription {
+    const id = randomUUID();
+    const ts = now();
+    const sub: StatusSubscription = {
+      id,
+      userId: input.userId,
+      entityType: input.entityType,
+      entityId: input.entityId,
+      triggerStatuses: input.triggerStatuses ?? ["any"],
+      deliveryChannels: input.deliveryChannels ?? ["in_app"],
+      deliveryDestination: input.deliveryDestination,
+      digestFrequency: input.digestFrequency ?? "immediate",
+      suppressDuplicatesMinutes: input.suppressDuplicatesMinutes ?? 60,
+      enabled: true,
+      createdAt: ts,
+      updatedAt: ts,
+    };
+    subscriptions.set(id, sub);
+    addAudit(id, input.userId, "created", `Subscribed to ${input.entityType}:${input.entityId}`);
+    logger.info({ subscriptionId: id, userId: input.userId }, "Status subscription created");
+    return sub;
+  }
+
+  getById(id: string): StatusSubscription | undefined {
+    return subscriptions.get(id);
+  }
+
+  listByUser(userId: string): StatusSubscription[] {
+    return Array.from(subscriptions.values()).filter((s) => s.userId === userId);
+  }
+
+  listByEntity(entityType: EntityType, entityId: string): StatusSubscription[] {
+    return Array.from(subscriptions.values()).filter(
+      (s) => s.entityType === entityType && s.entityId === entityId && s.enabled,
+    );
+  }
+
+  update(id: string, userId: string, input: SubscriptionUpdateInput): StatusSubscription | null {
+    const sub = subscriptions.get(id);
+    if (!sub || sub.userId !== userId) return null;
+
+    const updated: StatusSubscription = {
+      ...sub,
+      ...(input.triggerStatuses !== undefined && { triggerStatuses: input.triggerStatuses }),
+      ...(input.deliveryChannels !== undefined && { deliveryChannels: input.deliveryChannels }),
+      ...(input.deliveryDestination !== undefined && { deliveryDestination: input.deliveryDestination }),
+      ...(input.digestFrequency !== undefined && { digestFrequency: input.digestFrequency }),
+      ...(input.suppressDuplicatesMinutes !== undefined && { suppressDuplicatesMinutes: input.suppressDuplicatesMinutes }),
+      ...(input.enabled !== undefined && { enabled: input.enabled }),
+      updatedAt: now(),
+    };
+    subscriptions.set(id, updated);
+    addAudit(id, userId, "updated", `Updated subscription fields: ${Object.keys(input).join(", ")}`);
+    return updated;
+  }
+
+  delete(id: string, userId: string): boolean {
+    const sub = subscriptions.get(id);
+    if (!sub || sub.userId !== userId) return false;
+    subscriptions.delete(id);
+    addAudit(id, userId, "deleted", `Deleted subscription for ${sub.entityType}:${sub.entityId}`);
+    return true;
+  }
+
+  /**
+   * Called by the alerting layer when an entity's status changes.
+   * Returns subscriptions that should receive notifications, after applying
+   * duplicate-suppression logic.
+   */
+  getSubscriptionsToNotify(
+    entityType: EntityType,
+    entityId: string,
+    newStatus: string,
+  ): StatusSubscription[] {
+    const candidates = this.listByEntity(entityType, entityId).filter((s) => {
+      const matches =
+        s.triggerStatuses.includes("any") ||
+        s.triggerStatuses.includes(newStatus as TriggerStatus);
+      if (!matches) return false;
+
+      const lastTs = lastTriggered.get(s.id);
+      if (lastTs) {
+        const elapsedMinutes = (Date.now() - new Date(lastTs).getTime()) / 60_000;
+        if (elapsedMinutes < s.suppressDuplicatesMinutes) return false;
+      }
+      return true;
+    });
+
+    for (const s of candidates) {
+      lastTriggered.set(s.id, now());
+      addAudit(s.id, s.userId, "triggered", `Status changed to ${newStatus} for ${entityType}:${entityId}`);
+    }
+
+    return candidates;
+  }
+
+  getAuditTrail(subscriptionId: string): AuditEntry[] {
+    return auditLog.filter((e) => e.subscriptionId === subscriptionId);
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,6 +21,9 @@ const AlertRoutingAdmin = lazy(() => import("./pages/AlertRoutingAdmin"));
 const SupplyChain = lazy(() => import("./pages/SupplyChain"));
 const ApiDocs = lazy(() => import("./pages/ApiDocs"));
 const Help = lazy(() => import("./pages/Help"));
+const ReleaseNotes = lazy(() => import("./pages/ReleaseNotes"));
+const NotificationPreferencesPage = lazy(() => import("./pages/NotificationPreferencesPage"));
+const RelationshipExplorer = lazy(() => import("./pages/RelationshipExplorer"));
 
 function NotificationInitializer() {
   useNotifications();
@@ -58,6 +61,9 @@ function App() {
               <Route path="/supply-chain" element={<SupplyChain />} />
               <Route path="/api-docs" element={<ApiDocs />} />
               <Route path="/help" element={<Help />} />
+              <Route path="/release-notes" element={<ReleaseNotes />} />
+              <Route path="/notification-preferences" element={<NotificationPreferencesPage />} />
+              <Route path="/relationship-explorer" element={<RelationshipExplorer />} />
             </Route>
           </Routes>
         </Suspense>

--- a/frontend/src/content/releaseNotesData.ts
+++ b/frontend/src/content/releaseNotesData.ts
@@ -1,0 +1,184 @@
+export type ReleaseTag = "breaking" | "new" | "improvement" | "fix" | "deprecated";
+
+export interface ReleaseNote {
+  id: string;
+  version: string;
+  date: string;
+  summary: string;
+  tags: ReleaseTag[];
+  entries: {
+    tag: ReleaseTag;
+    title: string;
+    description: string;
+    migrationNote?: string;
+  }[];
+}
+
+export const releaseNotes: ReleaseNote[] = [
+  {
+    id: "v1.5.0",
+    version: "1.5.0",
+    date: "2026-05-29",
+    summary: "State export functions, frozen asset controls, and supply-chain graph improvements.",
+    tags: ["new", "improvement"],
+    entries: [
+      {
+        tag: "new",
+        title: "State Export Functions",
+        description:
+          "Export contract state snapshots via GET /api/export/state for off-chain sync and auditing. Supports JSON and compact formats.",
+      },
+      {
+        tag: "new",
+        title: "Frozen Asset Controls",
+        description:
+          "Administrators can now freeze and unfreeze individual assets. All asset metadata responses include a new is_frozen field.",
+      },
+      {
+        tag: "improvement",
+        title: "Supply-Chain Graph",
+        description: "Improved rendering performance and edge-label legibility for large graphs.",
+      },
+    ],
+  },
+  {
+    id: "v1.4.0",
+    version: "1.4.0",
+    date: "2026-05-15",
+    summary: "Whitelist management, asset category and status filtering.",
+    tags: ["new"],
+    entries: [
+      {
+        tag: "new",
+        title: "Whitelist Management",
+        description: "Add or remove asset codes from the protocol whitelist via POST /api/whitelist/add.",
+      },
+      {
+        tag: "new",
+        title: "Asset Category Filtering",
+        description:
+          "Retrieve assets by category (stablecoin, real-world-asset, native, bridged, wrapped, other) via GET /api/assets/category/{category}.",
+      },
+      {
+        tag: "new",
+        title: "Asset Status Filtering",
+        description:
+          "Retrieve assets by lifecycle status (active, paused, deprecated, pending-review) via GET /api/assets/status/{status}.",
+      },
+    ],
+  },
+  {
+    id: "v1.3.0",
+    version: "1.3.0",
+    date: "2026-04-28",
+    summary: "Alert routing engine, digest scheduling, and suppression controls.",
+    tags: ["new", "improvement"],
+    entries: [
+      {
+        tag: "new",
+        title: "Alert Routing Engine",
+        description:
+          "Route alerts to specific channels based on configurable rules. Supports priority, asset type, and severity matching.",
+      },
+      {
+        tag: "new",
+        title: "Digest Scheduling",
+        description:
+          "Subscribe to hourly or daily digests instead of real-time notifications. Configurable per user via the digest scheduler endpoint.",
+      },
+      {
+        tag: "improvement",
+        title: "Alert Suppression Controls",
+        description:
+          "Suppress repeat alerts within a configurable time window to reduce notification fatigue.",
+      },
+    ],
+  },
+  {
+    id: "v1.2.0",
+    version: "1.2.0",
+    date: "2026-03-10",
+    summary: "Supply chain visualization, external dependency monitoring, and breaking pagination change.",
+    tags: ["new", "breaking", "improvement"],
+    entries: [
+      {
+        tag: "breaking",
+        title: "Pagination cursor format changed",
+        description:
+          "The cursor parameter in paginated list endpoints is now base64-encoded. Clients constructing cursors manually must update their encoding.",
+        migrationNote:
+          "Replace raw cursor strings with base64(JSON.stringify({ id, createdAt })) before passing to the API.",
+      },
+      {
+        tag: "new",
+        title: "Supply Chain Visualization",
+        description:
+          "New /supply-chain page shows cross-chain asset flow, bridge health, and dependency graphs.",
+      },
+      {
+        tag: "new",
+        title: "External Dependency Monitoring",
+        description:
+          "Track health of external price feeds, oracles, and RPC providers. Alerts fire when a dependency degrades.",
+      },
+    ],
+  },
+  {
+    id: "v1.1.0",
+    version: "1.1.0",
+    date: "2026-01-20",
+    summary: "Watchlists, transaction history, and analytics dashboard.",
+    tags: ["new"],
+    entries: [
+      {
+        tag: "new",
+        title: "Watchlists",
+        description:
+          "Users can create named watchlists and monitor a custom set of assets from the dashboard.",
+      },
+      {
+        tag: "new",
+        title: "Transaction History",
+        description:
+          "Browse and filter all bridge transactions with status, amount, fee, and chain details.",
+      },
+      {
+        tag: "new",
+        title: "Analytics Dashboard",
+        description:
+          "Volume, liquidity depth, and health score trend charts are now available on the Analytics page.",
+      },
+    ],
+  },
+  {
+    id: "v1.0.0",
+    version: "1.0.0",
+    date: "2025-12-01",
+    summary: "Initial public release of Bridge Watch.",
+    tags: ["new"],
+    entries: [
+      {
+        tag: "new",
+        title: "Initial Release",
+        description:
+          "Bridge Watch is live. Monitor Stellar bridge assets, track incidents, and receive real-time alerts.",
+      },
+    ],
+  },
+];
+
+export const TAG_LABELS: Record<ReleaseTag, string> = {
+  breaking: "Breaking",
+  new: "New",
+  improvement: "Improvement",
+  fix: "Fix",
+  deprecated: "Deprecated",
+};
+
+export const TAG_COLORS: Record<ReleaseTag, string> = {
+  breaking: "bg-red-500/20 text-red-400 border border-red-500/30",
+  new: "bg-emerald-500/20 text-emerald-400 border border-emerald-500/30",
+  improvement: "bg-blue-500/20 text-blue-400 border border-blue-500/30",
+  fix: "bg-yellow-500/20 text-yellow-400 border border-yellow-500/30",
+  deprecated: "bg-orange-500/20 text-orange-400 border border-orange-500/30",
+};

--- a/frontend/src/pages/NotificationPreferencesPage.tsx
+++ b/frontend/src/pages/NotificationPreferencesPage.tsx
@@ -1,0 +1,257 @@
+import { useState } from "react";
+import { useNotificationContext } from "../hooks/useNotificationContext";
+import { usePreferences } from "../context/PreferencesContext";
+import { useToast } from "../context/ToastContext";
+
+type Channel = "in_app" | "email" | "webhook";
+type Priority = "all" | "high_critical" | "critical_only";
+type DigestFrequency = "immediate" | "hourly" | "daily" | "never";
+
+interface ExtendedPrefs {
+  channels: Channel[];
+  digestFrequency: DigestFrequency;
+  quietHoursEnabled: boolean;
+  quietHoursStart: string;
+  quietHoursEnd: string;
+  priority: Priority;
+}
+
+const STORAGE_KEY = "bridge-watch:notification-extended-prefs:v1";
+
+function loadExtendedPrefs(): ExtendedPrefs {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) return JSON.parse(raw) as ExtendedPrefs;
+  } catch {
+    // fall through
+  }
+  return {
+    channels: ["in_app"],
+    digestFrequency: "immediate",
+    quietHoursEnabled: false,
+    quietHoursStart: "22:00",
+    quietHoursEnd: "07:00",
+    priority: "all",
+  };
+}
+
+function saveExtendedPrefs(prefs: ExtendedPrefs): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+}
+
+function Toggle({
+  checked,
+  onChange,
+  label,
+}: {
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      onClick={() => onChange(!checked)}
+      className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-stellar-blue focus:ring-offset-2 focus:ring-offset-stellar-card ${
+        checked ? "bg-stellar-blue" : "bg-stellar-border"
+      }`}
+    >
+      <span
+        className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+          checked ? "translate-x-6" : "translate-x-1"
+        }`}
+      />
+    </button>
+  );
+}
+
+export default function NotificationPreferencesPage() {
+  const { preferences, updatePreferences } = useNotificationContext();
+  const { showSuccess } = useToast();
+  const [extended, setExtended] = useState<ExtendedPrefs>(loadExtendedPrefs);
+
+  function update(patch: Partial<ExtendedPrefs>) {
+    const next = { ...extended, ...patch };
+    setExtended(next);
+    saveExtendedPrefs(next);
+    showSuccess("Preference saved.");
+  }
+
+  function toggleChannel(ch: Channel) {
+    const next = extended.channels.includes(ch)
+      ? extended.channels.filter((c) => c !== ch)
+      : [...extended.channels, ch];
+    if (next.length === 0) return; // always keep at least one
+    update({ channels: next });
+  }
+
+  const channelConfig: { id: Channel; label: string; description: string }[] = [
+    { id: "in_app", label: "In-app", description: "Notifications appear in the sidebar drawer." },
+    { id: "email", label: "Email", description: "Receive alerts via email (requires verified address)." },
+    { id: "webhook", label: "Webhook", description: "POST payloads to a configured webhook endpoint." },
+  ];
+
+  const priorityOptions: { id: Priority; label: string; description: string }[] = [
+    { id: "all", label: "All severities", description: "Receive notifications for every severity level." },
+    { id: "high_critical", label: "High & Critical only", description: "Skip low and medium severity events." },
+    { id: "critical_only", label: "Critical only", description: "Only the most urgent alerts." },
+  ];
+
+  const digestOptions: { id: DigestFrequency; label: string }[] = [
+    { id: "immediate", label: "Immediate" },
+    { id: "hourly", label: "Hourly digest" },
+    { id: "daily", label: "Daily digest" },
+    { id: "never", label: "Never" },
+  ];
+
+  return (
+    <div className="space-y-8 max-w-2xl">
+      <div>
+        <h1 className="text-3xl font-bold text-stellar-text-primary mb-2">
+          Notification Preferences
+        </h1>
+        <p className="text-stellar-text-secondary">
+          Choose how and when you receive alerts about asset and bridge status changes.
+        </p>
+      </div>
+
+      {/* Sound toggle (existing) */}
+      <section className="rounded-xl border border-stellar-border bg-stellar-card p-6 space-y-4">
+        <h2 className="text-lg font-semibold text-stellar-text-primary">Sound</h2>
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <p className="text-sm text-stellar-text-primary">Notification sounds</p>
+            <p className="text-xs text-stellar-text-secondary mt-0.5">
+              Play a chime when a new notification arrives.
+            </p>
+          </div>
+          <Toggle
+            checked={preferences.soundEnabled}
+            onChange={(v) => {
+              updatePreferences({ soundEnabled: v });
+              showSuccess("Preference saved.");
+            }}
+            label="Toggle notification sounds"
+          />
+        </div>
+      </section>
+
+      {/* Delivery channels */}
+      <section className="rounded-xl border border-stellar-border bg-stellar-card p-6 space-y-4">
+        <h2 className="text-lg font-semibold text-stellar-text-primary">Delivery channels</h2>
+        <p className="text-sm text-stellar-text-secondary">
+          Select where notifications are sent. At least one channel must remain active.
+        </p>
+        <div className="space-y-3">
+          {channelConfig.map((ch) => (
+            <div key={ch.id} className="flex items-center justify-between gap-4">
+              <div>
+                <p className="text-sm text-stellar-text-primary">{ch.label}</p>
+                <p className="text-xs text-stellar-text-secondary mt-0.5">{ch.description}</p>
+              </div>
+              <Toggle
+                checked={extended.channels.includes(ch.id)}
+                onChange={() => toggleChannel(ch.id)}
+                label={`Toggle ${ch.label} channel`}
+              />
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Digest frequency */}
+      <section className="rounded-xl border border-stellar-border bg-stellar-card p-6 space-y-4">
+        <h2 className="text-lg font-semibold text-stellar-text-primary">Digest frequency</h2>
+        <p className="text-sm text-stellar-text-secondary">
+          Control how often batched summaries are sent instead of individual notifications.
+        </p>
+        <div className="flex flex-wrap gap-2">
+          {digestOptions.map((opt) => (
+            <button
+              key={opt.id}
+              type="button"
+              onClick={() => update({ digestFrequency: opt.id })}
+              className={`rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
+                extended.digestFrequency === opt.id
+                  ? "bg-stellar-blue text-white"
+                  : "border border-stellar-border text-stellar-text-secondary hover:text-white"
+              }`}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      </section>
+
+      {/* Quiet hours */}
+      <section className="rounded-xl border border-stellar-border bg-stellar-card p-6 space-y-4">
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <h2 className="text-lg font-semibold text-stellar-text-primary">Quiet hours</h2>
+            <p className="text-sm text-stellar-text-secondary mt-0.5">
+              Suppress non-critical notifications during the specified time window.
+            </p>
+          </div>
+          <Toggle
+            checked={extended.quietHoursEnabled}
+            onChange={(v) => update({ quietHoursEnabled: v })}
+            label="Toggle quiet hours"
+          />
+        </div>
+        {extended.quietHoursEnabled && (
+          <div className="flex flex-wrap gap-4 pt-2">
+            <label className="flex flex-col gap-1">
+              <span className="text-xs text-stellar-text-secondary">From</span>
+              <input
+                type="time"
+                value={extended.quietHoursStart}
+                onChange={(e) => update({ quietHoursStart: e.target.value })}
+                className="rounded-md border border-stellar-border bg-stellar-dark px-3 py-1.5 text-sm text-stellar-text-primary focus:outline-none focus:ring-2 focus:ring-stellar-blue"
+              />
+            </label>
+            <label className="flex flex-col gap-1">
+              <span className="text-xs text-stellar-text-secondary">Until</span>
+              <input
+                type="time"
+                value={extended.quietHoursEnd}
+                onChange={(e) => update({ quietHoursEnd: e.target.value })}
+                className="rounded-md border border-stellar-border bg-stellar-dark px-3 py-1.5 text-sm text-stellar-text-primary focus:outline-none focus:ring-2 focus:ring-stellar-blue"
+              />
+            </label>
+          </div>
+        )}
+      </section>
+
+      {/* Priority overrides */}
+      <section className="rounded-xl border border-stellar-border bg-stellar-card p-6 space-y-4">
+        <h2 className="text-lg font-semibold text-stellar-text-primary">Priority overrides</h2>
+        <p className="text-sm text-stellar-text-secondary">
+          Limit which severity levels trigger a notification.
+        </p>
+        <div className="space-y-2">
+          {priorityOptions.map((opt) => (
+            <label key={opt.id} className="flex items-start gap-3 cursor-pointer">
+              <input
+                type="radio"
+                name="priority"
+                value={opt.id}
+                checked={extended.priority === opt.id}
+                onChange={() => update({ priority: opt.id })}
+                className="mt-0.5 h-4 w-4 border-stellar-border bg-stellar-dark text-stellar-blue focus:ring-stellar-blue"
+              />
+              <span>
+                <span className="text-sm text-stellar-text-primary">{opt.label}</span>
+                <span className="block text-xs text-stellar-text-secondary mt-0.5">
+                  {opt.description}
+                </span>
+              </span>
+            </label>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/RelationshipExplorer.tsx
+++ b/frontend/src/pages/RelationshipExplorer.tsx
@@ -1,0 +1,501 @@
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { getDependencyGraph } from "../services/api";
+import type { DependencyGraph, DependencyNodeStatus } from "../types";
+
+const STATUS_COLORS: Record<DependencyNodeStatus, string> = {
+  healthy: "#22c55e",
+  degraded: "#f59e0b",
+  down: "#ef4444",
+  unknown: "#6b7280",
+};
+
+const STATUS_BADGE: Record<DependencyNodeStatus, string> = {
+  healthy: "bg-green-500/20 text-green-400 border border-green-500/30",
+  degraded: "bg-yellow-500/20 text-yellow-400 border border-yellow-500/30",
+  down: "bg-red-500/20 text-red-400 border border-red-500/30",
+  unknown: "bg-gray-500/20 text-gray-400 border border-gray-500/30",
+};
+
+type FilterStatus = DependencyNodeStatus | "all";
+type FilterType = string;
+
+interface LayoutNode {
+  id: string;
+  label: string;
+  description: string;
+  type: string;
+  status: DependencyNodeStatus;
+  impactHint: string;
+  x: number;
+  y: number;
+}
+
+const GRAPH_W = 800;
+const GRAPH_H = 500;
+const NODE_R = 24;
+
+function layoutNodes(nodes: DependencyGraph["nodes"]): LayoutNode[] {
+  if (nodes.length === 0) return [];
+
+  const byType = new Map<string, typeof nodes>();
+  for (const n of nodes) {
+    if (!byType.has(n.type)) byType.set(n.type, []);
+    byType.get(n.type)!.push(n);
+  }
+
+  const cols = Array.from(byType.entries());
+  const colW = GRAPH_W / (cols.length + 1);
+
+  const laid: LayoutNode[] = [];
+  cols.forEach(([, group], ci) => {
+    const rowH = GRAPH_H / (group.length + 1);
+    group.forEach((n, ri) => {
+      laid.push({
+        ...n,
+        x: colW * (ci + 1),
+        y: rowH * (ri + 1),
+      });
+    });
+  });
+
+  return laid;
+}
+
+function GraphNode({
+  node,
+  selected,
+  dimmed,
+  onClick,
+}: {
+  node: LayoutNode;
+  selected: boolean;
+  dimmed: boolean;
+  onClick: () => void;
+}) {
+  const color = STATUS_COLORS[node.status] ?? STATUS_COLORS.unknown;
+  return (
+    <g
+      transform={`translate(${node.x},${node.y})`}
+      className="cursor-pointer"
+      onClick={onClick}
+      role="button"
+      aria-label={`${node.label} (${node.status})`}
+      tabIndex={0}
+      onKeyDown={(e) => e.key === "Enter" && onClick()}
+      style={{ opacity: dimmed ? 0.3 : 1 }}
+    >
+      <circle
+        r={NODE_R + 4}
+        fill="transparent"
+        stroke={selected ? color : "transparent"}
+        strokeWidth={2}
+        className="transition-all"
+      />
+      <circle
+        r={NODE_R}
+        fill="#1e293b"
+        stroke={color}
+        strokeWidth={selected ? 2.5 : 1.5}
+        className="transition-all"
+      />
+      <text
+        textAnchor="middle"
+        dominantBaseline="central"
+        fontSize={10}
+        fill="#e2e8f0"
+        className="select-none pointer-events-none"
+        style={{ fontWeight: selected ? 700 : 400 }}
+      >
+        {node.label.length > 7 ? node.label.slice(0, 6) + "…" : node.label}
+      </text>
+      <text
+        y={NODE_R + 12}
+        textAnchor="middle"
+        fontSize={8}
+        fill="#94a3b8"
+        className="select-none pointer-events-none"
+      >
+        {node.type}
+      </text>
+    </g>
+  );
+}
+
+function EdgeLine({
+  from,
+  to,
+  kind,
+  highlight,
+}: {
+  from: LayoutNode;
+  to: LayoutNode;
+  kind: string;
+  highlight: boolean;
+}) {
+  const mx = (from.x + to.x) / 2;
+  const my = (from.y + to.y) / 2;
+  return (
+    <g>
+      <line
+        x1={from.x}
+        y1={from.y}
+        x2={to.x}
+        y2={to.y}
+        stroke={highlight ? "#60a5fa" : "#334155"}
+        strokeWidth={highlight ? 2 : 1}
+        strokeDasharray={kind === "optional" ? "4 4" : undefined}
+        markerEnd="url(#arrow)"
+        className="transition-all"
+      />
+      {highlight && (
+        <text
+          x={mx}
+          y={my - 6}
+          textAnchor="middle"
+          fontSize={8}
+          fill="#60a5fa"
+          className="select-none pointer-events-none"
+        >
+          {kind}
+        </text>
+      )}
+    </g>
+  );
+}
+
+export default function RelationshipExplorer() {
+  const { data, isLoading, error } = useQuery<DependencyGraph, Error>({
+    queryKey: ["dependencyGraph"],
+    queryFn: () => getDependencyGraph(),
+    staleTime: 60_000,
+  });
+
+  const [query, setQuery] = useState("");
+  const [filterStatus, setFilterStatus] = useState<FilterStatus>("all");
+  const [filterType, setFilterType] = useState<FilterType>("all");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const nodeTypes = useMemo(() => {
+    if (!data) return [];
+    return Array.from(new Set(data.nodes.map((n) => n.type))).sort();
+  }, [data]);
+
+  const filteredNodes = useMemo(() => {
+    if (!data) return [];
+    const q = query.trim().toLowerCase();
+    return data.nodes.filter((n) => {
+      if (filterStatus !== "all" && n.status !== filterStatus) return false;
+      if (filterType !== "all" && n.type !== filterType) return false;
+      if (q && !n.label.toLowerCase().includes(q) && !n.description.toLowerCase().includes(q))
+        return false;
+      return true;
+    });
+  }, [data, query, filterStatus, filterType]);
+
+  const filteredIds = useMemo(() => new Set(filteredNodes.map((n) => n.id)), [filteredNodes]);
+
+  const laidOut = useMemo(() => layoutNodes(data?.nodes ?? []), [data]);
+  const laidOutMap = useMemo(
+    () => new Map(laidOut.map((n) => [n.id, n])),
+    [laidOut],
+  );
+
+  const visibleEdges = useMemo(() => {
+    if (!data) return [];
+    return data.edges.filter(
+      (e) => filteredIds.has(e.from) && filteredIds.has(e.to),
+    );
+  }, [data, filteredIds]);
+
+  const selectedNode = selectedId ? laidOutMap.get(selectedId) : null;
+  const connectedIds = useMemo(() => {
+    if (!selectedId || !data) return new Set<string>();
+    const ids = new Set<string>();
+    for (const e of data.edges) {
+      if (e.from === selectedId) ids.add(e.to);
+      if (e.to === selectedId) ids.add(e.from);
+    }
+    return ids;
+  }, [selectedId, data]);
+
+  const selectedEdges = useMemo(() => {
+    if (!selectedId || !data) return [];
+    return data.edges.filter((e) => e.from === selectedId || e.to === selectedId);
+  }, [selectedId, data]);
+
+  return (
+    <div className="flex flex-col gap-6 h-full">
+      <div>
+        <h1 className="text-3xl font-bold text-stellar-text-primary mb-1">
+          Asset Relationship Explorer
+        </h1>
+        <p className="text-stellar-text-secondary text-sm">
+          Visualize dependencies between assets, bridges, alerts, and services.
+        </p>
+      </div>
+
+      {/* Summary cards */}
+      {data && (
+        <div className="flex flex-wrap gap-4">
+          {[
+            { label: "Total nodes", value: data.summary.totalNodes },
+            { label: "Degraded", value: data.summary.degradedServices, color: "text-yellow-400" },
+            { label: "Down", value: data.summary.downServices, color: "text-red-400" },
+          ].map((s) => (
+            <div
+              key={s.label}
+              className="rounded-lg border border-stellar-border bg-stellar-card px-4 py-3 min-w-[120px]"
+            >
+              <p className="text-xs text-stellar-text-secondary">{s.label}</p>
+              <p className={`text-2xl font-bold ${s.color ?? "text-stellar-text-primary"}`}>
+                {s.value}
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Filters */}
+      <div className="flex flex-wrap gap-3 items-center">
+        <div className="relative">
+          <svg
+            className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-stellar-text-secondary"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+          </svg>
+          <input
+            type="search"
+            placeholder="Search nodes…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            className="rounded-lg border border-stellar-border bg-stellar-dark pl-9 pr-3 py-1.5 text-sm text-stellar-text-primary placeholder-stellar-text-secondary focus:outline-none focus:ring-2 focus:ring-stellar-blue w-52"
+          />
+        </div>
+
+        <select
+          value={filterStatus}
+          onChange={(e) => setFilterStatus(e.target.value as FilterStatus)}
+          className="rounded-lg border border-stellar-border bg-stellar-dark px-3 py-1.5 text-sm text-stellar-text-primary focus:outline-none focus:ring-2 focus:ring-stellar-blue"
+        >
+          <option value="all">All statuses</option>
+          <option value="healthy">Healthy</option>
+          <option value="degraded">Degraded</option>
+          <option value="down">Down</option>
+          <option value="unknown">Unknown</option>
+        </select>
+
+        {nodeTypes.length > 0 && (
+          <select
+            value={filterType}
+            onChange={(e) => setFilterType(e.target.value)}
+            className="rounded-lg border border-stellar-border bg-stellar-dark px-3 py-1.5 text-sm text-stellar-text-primary focus:outline-none focus:ring-2 focus:ring-stellar-blue"
+          >
+            <option value="all">All types</option>
+            {nodeTypes.map((t) => (
+              <option key={t} value={t}>
+                {t}
+              </option>
+            ))}
+          </select>
+        )}
+
+        {selectedId && (
+          <button
+            type="button"
+            onClick={() => setSelectedId(null)}
+            className="rounded-lg border border-stellar-border bg-stellar-dark px-3 py-1.5 text-sm text-stellar-text-secondary hover:text-white transition-colors"
+          >
+            Clear selection
+          </button>
+        )}
+      </div>
+
+      <div className="flex gap-4 flex-1 min-h-0">
+        {/* Graph canvas */}
+        <div className="flex-1 rounded-xl border border-stellar-border bg-stellar-card overflow-hidden relative">
+          {isLoading && (
+            <div className="absolute inset-0 flex items-center justify-center text-stellar-text-secondary text-sm">
+              Loading graph…
+            </div>
+          )}
+          {error && (
+            <div className="absolute inset-0 flex items-center justify-center text-red-400 text-sm p-4 text-center">
+              {error.message}
+            </div>
+          )}
+          {!isLoading && !error && data && (
+            <svg
+              viewBox={`0 0 ${GRAPH_W} ${GRAPH_H}`}
+              className="w-full h-full"
+              aria-label="Dependency relationship graph"
+            >
+              <defs>
+                <marker
+                  id="arrow"
+                  markerWidth="8"
+                  markerHeight="8"
+                  refX="6"
+                  refY="3"
+                  orient="auto"
+                >
+                  <path d="M0,0 L0,6 L8,3 z" fill="#475569" />
+                </marker>
+              </defs>
+
+              {/* Edges */}
+              {visibleEdges.map((e, i) => {
+                const from = laidOutMap.get(e.from);
+                const to = laidOutMap.get(e.to);
+                if (!from || !to) return null;
+                const hl =
+                  selectedId === e.from ||
+                  selectedId === e.to;
+                return (
+                  <EdgeLine key={i} from={from} to={to} kind={e.kind} highlight={hl} />
+                );
+              })}
+
+              {/* Nodes */}
+              {laidOut
+                .filter((n) => filteredIds.has(n.id))
+                .map((n) => (
+                  <GraphNode
+                    key={n.id}
+                    node={n}
+                    selected={selectedId === n.id}
+                    dimmed={
+                      selectedId !== null &&
+                      selectedId !== n.id &&
+                      !connectedIds.has(n.id)
+                    }
+                    onClick={() => setSelectedId(selectedId === n.id ? null : n.id)}
+                  />
+                ))}
+            </svg>
+          )}
+          {!isLoading && !error && data && data.nodes.length === 0 && (
+            <div className="absolute inset-0 flex items-center justify-center text-stellar-text-secondary text-sm">
+              No dependency data available.
+            </div>
+          )}
+        </div>
+
+        {/* Detail panel */}
+        {selectedNode && (
+          <aside
+            className="w-72 shrink-0 rounded-xl border border-stellar-border bg-stellar-card p-5 space-y-4 overflow-y-auto"
+            aria-label="Node detail panel"
+          >
+            <div className="flex items-start justify-between gap-2">
+              <h2 className="text-base font-semibold text-stellar-text-primary leading-tight">
+                {selectedNode.label}
+              </h2>
+              <span
+                className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium shrink-0 ${STATUS_BADGE[selectedNode.status]}`}
+              >
+                {selectedNode.status}
+              </span>
+            </div>
+
+            <div className="text-xs text-stellar-text-secondary space-y-1">
+              <p>
+                <span className="text-stellar-text-primary font-medium">Type: </span>
+                {selectedNode.type}
+              </p>
+              <p>
+                <span className="text-stellar-text-primary font-medium">ID: </span>
+                <span className="font-mono">{selectedNode.id}</span>
+              </p>
+            </div>
+
+            {selectedNode.description && (
+              <p className="text-sm text-stellar-text-secondary">{selectedNode.description}</p>
+            )}
+
+            {selectedNode.impactHint && (
+              <div className="rounded-lg border border-stellar-border bg-stellar-dark p-3">
+                <p className="text-xs font-medium text-stellar-text-primary mb-1">Impact</p>
+                <p className="text-xs text-stellar-text-secondary">{selectedNode.impactHint}</p>
+              </div>
+            )}
+
+            {selectedEdges.length > 0 && (
+              <div>
+                <p className="text-xs font-medium text-stellar-text-primary mb-2">
+                  Connections ({selectedEdges.length})
+                </p>
+                <ul className="space-y-1.5">
+                  {selectedEdges.map((e, i) => {
+                    const otherId = e.from === selectedNode.id ? e.to : e.from;
+                    const other = laidOutMap.get(otherId);
+                    const direction = e.from === selectedNode.id ? "→" : "←";
+                    return (
+                      <li key={i}>
+                        <button
+                          type="button"
+                          onClick={() => setSelectedId(otherId)}
+                          className="w-full text-left rounded-md border border-stellar-border bg-stellar-dark px-3 py-1.5 text-xs hover:bg-stellar-border/40 transition-colors flex items-center justify-between gap-2"
+                        >
+                          <span className="flex items-center gap-1 truncate">
+                            <span className="text-stellar-text-secondary">{direction}</span>
+                            <span className="text-stellar-text-primary truncate">
+                              {other?.label ?? otherId}
+                            </span>
+                          </span>
+                          <span className="text-stellar-text-secondary shrink-0">{e.kind}</span>
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            )}
+          </aside>
+        )}
+      </div>
+
+      {/* Node list (responsive fallback / accessibility) */}
+      <details className="rounded-xl border border-stellar-border bg-stellar-card">
+        <summary className="px-5 py-3 text-sm font-medium text-stellar-text-primary cursor-pointer select-none">
+          Node list ({filteredNodes.length})
+        </summary>
+        <div className="px-5 pb-4 overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-stellar-border text-left">
+                <th className="py-2 pr-4 text-xs text-stellar-text-secondary font-medium">Label</th>
+                <th className="py-2 pr-4 text-xs text-stellar-text-secondary font-medium">Type</th>
+                <th className="py-2 pr-4 text-xs text-stellar-text-secondary font-medium">Status</th>
+                <th className="py-2 text-xs text-stellar-text-secondary font-medium">Impact</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredNodes.map((n) => (
+                <tr
+                  key={n.id}
+                  className={`border-b border-stellar-border/40 cursor-pointer hover:bg-stellar-dark/50 transition-colors ${
+                    selectedId === n.id ? "bg-stellar-blue/10" : ""
+                  }`}
+                  onClick={() => setSelectedId(selectedId === n.id ? null : n.id)}
+                >
+                  <td className="py-2 pr-4 text-stellar-text-primary font-medium">{n.label}</td>
+                  <td className="py-2 pr-4 text-stellar-text-secondary">{n.type}</td>
+                  <td className="py-2 pr-4">
+                    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_BADGE[n.status]}`}>
+                      {n.status}
+                    </span>
+                  </td>
+                  <td className="py-2 text-stellar-text-secondary text-xs">{n.impactHint}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </details>
+    </div>
+  );
+}

--- a/frontend/src/pages/ReleaseNotes.tsx
+++ b/frontend/src/pages/ReleaseNotes.tsx
@@ -1,0 +1,206 @@
+import { useMemo, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import {
+  releaseNotes,
+  TAG_COLORS,
+  TAG_LABELS,
+  type ReleaseTag,
+} from "../content/releaseNotesData";
+
+const ALL_TAGS: ReleaseTag[] = ["breaking", "new", "improvement", "fix", "deprecated"];
+
+function TagBadge({ tag }: { tag: ReleaseTag }) {
+  return (
+    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${TAG_COLORS[tag]}`}>
+      {TAG_LABELS[tag]}
+    </span>
+  );
+}
+
+export default function ReleaseNotes() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [query, setQuery] = useState(searchParams.get("q") ?? "");
+  const [activeTag, setActiveTag] = useState<ReleaseTag | "all">("all");
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return releaseNotes.filter((release) => {
+      const tagMatch =
+        activeTag === "all" ||
+        release.tags.includes(activeTag) ||
+        release.entries.some((e) => e.tag === activeTag);
+
+      if (!tagMatch) return false;
+      if (!q) return true;
+
+      return (
+        release.version.includes(q) ||
+        release.summary.toLowerCase().includes(q) ||
+        release.entries.some(
+          (e) =>
+            e.title.toLowerCase().includes(q) ||
+            e.description.toLowerCase().includes(q) ||
+            (e.migrationNote?.toLowerCase().includes(q) ?? false),
+        )
+      );
+    });
+  }, [query, activeTag]);
+
+  function handleQueryChange(value: string) {
+    setQuery(value);
+    const next = new URLSearchParams(searchParams);
+    if (value) {
+      next.set("q", value);
+    } else {
+      next.delete("q");
+    }
+    setSearchParams(next, { replace: true });
+  }
+
+  function copyLink(version: string) {
+    const url = new URL(window.location.href);
+    url.hash = `v${version}`;
+    navigator.clipboard.writeText(url.toString());
+  }
+
+  return (
+    <div className="space-y-8 max-w-3xl mx-auto">
+      <div>
+        <h1 className="text-3xl font-bold text-stellar-text-primary mb-2">Release Notes</h1>
+        <p className="text-stellar-text-secondary">
+          Track product changes, API updates, and migration guidance.
+        </p>
+      </div>
+
+      {/* Search + filter */}
+      <div className="flex flex-col sm:flex-row gap-3">
+        <div className="relative flex-1">
+          <svg
+            className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-stellar-text-secondary"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+          </svg>
+          <input
+            type="search"
+            placeholder="Search release notes…"
+            value={query}
+            onChange={(e) => handleQueryChange(e.target.value)}
+            className="w-full rounded-lg border border-stellar-border bg-stellar-dark pl-10 pr-4 py-2 text-sm text-stellar-text-primary placeholder-stellar-text-secondary focus:outline-none focus:ring-2 focus:ring-stellar-blue"
+          />
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={() => setActiveTag("all")}
+            className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+              activeTag === "all"
+                ? "bg-stellar-blue text-white"
+                : "border border-stellar-border text-stellar-text-secondary hover:text-white"
+            }`}
+          >
+            All
+          </button>
+          {ALL_TAGS.map((tag) => (
+            <button
+              key={tag}
+              type="button"
+              onClick={() => setActiveTag(activeTag === tag ? "all" : tag)}
+              className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+                activeTag === tag
+                  ? TAG_COLORS[tag]
+                  : "border border-stellar-border text-stellar-text-secondary hover:text-white"
+              }`}
+            >
+              {TAG_LABELS[tag]}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {filtered.length === 0 && (
+        <div className="rounded-xl border border-stellar-border bg-stellar-card p-8 text-center text-stellar-text-secondary">
+          No release notes match your search.
+        </div>
+      )}
+
+      {/* Timeline */}
+      <div className="relative">
+        <div className="absolute left-4 top-0 bottom-0 w-px bg-stellar-border" aria-hidden="true" />
+        <div className="space-y-8">
+          {filtered.map((release) => (
+            <div key={release.id} id={`v${release.version}`} className="relative pl-12">
+              {/* Timeline dot */}
+              <div
+                className={`absolute left-2 top-5 h-5 w-5 -translate-x-1/2 rounded-full border-2 border-stellar-dark flex items-center justify-center ${
+                  release.tags.includes("breaking") ? "bg-red-500" : "bg-stellar-blue"
+                }`}
+                aria-hidden="true"
+              >
+                {release.tags.includes("breaking") && (
+                  <svg className="h-3 w-3 text-white" fill="currentColor" viewBox="0 0 20 20">
+                    <path fillRule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z" clipRule="evenodd" />
+                  </svg>
+                )}
+              </div>
+
+              <div className="rounded-xl border border-stellar-border bg-stellar-card p-6 space-y-4">
+                {/* Header */}
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <div className="flex items-center gap-3 flex-wrap">
+                      <h2 className="text-xl font-bold text-stellar-text-primary">
+                        v{release.version}
+                      </h2>
+                      {release.tags.map((tag) => (
+                        <TagBadge key={tag} tag={tag} />
+                      ))}
+                    </div>
+                    <p className="text-xs text-stellar-text-secondary mt-1">{release.date}</p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => copyLink(release.version)}
+                    title="Copy shareable link"
+                    className="rounded-md p-1.5 text-stellar-text-secondary hover:text-white hover:bg-stellar-dark transition-colors"
+                  >
+                    <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+                    </svg>
+                  </button>
+                </div>
+
+                <p className="text-sm text-stellar-text-secondary">{release.summary}</p>
+
+                {/* Entries */}
+                <div className="space-y-4 pt-2 border-t border-stellar-border">
+                  {release.entries
+                    .filter((e) => activeTag === "all" || e.tag === activeTag)
+                    .map((entry, idx) => (
+                      <div key={idx} className="space-y-1">
+                        <div className="flex items-center gap-2 flex-wrap">
+                          <TagBadge tag={entry.tag} />
+                          <span className="text-sm font-medium text-stellar-text-primary">
+                            {entry.title}
+                          </span>
+                        </div>
+                        <p className="text-sm text-stellar-text-secondary pl-1">{entry.description}</p>
+                        {entry.migrationNote && (
+                          <div className="mt-2 rounded-lg border border-red-500/20 bg-red-500/5 p-3">
+                            <p className="text-xs font-semibold text-red-400 mb-1">Migration note</p>
+                            <p className="text-xs text-stellar-text-secondary">{entry.migrationNote}</p>
+                          </div>
+                        )}
+                      </div>
+                    ))}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **#399 Release Notes page** — Chronological timeline at `/release-notes` with search, tag filtering (Breaking/New/Improvement/Fix/Deprecated), per-entry migration notes, and shareable anchor links.
- **#397 Notification Preferences page** — Dedicated page at `/notification-preferences` with sound toggle, delivery channel toggles (in-app/email/webhook), digest frequency selector, quiet-hours time window, and priority override radio group. Settings persist in `localStorage`.
- **#396 Asset Relationship Explorer** — SVG dependency graph at `/relationship-explorer` that queries `/api/v1/metadata/dependencies`. Supports search, status/type filtering, click-to-select with edge highlighting, and an accessible node table below the canvas.
- **#401 Status Change Subscription Service** — New backend service (`StatusSubscriptionService`) with full CRUD, trigger-status rules, configurable delivery channels, duplicate suppression windows, and an audit trail. Exposed at `/api/v1/status-subscriptions` with an internal `/notify` endpoint for the alerting pipeline.

## Test plan

- [ ] Navigate to `/release-notes` — verify timeline renders, search filters entries, tag pills highlight matching entries, copy-link button sets the URL hash.
- [ ] Navigate to `/notification-preferences` — toggle each channel, change digest frequency, enable quiet hours and set times; reload and confirm settings persist.
- [ ] Navigate to `/relationship-explorer` — graph renders nodes from the dependency API; click a node to highlight edges and open the detail panel; use search and filter dropdowns.
- [ ] POST to `/api/v1/status-subscriptions/:userId` → GET list → PATCH update → GET audit → DELETE; verify 404 for unknown IDs.
- [ ] POST to `/api/v1/status-subscriptions/notify` and confirm only subscriptions matching entityType/status and outside the suppression window are returned.

Closes #396
Closes #397
Closes #399
Closes #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)