### PR TITLE
feat: add asset insights tray

### DIFF
--- a/frontend/src/components/asset/AssetInsightsTray.tsx
+++ b/frontend/src/components/asset/AssetInsightsTray.tsx
@@ -1,0 +1,399 @@
+import { useEffect, useRef } from "react";
+import { Link } from "react-router-dom";
+import { useAssetInsightsTray, type AssetAlert } from "../../hooks/useAssetInsightsTray";
+import type { HealthScore } from "../../types";
+
+interface AssetInsightsTrayProps {
+  open: boolean;
+  symbol: string | null;
+  assetName?: string | null;
+  onClose: () => void;
+  onAddToWatchlist?: (symbol: string) => void;
+}
+
+const FOCUSABLE_SELECTOR =
+  'a[href],button,[tabindex]:not([tabindex="-1"])';
+
+const SEVERITY_COLORS: Record<AssetAlert["severity"], string> = {
+  critical: "text-red-400 bg-red-500/10 border-red-500/30",
+  warning: "text-yellow-400 bg-yellow-500/10 border-yellow-500/30",
+  info: "text-blue-400 bg-blue-500/10 border-blue-500/30",
+};
+
+const SEVERITY_DOTS: Record<AssetAlert["severity"], string> = {
+  critical: "bg-red-500",
+  warning: "bg-yellow-500",
+  info: "bg-blue-500",
+};
+
+const TREND_LABELS: Record<NonNullable<HealthScore["trend"]>, string> = {
+  improving: "Improving",
+  stable: "Stable",
+  deteriorating: "Deteriorating",
+};
+
+const TREND_COLORS: Record<NonNullable<HealthScore["trend"]>, string> = {
+  improving: "text-green-400",
+  stable: "text-blue-400",
+  deteriorating: "text-red-400",
+};
+
+const TREND_ARROWS: Record<NonNullable<HealthScore["trend"]>, string> = {
+  improving: "↑",
+  stable: "→",
+  deteriorating: "↓",
+};
+
+function scoreColor(score: number): string {
+  if (score >= 80) return "text-green-400";
+  if (score >= 50) return "text-yellow-400";
+  return "text-red-400";
+}
+
+function formatRelativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+function formatVolume(v: number): string {
+  if (v >= 1_000_000_000) return `$${(v / 1_000_000_000).toFixed(2)}B`;
+  if (v >= 1_000_000) return `$${(v / 1_000_000).toFixed(2)}M`;
+  if (v >= 1_000) return `$${(v / 1_000).toFixed(2)}K`;
+  return `$${v.toFixed(2)}`;
+}
+
+function TrendSummaryCard({ health, loading }: { health: HealthScore | null | undefined; loading: boolean }) {
+  if (loading) {
+    return (
+      <div className="rounded-lg border border-stellar-border bg-stellar-card p-4 animate-pulse">
+        <p className="h-3 w-24 rounded bg-stellar-border/60" />
+        <p className="mt-3 h-8 w-16 rounded bg-stellar-border/60" />
+      </div>
+    );
+  }
+
+  if (!health) {
+    return (
+      <div className="rounded-lg border border-stellar-border bg-stellar-card p-4">
+        <p className="text-xs uppercase text-stellar-text-secondary">Trend Summary</p>
+        <p className="mt-2 text-sm text-stellar-text-secondary">No health data available.</p>
+      </div>
+    );
+  }
+
+  const { overallScore, trend, factors } = health;
+
+  return (
+    <section aria-label="Trend summary" className="rounded-lg border border-stellar-border bg-stellar-card p-4 space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-xs font-semibold uppercase tracking-wide text-stellar-text-secondary">
+          Trend Summary
+        </p>
+        {trend ? (
+          <span className={`text-xs font-semibold ${TREND_COLORS[trend]}`}>
+            {TREND_ARROWS[trend]} {TREND_LABELS[trend]}
+          </span>
+        ) : null}
+      </div>
+
+      <div className="flex items-end gap-3">
+        <p className={`text-4xl font-bold ${scoreColor(overallScore)}`}>
+          {Math.round(overallScore)}
+        </p>
+        <p className="mb-1 text-xs text-stellar-text-secondary">/ 100 health score</p>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2">
+        {Object.entries(factors).map(([key, value]) => {
+          const label = key
+            .replace(/([A-Z])/g, " $1")
+            .replace(/^./, (s) => s.toUpperCase());
+          return (
+            <div key={key} className="flex flex-col gap-1">
+              <p className="text-xs text-stellar-text-secondary truncate">{label}</p>
+              <div className="h-1.5 rounded-full bg-stellar-border overflow-hidden">
+                <div
+                  className={`h-full rounded-full transition-all ${
+                    value >= 80 ? "bg-green-500" : value >= 50 ? "bg-yellow-500" : "bg-red-500"
+                  }`}
+                  style={{ width: `${Math.min(100, Math.max(0, value))}%` }}
+                  role="progressbar"
+                  aria-valuenow={value}
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                  aria-label={label}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+function RecentAlertsCard({ alerts, loading }: { alerts: AssetAlert[]; loading: boolean }) {
+  if (loading) {
+    return (
+      <div className="rounded-lg border border-stellar-border bg-stellar-card p-4 animate-pulse space-y-3">
+        <p className="h-3 w-24 rounded bg-stellar-border/60" />
+        {[0, 1, 2].map((i) => (
+          <p key={i} className="h-10 rounded bg-stellar-border/40" />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <section aria-label="Recent alerts" className="rounded-lg border border-stellar-border bg-stellar-card p-4 space-y-3">
+      <p className="text-xs font-semibold uppercase tracking-wide text-stellar-text-secondary">
+        Recent Alerts
+      </p>
+
+      {alerts.length === 0 ? (
+        <p className="text-sm text-stellar-text-secondary">No recent alerts.</p>
+      ) : (
+        <ul className="space-y-2" role="list">
+          {alerts.map((alert) => (
+            <li
+              key={alert.id}
+              className={`rounded-md border p-3 text-xs ${SEVERITY_COLORS[alert.severity]}`}
+            >
+              <div className="flex items-start gap-2">
+                <span
+                  className={`mt-0.5 h-2 w-2 shrink-0 rounded-full ${SEVERITY_DOTS[alert.severity]}`}
+                  aria-hidden="true"
+                />
+                <div className="min-w-0 flex-1">
+                  <p className="font-medium leading-snug">{alert.message}</p>
+                  <p className="mt-1 opacity-70">{formatRelativeTime(alert.createdAt)}</p>
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function VolumeCard({ volume, loading }: {
+  volume: { volume24h: number; volume7d: number; volume30d: number } | null | undefined;
+  loading: boolean;
+}) {
+  if (loading) {
+    return (
+      <div className="rounded-lg border border-stellar-border bg-stellar-card p-4 animate-pulse">
+        <p className="h-3 w-20 rounded bg-stellar-border/60" />
+        <div className="mt-3 grid grid-cols-3 gap-2">
+          {[0, 1, 2].map((i) => <p key={i} className="h-8 rounded bg-stellar-border/40" />)}
+        </div>
+      </div>
+    );
+  }
+
+  if (!volume) return null;
+
+  const periods = [
+    { label: "24h", value: volume.volume24h },
+    { label: "7d", value: volume.volume7d },
+    { label: "30d", value: volume.volume30d },
+  ];
+
+  return (
+    <section aria-label="Volume overview" className="rounded-lg border border-stellar-border bg-stellar-card p-4 space-y-3">
+      <p className="text-xs font-semibold uppercase tracking-wide text-stellar-text-secondary">
+        Volume
+      </p>
+      <div className="grid grid-cols-3 gap-2">
+        {periods.map(({ label, value }) => (
+          <div key={label} className="flex flex-col gap-1">
+            <p className="text-xs text-stellar-text-secondary">{label}</p>
+            <p className="text-sm font-semibold text-white">{formatVolume(value)}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function QuickActionsCard({
+  symbol,
+  onClose,
+  onAddToWatchlist,
+}: {
+  symbol: string;
+  onClose: () => void;
+  onAddToWatchlist?: (symbol: string) => void;
+}) {
+  return (
+    <section aria-label="Quick actions" className="rounded-lg border border-stellar-border bg-stellar-card p-4 space-y-3">
+      <p className="text-xs font-semibold uppercase tracking-wide text-stellar-text-secondary">
+        Quick Actions
+      </p>
+      <div className="flex flex-col gap-2">
+        <Link
+          to={`/assets/${symbol}`}
+          onClick={onClose}
+          className="flex items-center justify-between rounded-md border border-stellar-border px-3 py-2 text-sm font-medium text-stellar-text-primary transition-colors hover:border-stellar-blue hover:text-white focus:outline-none focus:ring-2 focus:ring-stellar-blue"
+        >
+          View full details
+          <span aria-hidden="true">→</span>
+        </Link>
+
+        {onAddToWatchlist ? (
+          <button
+            type="button"
+            onClick={() => onAddToWatchlist(symbol)}
+            className="flex items-center justify-between rounded-md border border-stellar-border px-3 py-2 text-sm font-medium text-stellar-text-primary transition-colors hover:border-stellar-blue hover:text-white focus:outline-none focus:ring-2 focus:ring-stellar-blue"
+          >
+            Add to watchlist
+            <span aria-hidden="true">+</span>
+          </button>
+        ) : null}
+
+        <Link
+          to={`/assets/${symbol}?tab=alerts`}
+          onClick={onClose}
+          className="flex items-center justify-between rounded-md border border-stellar-border px-3 py-2 text-sm font-medium text-stellar-text-primary transition-colors hover:border-stellar-blue hover:text-white focus:outline-none focus:ring-2 focus:ring-stellar-blue"
+        >
+          View all alerts
+          <span aria-hidden="true">→</span>
+        </Link>
+
+        <Link
+          to={`/transactions?asset=${symbol}`}
+          onClick={onClose}
+          className="flex items-center justify-between rounded-md border border-stellar-border px-3 py-2 text-sm font-medium text-stellar-text-primary transition-colors hover:border-stellar-blue hover:text-white focus:outline-none focus:ring-2 focus:ring-stellar-blue"
+        >
+          View transactions
+          <span aria-hidden="true">→</span>
+        </Link>
+      </div>
+    </section>
+  );
+}
+
+export default function AssetInsightsTray({
+  open,
+  symbol,
+  assetName,
+  onClose,
+  onAddToWatchlist,
+}: AssetInsightsTrayProps) {
+  const panelRef = useRef<HTMLDivElement | null>(null);
+
+  const { health, healthLoading, volume, volumeLoading, recentAlerts, alertsLoading } =
+    useAssetInsightsTray(open ? symbol : null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    window.setTimeout(() => {
+      panelRef.current?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR)?.focus();
+    }, 0);
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+
+      if (event.key !== "Tab" || !panelRef.current) return;
+
+      const focusable = Array.from(
+        panelRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+      ).filter((el) => !el.hasAttribute("disabled"));
+
+      if (!focusable.length) return;
+
+      const currentIndex = focusable.indexOf(document.activeElement as HTMLElement);
+      if (currentIndex === -1) return;
+
+      event.preventDefault();
+      const nextIndex = event.shiftKey
+        ? (currentIndex - 1 + focusable.length) % focusable.length
+        : (currentIndex + 1) % focusable.length;
+      focusable[nextIndex]?.focus();
+    };
+
+    document.addEventListener("keydown", onKeyDown);
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [onClose, open]);
+
+  if (!open || !symbol) return null;
+
+  const displayName = assetName ?? symbol;
+
+  return (
+    <div className="fixed inset-0 z-50">
+      <button
+        type="button"
+        aria-label="Close asset insights tray"
+        onClick={onClose}
+        className="absolute inset-0 bg-slate-950/70 backdrop-blur-sm"
+      />
+
+      <aside
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="asset-insights-tray-title"
+        className="absolute right-0 top-0 flex h-full w-full flex-col border-l border-stellar-border bg-stellar-dark shadow-2xl shadow-black/40 sm:w-[26rem] lg:w-[30rem]"
+      >
+        {/* Header */}
+        <div className="border-b border-stellar-border bg-stellar-card/80 px-4 py-4">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <p className="text-xs uppercase tracking-wide text-stellar-text-secondary">
+                Asset Insights
+              </p>
+              <h2
+                id="asset-insights-tray-title"
+                className="truncate text-xl font-semibold text-white"
+              >
+                {displayName}
+              </h2>
+              {displayName !== symbol ? (
+                <p className="mt-0.5 text-sm text-stellar-text-secondary">{symbol}</p>
+              ) : null}
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              className="shrink-0 rounded-md px-2 py-1 text-sm text-stellar-text-secondary transition hover:text-white focus:outline-none focus:ring-2 focus:ring-stellar-blue"
+              aria-label="Close asset insights"
+            >
+              ✕
+            </button>
+          </div>
+        </div>
+
+        {/* Scrollable body */}
+        <div className="flex-1 space-y-4 overflow-y-auto p-4">
+          <TrendSummaryCard health={health} loading={healthLoading} />
+          <VolumeCard volume={volume} loading={volumeLoading} />
+          <RecentAlertsCard alerts={recentAlerts} loading={alertsLoading} />
+          <QuickActionsCard
+            symbol={symbol}
+            onClose={onClose}
+            onAddToWatchlist={onAddToWatchlist}
+          />
+        </div>
+      </aside>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/AssetDiscoverySection.tsx
+++ b/frontend/src/components/dashboard/AssetDiscoverySection.tsx
@@ -7,6 +7,7 @@ import AddToWatchlistButton from "../watchlist/AddToWatchlistButton";
 import type { AssetWithHealth } from "../../types";
 import { useUserPreferencesStore } from "../../stores/userPreferencesStore";
 import { useFavorites } from "../../hooks/useFavorites";
+import { useUIStore, selectInsightsTray } from "../../stores/uiStore";
 
 function chunkAssets<T>(items: T[], size: number): T[][] {
   const rows: T[][] = [];
@@ -54,6 +55,7 @@ export default function AssetDiscoverySection({
     toggleFavoriteAsset,
   } = useFavorites();
   const favoriteAssets = useUserPreferencesStore((s) => s.favoriteAssets);
+  const { openInsightsTray } = useUIStore(selectInsightsTray);
 
   const cols = useColumnCount();
   const parentRef = useRef<HTMLDivElement>(null);
@@ -236,6 +238,14 @@ export default function AssetDiscoverySection({
                             </p>
                           ) : null}
                         </Link>
+                        <button
+                          type="button"
+                          onClick={() => openInsightsTray(asset.symbol)}
+                          className="w-full rounded-md border border-stellar-border px-3 py-2 text-xs font-medium text-stellar-text-secondary transition-colors hover:border-stellar-blue hover:text-white focus:outline-none focus:ring-2 focus:ring-stellar-blue"
+                          aria-label={`Open insights for ${asset.name ?? asset.symbol}`}
+                        >
+                          Insights
+                        </button>
                       </div>
                     ))}
                   </div>

--- a/frontend/src/hooks/useAssetInsightsTray.ts
+++ b/frontend/src/hooks/useAssetInsightsTray.ts
@@ -1,0 +1,52 @@
+import { useQuery } from "@tanstack/react-query";
+import { getAssetHealth, getAssetAlerts, getAssetVolume, getAssetHealthHistory } from "../services/api";
+
+export interface AssetAlert {
+  id: string;
+  type: string;
+  severity: "info" | "warning" | "critical";
+  message: string;
+  createdAt: string;
+}
+
+export function useAssetInsightsTray(symbol: string | null) {
+  const enabled = !!symbol;
+
+  const health = useQuery({
+    queryKey: ["asset-health", symbol],
+    queryFn: () => getAssetHealth(symbol!),
+    enabled,
+    refetchInterval: 30_000,
+  });
+
+  const alerts = useQuery({
+    queryKey: ["asset-alerts", symbol],
+    queryFn: () => getAssetAlerts(symbol!),
+    enabled,
+  });
+
+  const volume = useQuery({
+    queryKey: ["asset-volume", symbol],
+    queryFn: () => getAssetVolume(symbol!),
+    enabled,
+  });
+
+  const healthHistory = useQuery({
+    queryKey: ["asset-health-history", symbol],
+    queryFn: () => getAssetHealthHistory(symbol!),
+    enabled,
+  });
+
+  const recentAlerts: AssetAlert[] = (alerts.data ?? []).slice(0, 5);
+
+  return {
+    health: health.data,
+    healthLoading: health.isLoading,
+    volume: volume.data,
+    volumeLoading: volume.isLoading,
+    healthHistory: healthHistory.data,
+    healthHistoryLoading: healthHistory.isLoading,
+    recentAlerts,
+    alertsLoading: alerts.isLoading,
+  };
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -26,6 +26,8 @@ import DrilldownDrawer, {
   type DrilldownContext,
 } from "../components/dashboard/DrilldownDrawer";
 import DashboardSharingModal from "../components/dashboard/DashboardSharingModal";
+import AssetInsightsTray from "../components/asset/AssetInsightsTray";
+import { useUIStore, selectInsightsTray } from "../stores/uiStore";
 import type { AssetWithHealth, Bridge, FilterStatus } from "../types";
 
 type DashboardView = "overview" | "assets" | "bridges";
@@ -146,6 +148,8 @@ export default function Dashboard() {
   const navigate = useNavigate();
   const [exportPickerOpen, setExportPickerOpen] = useState(false);
   const [sharingOpen, setSharingOpen] = useState(false);
+  const { open: insightsTrayOpen, symbol: insightsTraySymbol, closeInsightsTray } =
+    useUIStore(selectInsightsTray);
   const {
     data: assetsWithHealth,
     isLoading: assetsLoading,
@@ -651,6 +655,14 @@ export default function Dashboard() {
         context={activeDrilldown}
         onClose={() => setDrilldown(null)}
         onBack={() => setDrilldown(null)}
+      />
+      <AssetInsightsTray
+        open={insightsTrayOpen}
+        symbol={insightsTraySymbol}
+        assetName={
+          assetsWithHealth?.find((a) => a.symbol === insightsTraySymbol)?.name ?? null
+        }
+        onClose={closeInsightsTray}
       />
     </div>
   );

--- a/frontend/src/stores/uiStore.ts
+++ b/frontend/src/stores/uiStore.ts
@@ -41,6 +41,9 @@ export interface UIState {
   selectedBridge: string | null;
   selectedTimeRange: "1h" | "24h" | "7d" | "30d";
 
+  // Asset insights tray
+  insightsTrayOpen: boolean;
+
   // View states
   isMobileView: boolean;
   isTouchDevice: boolean;
@@ -70,6 +73,10 @@ export interface UIActions {
   setSelectedBridge: (bridge: string | null) => void;
   setSelectedTimeRange: (range: "1h" | "24h" | "7d" | "30d") => void;
 
+  // Asset insights tray actions
+  openInsightsTray: (symbol: string) => void;
+  closeInsightsTray: () => void;
+
   // View actions
   setIsMobileView: (isMobile: boolean) => void;
   setIsTouchDevice: (isTouch: boolean) => void;
@@ -91,6 +98,7 @@ const initialUIState: UIState = {
   selectedTimeRange: "24h",
   isMobileView: false,
   isTouchDevice: false,
+  insightsTrayOpen: false,
 };
 
 export const useUIStore = create<UIState & UIActions>()(
@@ -175,6 +183,14 @@ export const useUIStore = create<UIState & UIActions>()(
         set({ selectedTimeRange: range }, false, "setSelectedTimeRange");
       },
 
+      openInsightsTray: (symbol) => {
+        set({ selectedAsset: symbol, insightsTrayOpen: true }, false, "openInsightsTray");
+      },
+
+      closeInsightsTray: () => {
+        set({ insightsTrayOpen: false }, false, "closeInsightsTray");
+      },
+
       setIsMobileView: (isMobile) => {
         set({ isMobileView: isMobile }, false, "setIsMobileView");
       },
@@ -212,3 +228,10 @@ export const selectSelectedAsset = (state: UIState & UIActions) =>
 
 export const selectIsMobileView = (state: UIState & UIActions) =>
   state.isMobileView;
+
+export const selectInsightsTray = (state: UIState & UIActions) => ({
+  open: state.insightsTrayOpen,
+  symbol: state.selectedAsset,
+  openInsightsTray: state.openInsightsTray,
+  closeInsightsTray: state.closeInsightsTray,
+});


### PR DESCRIPTION
## Summary

- Adds a slide-out `AssetInsightsTray` component that surfaces compact insights for the selected asset: health score + factor progress bars (trend summary), volume overview (24h/7d/30d), recent alerts list, and quick-action links
- Wires the tray to asset selection state via a new `insightsTrayOpen` / `openInsightsTray` / `closeInsightsTray` slice in `uiStore`
- Adds an **Insights** button to every asset card in `AssetDiscoverySection` that opens the tray for that asset
- Renders the tray in `Dashboard` alongside the existing `DrilldownDrawer`
- Fully keyboard accessible: `Escape` closes, `Tab`/`Shift+Tab` cycles focus within the panel, focus is trapped while open (matching `NotificationsDrawer` and `DrilldownDrawer` patterns)

## Closes

Closes #486
Closes #485
Closes #484
Closes #489

## Test plan

- [ ] Click **Insights** on any asset card — tray slides in from the right with the correct asset name
- [ ] Trend summary card shows health score, factor bars, and improving/stable/deteriorating trend
- [ ] Volume card shows 24h / 7d / 30d figures
- [ ] Recent alerts card lists up to 5 alerts with severity colour coding
- [ ] Quick actions: "View full details", "View all alerts", "Transactions" links navigate correctly and close the tray
- [ ] Press `Escape` — tray closes
- [ ] `Tab` / `Shift+Tab` cycles focus only within the tray panel (no focus escapes)
- [ ] Clicking the backdrop closes the tray
- [ ] Opening tray for a second asset replaces the previous one
- [ ] No layout shift or scroll-lock leak after close