### PR TITLE
feat: dashboard UX enhancements (filter presets, entity summary banner, tour, live update pills)

### DIFF
--- a/frontend/docs/dashboard-tour.md
+++ b/frontend/docs/dashboard-tour.md
@@ -1,0 +1,63 @@
+# Dashboard Tour
+
+A lightweight, accessible overlay that guides new users through the main
+dashboard regions.
+
+## Capabilities
+
+- **Step-by-step guide** — walks the user through key dashboard regions with a
+  spotlight and a tooltip per step.
+- **Skip and resume** — the tour can be skipped at any point and resumes at the
+  last viewed step the next time it is started.
+- **Responsive positioning** — the spotlight and tooltip recompute on resize and
+  scroll, and the tooltip is clamped within the viewport.
+- **Accessible navigation** — the tooltip is a focusable modal dialog with ARIA
+  labelling; supports keyboard navigation (`←`/`→` to move, `Esc` to skip) and
+  moves focus to each step.
+- **Persist completion** — completion and the last-viewed step are stored in
+  local storage, so the tour auto-starts only once and remembers progress.
+
+## Main files
+
+- `src/hooks/useDashboardTour.ts` — tour state, persistence, skip/resume logic.
+- `src/components/dashboard/DashboardTour.tsx` — overlay, spotlight, tooltip.
+- `src/pages/Dashboard.tsx` — step definitions, region markers, trigger button.
+
+## Flow
+
+1. On a user's first visit the tour auto-starts at step one.
+2. Each step highlights a dashboard region (`data-tour="..."`) and shows a
+   tooltip with the step title, description, progress dots, and controls.
+3. Navigate with **Back** / **Next**, the arrow keys, or **Skip**.
+4. **Skip** (button, `Esc`, or clicking the backdrop) closes the tour but keeps
+   the current step so it can be resumed.
+5. **Finish** on the last step marks the tour completed.
+6. Users can re-open the tour at any time via the **Take a tour** / **Replay
+   tour** button in the dashboard toolbar.
+
+## Step definition
+
+```ts
+interface TourStep {
+  id: string;
+  target: string; // CSS selector, e.g. '[data-tour="kpis"]'
+  title: string;
+  body: string;
+  placement?: "top" | "bottom" | "left" | "right" | "auto";
+}
+```
+
+Region markers currently used on the dashboard:
+
+- `[data-tour="toolbar"]` — preset/refresh/export/share actions.
+- `[data-tour="filters"]` — the asset/bridge filter panel.
+- `[data-tour="kpis"]` — the key-metrics banner.
+- `[data-tour="status-cards"]` — the inline status cards.
+
+## Persistence
+
+- Storage key: `bridge-watch:dashboard-tour:v1`.
+- Stored shape: `{ completed: boolean, lastStep: number, seen: boolean }`.
+  - `seen` suppresses auto-start after the first run.
+  - `lastStep` enables skip-and-resume.
+  - `completed` is set when the user finishes the final step.

--- a/frontend/docs/entity-summary-banner.md
+++ b/frontend/docs/entity-summary-banner.md
@@ -1,0 +1,72 @@
+# Entity Summary Banner
+
+A banner that surfaces the most important summary fields for the selected entity
+(asset, bridge, etc.) at the top of its detail page.
+
+## Capabilities
+
+- **Summary fields** — shows the key metrics for an entity in a compact grid.
+- **Context sensitive** — the calling page supplies the field set, so each entity
+  type shows the fields that matter for it (e.g. assets show health, price,
+  liquidity, trend).
+- **Compact layout** — dense by default; values, status dots, and trend chips.
+- **Compact and expanded modes** — a built-in toggle switches between a dense grid
+  and an expanded layout that reveals per-field hint text.
+- **Loading state** — renders skeleton cards while the underlying data loads.
+- **Drilldown links** — each field can link to a route (`to`) or trigger an
+  in-page drilldown (`onDrilldown`, e.g. switching detail tabs).
+
+## Main files
+
+- `src/components/entity/EntitySummaryBanner.tsx` — the banner component.
+- `src/components/entity/index.ts` — public exports.
+- `src/pages/AssetDetail.tsx` — integration for the asset entity.
+
+## Behaviour
+
+- The banner header shows an entity-type badge, the entity title, and an optional
+  subtitle. An `actions` slot holds page-level controls (refresh, watchlist, etc.).
+- The mode toggle (top-right) flips between **Compact view** and **Expanded view**.
+  Expanded mode shows each field's `hint` for extra context.
+- Each field renders its label, value, an optional status dot
+  (`healthy` / `warning` / `critical` / `neutral`), and an optional trend chip
+  (`up` / `down` / `neutral`).
+- A field with `to` renders a router `Link`; a field with `onDrilldown` renders a
+  button. The affordance label defaults to "View" and can be overridden with
+  `drilldownLabel`.
+- While `loading` is true, the banner renders skeleton cards (at least four).
+
+## Usage
+
+```tsx
+import { EntitySummaryBanner, type EntitySummaryField } from "../components/entity";
+
+const fields: EntitySummaryField[] = [
+  {
+    id: "health",
+    label: "Health score",
+    value: "82/100",
+    status: "healthy",
+    trend: { direction: "up", label: "Improving" },
+    hint: "Composite health score across all factors.",
+    onDrilldown: () => setTab("summary"),
+    drilldownLabel: "Open summary",
+  },
+  // ...more fields
+];
+
+<EntitySummaryBanner
+  entityType="Asset"
+  title="USDC"
+  subtitle="Detailed monitoring for USDC on the Stellar network"
+  fields={fields}
+  loading={isLoading}
+  defaultMode="compact"
+/>;
+```
+
+## Reuse
+
+The banner is entity-agnostic: any detail page can build its own
+`EntitySummaryField[]` and render the banner. This keeps the layout, loading
+state, mode toggle, and drilldown behaviour consistent across entity types.

--- a/frontend/docs/filter-presets.md
+++ b/frontend/docs/filter-presets.md
@@ -1,0 +1,61 @@
+# Filter Presets Menu
+
+Save commonly used dashboard filter combinations and reapply them from a single menu.
+
+## Capabilities
+
+- **Save preset** — name and store the current dashboard filters (assets, bridges, status, time range).
+- **Load preset** — apply a saved preset to the dashboard in one click.
+- **Rename preset** — rename a preset inline; duplicate names are rejected.
+- **Delete preset** — remove presets that are no longer needed.
+- **Shared access options** — mark a preset as `Shared` or `Private`. Shared presets expose a "Copy link" action that produces a URL re-applying the preset's filters.
+- **Persistent storage** — presets are persisted in browser local storage and survive reloads.
+
+## Main files
+
+- `src/hooks/useDashboardFilters.ts` — filter state, preset CRUD, share-URL builder.
+- `src/components/Filters/FilterPresetsMenu.tsx` — dropdown menu UI.
+- `src/components/Filters/AssetFilterPanel.tsx` — inline preset controls in the filter sidebar.
+- `src/pages/Dashboard.tsx` — wires the menu into the dashboard toolbar.
+
+## Workflow
+
+1. Apply one or more filters on the dashboard (assets, bridges, status, time range).
+2. Open the **Presets** menu in the dashboard toolbar.
+3. Enter a name and choose **Save**. The current filter combination is stored.
+4. Reopen the menu at any time and click a preset name to reapply it.
+5. Use **Rename**, **Make shared / Make private**, or **Delete** under each preset.
+6. For shared presets, choose **Copy link** to share a URL that opens the dashboard with the preset's filters applied.
+
+## Preset definition
+
+```ts
+interface DashboardFilterPreset {
+  id: string;
+  name: string;
+  filters: {
+    assets: string[];
+    bridges: string[];
+    status: "all" | "healthy" | "warning" | "critical";
+    timeRange: "all" | "24h" | "7d" | "30d";
+  };
+  shared: boolean;
+  createdAt: number;
+  updatedAt: number;
+}
+```
+
+## Persistence
+
+- Storage key: `bridge-watch:dashboard-filter-presets:v1`.
+- Stored as a JSON array of `DashboardFilterPreset` objects.
+- Presets saved before the shared/timestamp fields existed are normalized on read
+  (`shared` defaults to `false`, timestamps default to the current time).
+
+## Shared links
+
+A shared preset's link encodes the filters as dashboard URL search params, e.g.:
+
+`/dashboard?assets=USDC,EURC&bridges=Circle&status=warning&range=7d`
+
+Opening the link applies those filters because dashboard filter state is URL-persisted.

--- a/frontend/docs/live-update-pills.md
+++ b/frontend/docs/live-update-pills.md
@@ -1,0 +1,59 @@
+# Live Update Pills
+
+Small pills that show how recently a view's data updated, whether it is stale,
+and whether it is polling live.
+
+## Capabilities
+
+- **Last updated time** — shows a short relative time, e.g. "Updated 5s ago".
+- **Stale indicator** — switches to an amber "stale" state once the data is older
+  than a configurable threshold (default 60s).
+- **Live polling state** — shows a pulsing green dot and a "live" suffix while the
+  view is actively fetching/polling.
+- **Compact size** — a single rounded pill with a status dot and short text.
+- **Accessible text** — exposes a full sentence via `role="status"`,
+  `aria-live="polite"`, and an `aria-label`; the decorative dot is hidden from
+  assistive tech.
+
+## Main files
+
+- `src/hooks/useRelativeTime.ts` — relative-time formatting, age, and staleness;
+  re-renders on a cadence matched to the value's age.
+- `src/components/LiveUpdatePill/LiveUpdatePill.tsx` — the pill component.
+- `src/pages/Dashboard.tsx`, `src/pages/AssetDetail.tsx` — reuse sites.
+
+## Update semantics
+
+- **Timestamp source** — pass `updatedAt` from the data layer. The reuse sites use
+  React Query's `dataUpdatedAt` (the last successful fetch time). `null` /
+  invalid values render as "never".
+- **Relative buckets** — `< 5s` → "just now", `< 60s` → "Ns ago",
+  `< 60m` → "Nm ago", `< 24h` → "Nh ago", else "Nd ago".
+- **Re-render cadence** — every 1s under a minute old, every 30s under an hour,
+  every 5m beyond that. This keeps the text fresh without excessive renders.
+- **Staleness** — `isStale` becomes true once `age > staleAfterMs`. A stale pill
+  takes priority over the live state.
+- **Polling** — when `polling` is true and the data is not stale, the pill shows
+  the live (pulsing) state. While polling but stale, the stale state still wins.
+
+## States
+
+| State   | Dot            | Text example         |
+| ------- | -------------- | -------------------- |
+| live    | pulsing green  | `Updated 3s ago · live` |
+| fresh   | green          | `Updated 12s ago`    |
+| stale   | amber          | `Updated 5m ago · stale` |
+| unknown | grey           | `Updated: never`     |
+
+## Usage
+
+```tsx
+import { LiveUpdatePill } from "../components/LiveUpdatePill";
+
+<LiveUpdatePill
+  updatedAt={query.dataUpdatedAt > 0 ? query.dataUpdatedAt : null}
+  polling={query.isFetching}
+  staleAfterMs={60_000}
+  label="Updated"
+/>;
+```

--- a/frontend/src/components/Filters/FilterPresetsMenu.tsx
+++ b/frontend/src/components/Filters/FilterPresetsMenu.tsx
@@ -1,0 +1,266 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  buildPresetShareUrl,
+  isDashboardFilterActive,
+  type DashboardFilterPreset,
+  type DashboardFilters,
+} from "../../hooks/useDashboardFilters";
+
+interface FilterPresetsMenuProps {
+  readonly filters: DashboardFilters;
+  readonly presets: DashboardFilterPreset[];
+  readonly onSavePreset: (name: string) => boolean;
+  readonly onApplyPreset: (id: string) => void;
+  readonly onRenamePreset: (id: string, name: string) => boolean;
+  readonly onDeletePreset: (id: string) => void;
+  readonly onToggleShared: (id: string, shared: boolean) => void;
+  /** Pathname used when building shareable preset links. Defaults to the dashboard. */
+  readonly sharePathname?: string;
+}
+
+function summarizeFilters(filters: DashboardFilters): string {
+  const parts: string[] = [];
+  if (filters.assets.length > 0) parts.push(`${filters.assets.length} asset${filters.assets.length > 1 ? "s" : ""}`);
+  if (filters.bridges.length > 0) parts.push(`${filters.bridges.length} bridge${filters.bridges.length > 1 ? "s" : ""}`);
+  if (filters.status !== "all") parts.push(filters.status);
+  if (filters.timeRange !== "all") parts.push(filters.timeRange);
+  return parts.length > 0 ? parts.join(" • ") : "No filters";
+}
+
+/**
+ * Dropdown menu for saving, loading, renaming, deleting and sharing dashboard
+ * filter presets. Hooks into the dashboard filter state via the supplied
+ * callbacks; preset definitions are persisted by `useDashboardFilters`.
+ */
+export default function FilterPresetsMenu({
+  filters,
+  presets,
+  onSavePreset,
+  onApplyPreset,
+  onRenamePreset,
+  onDeletePreset,
+  onToggleShared,
+  sharePathname = "/dashboard",
+}: FilterPresetsMenuProps) {
+  const [open, setOpen] = useState(false);
+  const [presetName, setPresetName] = useState("");
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editingName, setEditingName] = useState("");
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const canSaveCurrent = isDashboardFilterActive(filters);
+
+  useEffect(() => {
+    if (!open) return;
+
+    function handlePointer(event: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    }
+    function handleKey(event: KeyboardEvent) {
+      if (event.key === "Escape") setOpen(false);
+    }
+
+    document.addEventListener("mousedown", handlePointer);
+    document.addEventListener("keydown", handleKey);
+    return () => {
+      document.removeEventListener("mousedown", handlePointer);
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, [open]);
+
+  function handleSave() {
+    if (onSavePreset(presetName)) {
+      setPresetName("");
+    }
+  }
+
+  function startRename(preset: DashboardFilterPreset) {
+    setEditingId(preset.id);
+    setEditingName(preset.name);
+  }
+
+  function commitRename() {
+    if (editingId && onRenamePreset(editingId, editingName)) {
+      setEditingId(null);
+      setEditingName("");
+    }
+  }
+
+  async function handleCopyShareLink(preset: DashboardFilterPreset) {
+    const url = buildPresetShareUrl(preset, sharePathname);
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopiedId(preset.id);
+      window.setTimeout(() => setCopiedId((current) => (current === preset.id ? null : current)), 2000);
+    } catch {
+      // Clipboard may be unavailable (insecure context); fail silently.
+    }
+  }
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        className="flex items-center gap-2 rounded-full border border-stellar-border px-4 py-2 text-sm text-white transition-colors hover:bg-stellar-border"
+      >
+        <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2a1 1 0 01-.293.707L15 12.414V19a1 1 0 01-1.447.894l-4-2A1 1 0 019 17v-4.586L3.293 6.707A1 1 0 013 6V4z" />
+        </svg>
+        Presets
+        {presets.length > 0 ? (
+          <span className="rounded-full bg-stellar-blue/20 px-2 text-xs text-stellar-blue">{presets.length}</span>
+        ) : null}
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          aria-label="Filter presets"
+          className="absolute right-0 z-40 mt-2 w-80 rounded-lg border border-stellar-border bg-stellar-card p-4 shadow-xl"
+        >
+          <div className="space-y-2">
+            <label htmlFor="filter-preset-menu-name" className="block text-xs font-medium text-stellar-text-primary">
+              Save current filters
+            </label>
+            <p className="text-xs text-stellar-text-secondary">{summarizeFilters(filters)}</p>
+            <div className="flex gap-2">
+              <input
+                id="filter-preset-menu-name"
+                type="text"
+                value={presetName}
+                onChange={(event) => setPresetName(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") handleSave();
+                }}
+                placeholder="Preset name"
+                className="flex-1 rounded-md border border-stellar-border bg-stellar-dark px-2 py-1.5 text-xs text-stellar-text-primary placeholder:text-stellar-text-secondary focus:outline-none focus:ring-2 focus:ring-stellar-blue"
+              />
+              <button
+                type="button"
+                onClick={handleSave}
+                disabled={!canSaveCurrent || presetName.trim().length === 0}
+                className="rounded-md border border-stellar-blue bg-stellar-blue/20 px-3 py-1.5 text-xs text-white transition-colors hover:bg-stellar-blue/30 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                Save
+              </button>
+            </div>
+            {!canSaveCurrent ? (
+              <p className="text-xs text-stellar-text-secondary">Apply at least one filter to save a preset.</p>
+            ) : null}
+          </div>
+
+          <div className="my-3 border-t border-stellar-border" />
+
+          <div className="space-y-2">
+            <p className="text-xs font-medium text-stellar-text-primary">Saved presets</p>
+            {presets.length === 0 ? (
+              <p className="text-xs text-stellar-text-secondary">No presets saved yet.</p>
+            ) : (
+              <ul className="max-h-72 space-y-2 overflow-auto">
+                {presets.map((preset) => (
+                  <li
+                    key={preset.id}
+                    className="rounded-md border border-stellar-border bg-stellar-dark/60 p-2"
+                  >
+                    {editingId === preset.id ? (
+                      <div className="flex gap-2">
+                        <input
+                          type="text"
+                          value={editingName}
+                          autoFocus
+                          onChange={(event) => setEditingName(event.target.value)}
+                          onKeyDown={(event) => {
+                            if (event.key === "Enter") commitRename();
+                            if (event.key === "Escape") setEditingId(null);
+                          }}
+                          aria-label={`Rename ${preset.name}`}
+                          className="flex-1 rounded border border-stellar-border bg-stellar-dark px-2 py-1 text-xs text-stellar-text-primary focus:outline-none focus:ring-2 focus:ring-stellar-blue"
+                        />
+                        <button
+                          type="button"
+                          onClick={commitRename}
+                          className="rounded border border-stellar-border px-2 py-1 text-xs text-stellar-text-secondary hover:text-white"
+                        >
+                          Save
+                        </button>
+                      </div>
+                    ) : (
+                      <>
+                        <div className="flex items-center justify-between gap-2">
+                          <button
+                            type="button"
+                            role="menuitem"
+                            onClick={() => {
+                              onApplyPreset(preset.id);
+                              setOpen(false);
+                            }}
+                            className="flex-1 truncate text-left text-sm text-stellar-text-primary hover:text-white"
+                            title={`Apply ${preset.name}`}
+                          >
+                            {preset.name}
+                          </button>
+                          {preset.shared ? (
+                            <span className="rounded-full bg-green-500/15 px-2 py-0.5 text-[10px] uppercase tracking-wide text-green-300">
+                              Shared
+                            </span>
+                          ) : (
+                            <span className="rounded-full bg-stellar-border/60 px-2 py-0.5 text-[10px] uppercase tracking-wide text-stellar-text-secondary">
+                              Private
+                            </span>
+                          )}
+                        </div>
+                        <p className="mt-1 truncate text-[11px] text-stellar-text-secondary">
+                          {summarizeFilters(preset.filters)}
+                        </p>
+                        <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px]">
+                          <button
+                            type="button"
+                            onClick={() => startRename(preset)}
+                            className="text-stellar-text-secondary hover:text-white"
+                          >
+                            Rename
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => onToggleShared(preset.id, !preset.shared)}
+                            className="text-stellar-text-secondary hover:text-white"
+                          >
+                            {preset.shared ? "Make private" : "Make shared"}
+                          </button>
+                          {preset.shared ? (
+                            <button
+                              type="button"
+                              onClick={() => {
+                                void handleCopyShareLink(preset);
+                              }}
+                              className="text-stellar-blue hover:text-white"
+                            >
+                              {copiedId === preset.id ? "Copied!" : "Copy link"}
+                            </button>
+                          ) : null}
+                          <button
+                            type="button"
+                            onClick={() => onDeletePreset(preset.id)}
+                            className="text-red-300 hover:text-red-200"
+                          >
+                            Delete
+                          </button>
+                        </div>
+                      </>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/LiveUpdatePill/LiveUpdatePill.tsx
+++ b/frontend/src/components/LiveUpdatePill/LiveUpdatePill.tsx
@@ -1,0 +1,72 @@
+import { useRelativeTime, type TimestampInput } from "../../hooks/useRelativeTime";
+
+interface LiveUpdatePillProps {
+  /** When the view's data was last updated. */
+  updatedAt: TimestampInput;
+  /** Mark the value stale once older than this (ms). Defaults to 60s. */
+  staleAfterMs?: number;
+  /** Whether the view is actively polling for live updates. */
+  polling?: boolean;
+  /** Prefix for the visible/announced text. Defaults to "Updated". */
+  label?: string;
+  className?: string;
+}
+
+type PillState = "live" | "fresh" | "stale" | "unknown";
+
+const dotClasses: Record<PillState, string> = {
+  live: "bg-green-400",
+  fresh: "bg-green-400",
+  stale: "bg-yellow-400",
+  unknown: "bg-stellar-text-secondary",
+};
+
+const containerClasses: Record<PillState, string> = {
+  live: "border-green-400/30 bg-green-500/10 text-green-300",
+  fresh: "border-stellar-border bg-stellar-dark/50 text-stellar-text-secondary",
+  stale: "border-yellow-400/30 bg-yellow-500/10 text-yellow-300",
+  unknown: "border-stellar-border bg-stellar-dark/50 text-stellar-text-secondary",
+};
+
+/**
+ * Compact pill showing how recently a view updated, whether it is stale, and
+ * whether it is polling live. Designed to be reused across views.
+ */
+export default function LiveUpdatePill({
+  updatedAt,
+  staleAfterMs = 60_000,
+  polling = false,
+  label = "Updated",
+  className = "",
+}: LiveUpdatePillProps) {
+  const { text, isStale, ageMs } = useRelativeTime(updatedAt, { staleAfterMs });
+
+  const state: PillState =
+    ageMs === null ? "unknown" : isStale ? "stale" : polling ? "live" : "fresh";
+
+  const suffix = state === "stale" ? " · stale" : state === "live" ? " · live" : "";
+  const announced =
+    ageMs === null
+      ? `${label}: never`
+      : `${label} ${text}${isStale ? ", data is stale" : polling ? ", live updates on" : ""}`;
+
+  return (
+    <span
+      role="status"
+      aria-live="polite"
+      aria-label={announced}
+      title={announced}
+      className={`inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-xs ${containerClasses[state]} ${className}`}
+    >
+      <span className="relative flex h-2 w-2" aria-hidden="true">
+        {state === "live" ? (
+          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-400 opacity-75" />
+        ) : null}
+        <span className={`relative inline-flex h-2 w-2 rounded-full ${dotClasses[state]}`} />
+      </span>
+      <span aria-hidden="true">
+        {ageMs === null ? `${label}: never` : `${label} ${text}${suffix}`}
+      </span>
+    </span>
+  );
+}

--- a/frontend/src/components/LiveUpdatePill/index.ts
+++ b/frontend/src/components/LiveUpdatePill/index.ts
@@ -1,0 +1,1 @@
+export { default as LiveUpdatePill } from "./LiveUpdatePill";

--- a/frontend/src/components/dashboard/DashboardTour.tsx
+++ b/frontend/src/components/dashboard/DashboardTour.tsx
@@ -1,0 +1,230 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import type { TourStep } from "../../hooks/useDashboardTour";
+
+interface DashboardTourProps {
+  readonly steps: TourStep[];
+  readonly activeStep: number | null;
+  readonly onNext: () => void;
+  readonly onPrev: () => void;
+  readonly onSkip: () => void;
+  readonly onFinish: () => void;
+}
+
+interface TargetRect {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+const SPOTLIGHT_PADDING = 8;
+const TOOLTIP_GAP = 12;
+const TOOLTIP_WIDTH = 320;
+
+function readRect(target: string): TargetRect | null {
+  if (typeof document === "undefined") return null;
+  const element = document.querySelector(target);
+  if (!element) return null;
+  const rect = element.getBoundingClientRect();
+  return { top: rect.top, left: rect.left, width: rect.width, height: rect.height };
+}
+
+/**
+ * Lightweight dashboard tour overlay. Renders a spotlight around the active
+ * step's target element and an accessible tooltip with step navigation.
+ * Positioning recomputes on resize/scroll so it stays responsive.
+ */
+export default function DashboardTour({
+  steps,
+  activeStep,
+  onNext,
+  onPrev,
+  onSkip,
+  onFinish,
+}: DashboardTourProps) {
+  const [rect, setRect] = useState<TargetRect | null>(null);
+  const tooltipRef = useRef<HTMLDivElement>(null);
+  const step = activeStep !== null ? steps[activeStep] : null;
+  const isLast = activeStep !== null && activeStep === steps.length - 1;
+  const isFirst = activeStep === 0;
+
+  const updateRect = useCallback(() => {
+    if (!step) {
+      setRect(null);
+      return;
+    }
+    setRect(readRect(step.target));
+  }, [step]);
+
+  // Scroll the target into view and measure it when the step changes.
+  useLayoutEffect(() => {
+    if (!step) return;
+    const element = document.querySelector(step.target);
+    if (element) {
+      element.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+    updateRect();
+  }, [step, updateRect]);
+
+  // Keep the spotlight aligned as the layout changes (responsive positioning).
+  useEffect(() => {
+    if (!step) return;
+    const handle = () => updateRect();
+    window.addEventListener("resize", handle);
+    window.addEventListener("scroll", handle, true);
+    const interval = window.setInterval(handle, 250);
+    return () => {
+      window.removeEventListener("resize", handle);
+      window.removeEventListener("scroll", handle, true);
+      window.clearInterval(interval);
+    };
+  }, [step, updateRect]);
+
+  // Move focus to the tooltip on each step for keyboard/screen-reader users.
+  useEffect(() => {
+    if (step && tooltipRef.current) {
+      tooltipRef.current.focus();
+    }
+  }, [step]);
+
+  // Keyboard navigation.
+  useEffect(() => {
+    if (!step) return;
+    function handleKey(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onSkip();
+      } else if (event.key === "ArrowRight") {
+        event.preventDefault();
+        onNext();
+      } else if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        onPrev();
+      }
+    }
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [step, onNext, onPrev, onSkip]);
+
+  if (!step || activeStep === null || typeof document === "undefined") {
+    return null;
+  }
+
+  const viewportWidth = window.innerWidth;
+  const viewportHeight = window.innerHeight;
+
+  // Resolve tooltip position. Prefer below the target, flip above if needed.
+  let tooltipTop = TOOLTIP_GAP;
+  let tooltipLeft = TOOLTIP_GAP;
+
+  if (rect) {
+    const spaceBelow = viewportHeight - (rect.top + rect.height);
+    const placeBelow = step.placement === "bottom" || (step.placement !== "top" && spaceBelow > 220);
+
+    tooltipTop = placeBelow
+      ? rect.top + rect.height + SPOTLIGHT_PADDING + TOOLTIP_GAP
+      : Math.max(TOOLTIP_GAP, rect.top - SPOTLIGHT_PADDING - TOOLTIP_GAP - 200);
+
+    tooltipLeft = Math.min(
+      Math.max(rect.left + rect.width / 2 - TOOLTIP_WIDTH / 2, TOOLTIP_GAP),
+      viewportWidth - TOOLTIP_WIDTH - TOOLTIP_GAP,
+    );
+  } else {
+    // No target found — center the tooltip.
+    tooltipTop = viewportHeight / 2 - 120;
+    tooltipLeft = Math.max(TOOLTIP_GAP, viewportWidth / 2 - TOOLTIP_WIDTH / 2);
+  }
+
+  const titleId = `dashboard-tour-title-${step.id}`;
+  const bodyId = `dashboard-tour-body-${step.id}`;
+
+  return createPortal(
+    <div className="fixed inset-0 z-[100]" aria-hidden={false}>
+      {/* Dimmed backdrop. Clicking outside skips the tour. */}
+      <button
+        type="button"
+        aria-label="Skip tour"
+        onClick={onSkip}
+        className="absolute inset-0 h-full w-full cursor-default bg-black/50"
+      />
+
+      {/* Spotlight around the target element. */}
+      {rect ? (
+        <div
+          className="pointer-events-none absolute rounded-lg ring-2 ring-stellar-blue transition-all duration-200"
+          style={{
+            top: rect.top - SPOTLIGHT_PADDING,
+            left: rect.left - SPOTLIGHT_PADDING,
+            width: rect.width + SPOTLIGHT_PADDING * 2,
+            height: rect.height + SPOTLIGHT_PADDING * 2,
+            boxShadow: "0 0 0 9999px rgba(0,0,0,0.5)",
+          }}
+        />
+      ) : null}
+
+      {/* Tooltip / step card. */}
+      <div
+        ref={tooltipRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={bodyId}
+        tabIndex={-1}
+        className="absolute w-80 rounded-xl border border-stellar-border bg-stellar-card p-4 shadow-2xl focus:outline-none focus-visible:ring-2 focus-visible:ring-stellar-blue"
+        style={{ top: tooltipTop, left: tooltipLeft }}
+      >
+        <div className="flex items-center justify-between">
+          <span className="text-xs font-medium uppercase tracking-wide text-stellar-text-secondary">
+            Step {activeStep + 1} of {steps.length}
+          </span>
+          <button
+            type="button"
+            onClick={onSkip}
+            className="text-xs text-stellar-text-secondary hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-stellar-blue"
+          >
+            Skip
+          </button>
+        </div>
+
+        <h3 id={titleId} className="mt-2 text-base font-semibold text-white">
+          {step.title}
+        </h3>
+        <p id={bodyId} className="mt-1 text-sm text-stellar-text-secondary" aria-live="polite">
+          {step.body}
+        </p>
+
+        {/* Progress dots. */}
+        <div className="mt-3 flex items-center gap-1.5" aria-hidden="true">
+          {steps.map((dot, index) => (
+            <span
+              key={dot.id}
+              className={`h-1.5 rounded-full transition-all ${
+                index === activeStep ? "w-4 bg-stellar-blue" : "w-1.5 bg-stellar-border"
+              }`}
+            />
+          ))}
+        </div>
+
+        <div className="mt-4 flex items-center justify-between gap-2">
+          <button
+            type="button"
+            onClick={onPrev}
+            disabled={isFirst}
+            className="rounded-md border border-stellar-border px-3 py-1.5 text-sm text-stellar-text-secondary transition-colors hover:text-white disabled:cursor-not-allowed disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-stellar-blue"
+          >
+            Back
+          </button>
+          <button
+            type="button"
+            onClick={isLast ? onFinish : onNext}
+            className="rounded-md border border-stellar-blue bg-stellar-blue/20 px-4 py-1.5 text-sm font-medium text-white transition-colors hover:bg-stellar-blue/30 focus:outline-none focus-visible:ring-2 focus-visible:ring-stellar-blue"
+          >
+            {isLast ? "Finish" : "Next"}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/frontend/src/components/entity/EntitySummaryBanner.tsx
+++ b/frontend/src/components/entity/EntitySummaryBanner.tsx
@@ -1,0 +1,207 @@
+import { useState, type ReactNode } from "react";
+import { Link } from "react-router-dom";
+
+export type SummaryTrendDirection = "up" | "down" | "neutral";
+export type SummaryFieldStatus = "healthy" | "warning" | "critical" | "neutral";
+export type EntitySummaryMode = "compact" | "expanded";
+
+export interface EntitySummaryField {
+  /** Stable id for the field. */
+  id: string;
+  /** Short field label, e.g. "Health". */
+  label: string;
+  /** Primary value shown for the field. */
+  value: ReactNode;
+  /** Optional trend chip. */
+  trend?: { direction: SummaryTrendDirection; label?: string };
+  /** Optional status used to colour the value dot. */
+  status?: SummaryFieldStatus;
+  /** Extra context shown only in expanded mode. */
+  hint?: string;
+  /** Router path for a drilldown link rendered under the field. */
+  to?: string;
+  /** Click handler for an in-page drilldown (e.g. switching tabs). */
+  onDrilldown?: () => void;
+  /** Label for the drilldown affordance. Defaults to "View". */
+  drilldownLabel?: string;
+}
+
+interface EntitySummaryBannerProps {
+  /** Context label/badge, e.g. "Asset" or "Bridge". Drives context sensitivity. */
+  entityType: string;
+  /** Primary entity title, e.g. the symbol or bridge name. */
+  title: string;
+  /** Optional supporting copy below the title. */
+  subtitle?: string;
+  /** Most important summary fields for the selected entity. */
+  fields: EntitySummaryField[];
+  /** Render skeletons while underlying data loads. */
+  loading?: boolean;
+  /** Initial layout density. Users can toggle between compact and expanded. */
+  defaultMode?: EntitySummaryMode;
+  /** Optional leading icon/emoji. */
+  icon?: ReactNode;
+  /** Optional right-aligned actions (buttons, etc.). */
+  actions?: ReactNode;
+  className?: string;
+}
+
+const trendClasses: Record<SummaryTrendDirection, string> = {
+  up: "border-green-400/30 bg-green-500/10 text-green-300",
+  down: "border-red-400/30 bg-red-500/10 text-red-300",
+  neutral: "border-stellar-border bg-stellar-dark/50 text-stellar-text-secondary",
+};
+
+const trendGlyph: Record<SummaryTrendDirection, string> = {
+  up: "↑",
+  down: "↓",
+  neutral: "→",
+};
+
+const statusDot: Record<SummaryFieldStatus, string> = {
+  healthy: "bg-green-400",
+  warning: "bg-yellow-400",
+  critical: "bg-red-400",
+  neutral: "bg-stellar-text-secondary",
+};
+
+function FieldSkeleton({ expanded }: { readonly expanded: boolean }) {
+  return (
+    <div className="rounded-lg border border-stellar-border bg-stellar-dark/40 p-3">
+      <div className="animate-pulse space-y-2">
+        <div className="h-3 w-16 rounded bg-stellar-border" />
+        <div className="h-6 w-24 rounded bg-stellar-border" />
+        {expanded ? <div className="h-3 w-full rounded bg-stellar-border" /> : null}
+      </div>
+    </div>
+  );
+}
+
+function SummaryFieldCard({
+  field,
+  expanded,
+}: {
+  readonly field: EntitySummaryField;
+  readonly expanded: boolean;
+}) {
+  const drilldownLabel = field.drilldownLabel ?? "View";
+
+  return (
+    <div className="rounded-lg border border-stellar-border bg-stellar-dark/40 p-3">
+      <p className="text-xs font-medium uppercase tracking-wide text-stellar-text-secondary">
+        {field.label}
+      </p>
+      <div className="mt-1 flex items-center gap-2">
+        {field.status ? (
+          <span
+            className={`h-2 w-2 shrink-0 rounded-full ${statusDot[field.status]}`}
+            aria-hidden="true"
+          />
+        ) : null}
+        <span className="text-lg font-semibold text-white">{field.value}</span>
+        {field.trend ? (
+          <span
+            className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] ${trendClasses[field.trend.direction]}`}
+          >
+            <span aria-hidden="true">{trendGlyph[field.trend.direction]}</span>
+            {field.trend.label ?? field.trend.direction}
+          </span>
+        ) : null}
+      </div>
+
+      {expanded && field.hint ? (
+        <p className="mt-2 text-xs text-stellar-text-secondary">{field.hint}</p>
+      ) : null}
+
+      {field.to ? (
+        <Link
+          to={field.to}
+          className="mt-2 inline-flex items-center text-xs font-medium text-stellar-blue hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-stellar-blue"
+        >
+          {drilldownLabel} →
+        </Link>
+      ) : field.onDrilldown ? (
+        <button
+          type="button"
+          onClick={field.onDrilldown}
+          className="mt-2 inline-flex items-center text-xs font-medium text-stellar-blue hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-stellar-blue"
+        >
+          {drilldownLabel} →
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * Context-sensitive summary banner for a selected entity (asset, bridge, etc.).
+ * Shows the most important summary fields in a compact grid with a loading
+ * state, optional drilldown links, and a compact/expanded layout toggle.
+ */
+export default function EntitySummaryBanner({
+  entityType,
+  title,
+  subtitle,
+  fields,
+  loading = false,
+  defaultMode = "compact",
+  icon,
+  actions,
+  className = "",
+}: EntitySummaryBannerProps) {
+  const [mode, setMode] = useState<EntitySummaryMode>(defaultMode);
+  const expanded = mode === "expanded";
+  const skeletonCount = Math.max(fields.length, 4);
+
+  return (
+    <section
+      aria-label={`${entityType} summary: ${title}`}
+      className={`rounded-2xl border border-stellar-border bg-gradient-to-br from-stellar-card via-stellar-card to-stellar-dark/40 p-5 ${className}`}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex items-start gap-3">
+          {icon ? (
+            <span className="text-2xl" role="img" aria-hidden="true">
+              {icon}
+            </span>
+          ) : null}
+          <div>
+            <span className="inline-block rounded-full border border-stellar-border px-2 py-0.5 text-[11px] uppercase tracking-wide text-stellar-text-secondary">
+              {entityType}
+            </span>
+            <h2 className="mt-1 text-2xl font-bold text-white">{title}</h2>
+            {subtitle ? (
+              <p className="mt-1 text-sm text-stellar-text-secondary">{subtitle}</p>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          {actions}
+          <button
+            type="button"
+            onClick={() => setMode((prev) => (prev === "compact" ? "expanded" : "compact"))}
+            aria-pressed={expanded}
+            className="rounded-full border border-stellar-border px-3 py-1.5 text-xs text-stellar-text-secondary transition-colors hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-stellar-blue"
+          >
+            {expanded ? "Compact view" : "Expanded view"}
+          </button>
+        </div>
+      </div>
+
+      <div
+        className={`mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3 ${
+          expanded ? "lg:grid-cols-3" : "lg:grid-cols-4"
+        }`}
+      >
+        {loading
+          ? Array.from({ length: skeletonCount }, (_, index) => (
+              <FieldSkeleton key={index} expanded={expanded} />
+            ))
+          : fields.map((field) => (
+              <SummaryFieldCard key={field.id} field={field} expanded={expanded} />
+            ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/entity/index.ts
+++ b/frontend/src/components/entity/index.ts
@@ -1,0 +1,7 @@
+export { default as EntitySummaryBanner } from "./EntitySummaryBanner";
+export type {
+  EntitySummaryField,
+  EntitySummaryMode,
+  SummaryFieldStatus,
+  SummaryTrendDirection,
+} from "./EntitySummaryBanner";

--- a/frontend/src/hooks/useDashboardFilters.ts
+++ b/frontend/src/hooks/useDashboardFilters.ts
@@ -16,6 +16,10 @@ export interface DashboardFilterPreset {
   id: string;
   name: string;
   filters: DashboardFilters;
+  /** Whether the preset is shared (exposes a shareable link) or kept private. */
+  shared: boolean;
+  createdAt: number;
+  updatedAt: number;
 }
 
 const FILTER_PRESET_STORAGE_KEY = "bridge-watch:dashboard-filter-presets:v1";
@@ -112,6 +116,32 @@ export function isTimestampInRange(
   return value.getTime() >= cutoff;
 }
 
+function normalizePreset(preset: Partial<DashboardFilterPreset> & { id: string; name: string; filters: DashboardFilters }): DashboardFilterPreset {
+  const now = Date.now();
+  return {
+    id: preset.id,
+    name: preset.name,
+    filters: preset.filters,
+    shared: preset.shared ?? false,
+    createdAt: preset.createdAt ?? now,
+    updatedAt: preset.updatedAt ?? preset.createdAt ?? now,
+  };
+}
+
+/**
+ * Build an absolute, shareable URL that re-applies a preset's filters when opened.
+ * Filters are encoded as URL search params, matching the dashboard's URL-persisted state.
+ */
+export function buildPresetShareUrl(preset: DashboardFilterPreset, pathname = "/dashboard"): string {
+  const params = buildDashboardSearchParams(preset.filters);
+  const query = params.toString();
+  const origin =
+    typeof window === "undefined" || !window.location?.origin
+      ? "https://bridge-watch.local"
+      : window.location.origin;
+  return `${origin}${pathname}${query ? `?${query}` : ""}`;
+}
+
 function toggleSelection(values: string[], candidate: string): string[] {
   if (values.includes(candidate)) {
     return values.filter((value) => value !== candidate);
@@ -122,9 +152,14 @@ function toggleSelection(values: string[], candidate: string): string[] {
 
 export function useDashboardFilters() {
   const [searchParams, setSearchParams] = useSearchParams();
-  const [savedPresets, setSavedPresets] = useLocalStorageState<DashboardFilterPreset[]>(
+  const [storedPresets, setSavedPresets] = useLocalStorageState<DashboardFilterPreset[]>(
     FILTER_PRESET_STORAGE_KEY,
     [],
+  );
+
+  const savedPresets = useMemo(
+    () => storedPresets.map((preset) => normalizePreset(preset)),
+    [storedPresets],
   );
 
   const filters = useMemo(() => parseDashboardFilters(searchParams), [searchParams]);
@@ -188,10 +223,14 @@ export function useDashboardFilters() {
       const presetName = name.trim();
       if (!presetName) return false;
 
+      const now = Date.now();
       const nextPreset: DashboardFilterPreset = {
-        id: `preset-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        id: `preset-${now}-${Math.random().toString(36).slice(2, 8)}`,
         name: presetName,
         filters,
+        shared: false,
+        createdAt: now,
+        updatedAt: now,
       };
 
       setSavedPresets((prev) => {
@@ -202,6 +241,43 @@ export function useDashboardFilters() {
       return true;
     },
     [filters, setSavedPresets],
+  );
+
+  const renamePreset = useCallback(
+    (presetId: string, name: string): boolean => {
+      const nextName = name.trim();
+      if (!nextName) return false;
+
+      let renamed = false;
+      setSavedPresets((prev) => {
+        const clash = prev.some(
+          (preset) => preset.id !== presetId && preset.name.toLowerCase() === nextName.toLowerCase(),
+        );
+        if (clash) return prev;
+
+        return prev.map((preset) => {
+          if (preset.id !== presetId) return preset;
+          renamed = true;
+          return normalizePreset({ ...preset, name: nextName, updatedAt: Date.now() });
+        });
+      });
+
+      return renamed;
+    },
+    [setSavedPresets],
+  );
+
+  const setPresetShared = useCallback(
+    (presetId: string, shared: boolean) => {
+      setSavedPresets((prev) =>
+        prev.map((preset) =>
+          preset.id === presetId
+            ? normalizePreset({ ...preset, shared, updatedAt: Date.now() })
+            : preset,
+        ),
+      );
+    },
+    [setSavedPresets],
   );
 
   const applyPreset = useCallback(
@@ -232,6 +308,8 @@ export function useDashboardFilters() {
     clearAll,
     savePreset,
     applyPreset,
+    renamePreset,
+    setPresetShared,
     deletePreset,
   };
 }

--- a/frontend/src/hooks/useDashboardTour.ts
+++ b/frontend/src/hooks/useDashboardTour.ts
@@ -1,0 +1,136 @@
+import { useCallback, useEffect, useState } from "react";
+import { useLocalStorageState } from "./useLocalStorageState";
+
+export type TourPlacement = "top" | "bottom" | "left" | "right" | "auto";
+
+export interface TourStep {
+  /** Stable id for the step. */
+  id: string;
+  /** CSS selector for the element the step highlights, e.g. `[data-tour="kpis"]`. */
+  target: string;
+  /** Step heading. */
+  title: string;
+  /** Step body copy. */
+  body: string;
+  /** Preferred tooltip placement relative to the target. */
+  placement?: TourPlacement;
+}
+
+interface TourProgress {
+  /** True once the user has reached the end of the tour. */
+  completed: boolean;
+  /** Last step index the user was on (used to resume after skipping). */
+  lastStep: number;
+  /** True once the tour has been started at least once (suppresses auto-start). */
+  seen: boolean;
+}
+
+const DEFAULT_PROGRESS: TourProgress = { completed: false, lastStep: 0, seen: false };
+
+interface UseDashboardTourOptions {
+  /** Number of steps in the tour. */
+  stepCount: number;
+  /** Local storage key for persisting completion/resume state. */
+  storageKey?: string;
+  /** Auto-start the tour on first visit when it has never been seen. */
+  autoStart?: boolean;
+}
+
+/**
+ * Drives a step-by-step dashboard tour overlay. Persists completion and the
+ * last-viewed step so the tour can be skipped and resumed, and auto-starts once
+ * for users who have never seen it.
+ */
+export function useDashboardTour({
+  stepCount,
+  storageKey = "bridge-watch:dashboard-tour:v1",
+  autoStart = true,
+}: UseDashboardTourOptions) {
+  const [progress, setProgress] = useLocalStorageState<TourProgress>(storageKey, DEFAULT_PROGRESS);
+  const [activeStep, setActiveStep] = useState<number | null>(null);
+
+  const clamp = useCallback(
+    (index: number) => Math.min(Math.max(index, 0), Math.max(stepCount - 1, 0)),
+    [stepCount],
+  );
+
+  // Auto-start once for users who have never engaged with the tour.
+  useEffect(() => {
+    if (!autoStart || stepCount === 0) return;
+    if (!progress.seen && activeStep === null) {
+      setActiveStep(0);
+      setProgress((prev) => ({ ...prev, seen: true }));
+    }
+  }, [autoStart, stepCount, progress.seen, activeStep, setProgress]);
+
+  const start = useCallback(() => {
+    // Resume where the user left off unless the tour was completed.
+    const resumeAt = progress.completed ? 0 : clamp(progress.lastStep);
+    setActiveStep(resumeAt);
+    setProgress((prev) => ({ ...prev, seen: true }));
+  }, [progress.completed, progress.lastStep, clamp, setProgress]);
+
+  const goTo = useCallback(
+    (index: number) => {
+      const next = clamp(index);
+      setActiveStep(next);
+      setProgress((prev) => ({ ...prev, lastStep: next }));
+    },
+    [clamp, setProgress],
+  );
+
+  const next = useCallback(() => {
+    setActiveStep((current) => {
+      if (current === null) return current;
+      if (current >= stepCount - 1) {
+        setProgress((prev) => ({ ...prev, completed: true, lastStep: 0 }));
+        return null;
+      }
+      const nextIndex = clamp(current + 1);
+      setProgress((prev) => ({ ...prev, lastStep: nextIndex }));
+      return nextIndex;
+    });
+  }, [stepCount, clamp, setProgress]);
+
+  const prev = useCallback(() => {
+    setActiveStep((current) => {
+      if (current === null) return current;
+      const prevIndex = clamp(current - 1);
+      setProgress((p) => ({ ...p, lastStep: prevIndex }));
+      return prevIndex;
+    });
+  }, [clamp, setProgress]);
+
+  const skip = useCallback(() => {
+    // Keep lastStep so the tour can be resumed; do not mark completed.
+    setActiveStep((current) => {
+      if (current !== null) {
+        setProgress((prev) => ({ ...prev, lastStep: clamp(current) }));
+      }
+      return null;
+    });
+  }, [clamp, setProgress]);
+
+  const finish = useCallback(() => {
+    setActiveStep(null);
+    setProgress((prev) => ({ ...prev, completed: true, lastStep: 0 }));
+  }, [setProgress]);
+
+  const reset = useCallback(() => {
+    setProgress(DEFAULT_PROGRESS);
+    setActiveStep(0);
+  }, [setProgress]);
+
+  return {
+    activeStep,
+    isActive: activeStep !== null,
+    completed: progress.completed,
+    start,
+    next,
+    prev,
+    skip,
+    finish,
+    goTo,
+    reset,
+  };
+}

--- a/frontend/src/hooks/useRelativeTime.ts
+++ b/frontend/src/hooks/useRelativeTime.ts
@@ -1,0 +1,90 @@
+import { useEffect, useMemo, useState } from "react";
+
+export type TimestampInput = Date | string | number | null | undefined;
+
+function toMillis(timestamp: TimestampInput): number | null {
+  if (timestamp === null || timestamp === undefined) return null;
+  if (timestamp instanceof Date) {
+    return Number.isNaN(timestamp.getTime()) ? null : timestamp.getTime();
+  }
+  if (typeof timestamp === "number") {
+    return Number.isNaN(timestamp) ? null : timestamp;
+  }
+  const parsed = new Date(timestamp).getTime();
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+/**
+ * Format the gap between `now` and a timestamp as a short, human relative string
+ * such as "just now", "5s ago", "3m ago", "2h ago", or "4d ago".
+ */
+export function formatRelativeTime(timestamp: TimestampInput, now = Date.now()): string {
+  const millis = toMillis(timestamp);
+  if (millis === null) return "never";
+
+  const diff = Math.max(0, now - millis);
+  const seconds = Math.floor(diff / 1000);
+  if (seconds < 5) return "just now";
+  if (seconds < 60) return `${seconds}s ago`;
+
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+/** Choose a re-render cadence proportional to the timestamp's age. */
+function tickIntervalFor(ageMs: number): number {
+  if (ageMs < 60_000) return 1_000; // under a minute → every second
+  if (ageMs < 3_600_000) return 30_000; // under an hour → every 30s
+  return 300_000; // older → every 5 minutes
+}
+
+interface UseRelativeTimeOptions {
+  /** Treat the timestamp as stale once it is older than this. Defaults to 60s. */
+  staleAfterMs?: number;
+}
+
+interface RelativeTimeResult {
+  /** Human relative string, e.g. "5s ago". */
+  text: string;
+  /** Age of the timestamp in milliseconds (null when no valid timestamp). */
+  ageMs: number | null;
+  /** True when the timestamp is older than `staleAfterMs`. */
+  isStale: boolean;
+}
+
+/**
+ * Live relative-time value that re-renders on a cadence matched to the
+ * timestamp's age, and reports whether the value has gone stale.
+ */
+export function useRelativeTime(
+  timestamp: TimestampInput,
+  { staleAfterMs = 60_000 }: UseRelativeTimeOptions = {},
+): RelativeTimeResult {
+  const millis = toMillis(timestamp);
+  const [now, setNow] = useState(() => Date.now());
+
+  const ageMs = millis === null ? null : Math.max(0, now - millis);
+
+  useEffect(() => {
+    if (millis === null) return;
+    const interval = tickIntervalFor(Math.max(0, Date.now() - millis));
+    const id = window.setInterval(() => setNow(Date.now()), interval);
+    return () => window.clearInterval(id);
+    // Re-evaluate the cadence as the value ages (now changes drive this).
+  }, [millis, now]);
+
+  return useMemo(
+    () => ({
+      text: formatRelativeTime(timestamp, now),
+      ageMs,
+      isStale: ageMs !== null && ageMs > staleAfterMs,
+    }),
+    [timestamp, now, ageMs, staleAfterMs],
+  );
+}

--- a/frontend/src/pages/AssetDetail.tsx
+++ b/frontend/src/pages/AssetDetail.tsx
@@ -21,6 +21,7 @@ import AssetTagsPanel from "../components/asset/AssetTagsPanel";
 import ChartAnnotationPanel from "../components/asset/ChartAnnotationPanel";
 import { AlertTimelineFeed } from "../components/alerts";
 import { EntitySummaryBanner, type EntitySummaryField } from "../components/entity";
+import { LiveUpdatePill } from "../components/LiveUpdatePill";
 
 const USER_NAME = "xqcxx";
 type TabId = "summary" | "history" | "alerts" | "metadata";
@@ -250,6 +251,10 @@ export default function AssetDetail() {
         loading={summaryLoading}
         actions={
           <>
+            <LiveUpdatePill
+              updatedAt={health.dataUpdatedAt > 0 ? health.dataUpdatedAt : null}
+              polling={health.isFetching}
+            />
             <button
               type="button"
               onClick={() => {

--- a/frontend/src/pages/AssetDetail.tsx
+++ b/frontend/src/pages/AssetDetail.tsx
@@ -20,6 +20,7 @@ import PullToRefresh from "../components/PullToRefresh";
 import AssetTagsPanel from "../components/asset/AssetTagsPanel";
 import ChartAnnotationPanel from "../components/asset/ChartAnnotationPanel";
 import { AlertTimelineFeed } from "../components/alerts";
+import { EntitySummaryBanner, type EntitySummaryField } from "../components/entity";
 
 const USER_NAME = "xqcxx";
 type TabId = "summary" | "history" | "alerts" | "metadata";
@@ -48,6 +49,22 @@ function parseTabId(value: string | null): TabId {
     return value;
   }
   return "summary";
+}
+
+function healthStatus(score: number | null | undefined): "healthy" | "warning" | "critical" | "neutral" {
+  if (score === null || score === undefined) return "neutral";
+  if (score >= 80) return "healthy";
+  if (score >= 50) return "warning";
+  return "critical";
+}
+
+function trendChip(
+  trend: "improving" | "stable" | "deteriorating" | null | undefined,
+): { direction: "up" | "down" | "neutral"; label: string } | undefined {
+  if (trend === "improving") return { direction: "up", label: "Improving" };
+  if (trend === "deteriorating") return { direction: "down", label: "Deteriorating" };
+  if (trend === "stable") return { direction: "neutral", label: "Stable" };
+  return undefined;
 }
 
 export default function AssetDetail() {
@@ -141,6 +158,64 @@ export default function AssetDetail() {
         ? "Synced"
         : "Draft";
 
+  const summaryLoading = health.isLoading || priceLoading || liquidityLoading;
+  const latestPrice =
+    priceData?.history && priceData.history.length > 0
+      ? priceData.history[priceData.history.length - 1].price
+      : null;
+  const liquiditySourceCount = liquidityData?.sources?.length ?? 0;
+
+  const summaryFields = useMemo<EntitySummaryField[]>(() => {
+    const score = health.data?.overallScore ?? null;
+    return [
+      {
+        id: "health",
+        label: "Health score",
+        value: typeof score === "number" ? `${Math.round(score)}/100` : "--",
+        status: healthStatus(score),
+        trend: trendChip(health.data?.trend),
+        hint: "Composite health score across liquidity, price stability, uptime, reserves, and volume.",
+        onDrilldown: () => setSearchParams({ tab: "summary" }, { replace: true }),
+        drilldownLabel: "Open summary",
+      },
+      {
+        id: "price",
+        label: "Latest price",
+        value: typeof latestPrice === "number" ? `$${latestPrice.toFixed(4)}` : "--",
+        hint:
+          priceData?.sources && priceData.sources.length > 0
+            ? `Aggregated from ${priceData.sources.length} price source${priceData.sources.length > 1 ? "s" : ""}.`
+            : "No price source data available.",
+        onDrilldown: () => setSearchParams({ tab: "history" }, { replace: true }),
+        drilldownLabel: "Price history",
+      },
+      {
+        id: "liquidity",
+        label: "Liquidity sources",
+        value: liquiditySourceCount,
+        hint: "Number of venues currently reporting liquidity depth for this asset.",
+        onDrilldown: () => setSearchParams({ tab: "history" }, { replace: true }),
+        drilldownLabel: "View depth",
+      },
+      {
+        id: "trend",
+        label: "Trend",
+        value: trendChip(health.data?.trend)?.label ?? "Unknown",
+        trend: trendChip(health.data?.trend),
+        hint: "Direction of the most recent health-score movement.",
+        onDrilldown: () => setSearchParams({ tab: "alerts" }, { replace: true }),
+        drilldownLabel: "Related alerts",
+      },
+    ];
+  }, [
+    health.data?.overallScore,
+    health.data?.trend,
+    latestPrice,
+    liquiditySourceCount,
+    priceData?.sources,
+    setSearchParams,
+  ]);
+
   if (!symbol) {
     return <div className="text-stellar-text-secondary">No asset symbol provided.</div>;
   }
@@ -167,29 +242,27 @@ export default function AssetDetail() {
         isRefreshing={pullToRefresh.isRefreshing}
       />
 
-      <div className="rounded-2xl border border-stellar-border bg-gradient-to-br from-stellar-card via-stellar-card to-stellar-dark/35 p-6">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div>
-            <h1 className="text-3xl font-bold text-white">{symbol}</h1>
-            <p className="mt-2 text-stellar-text-secondary">
-              Detailed monitoring for {symbol} on the Stellar network
-            </p>
-          </div>
-
-          <div className="flex flex-wrap items-center gap-3">
+      <EntitySummaryBanner
+        entityType="Asset"
+        title={symbol}
+        subtitle={`Detailed monitoring for ${symbol} on the Stellar network`}
+        fields={summaryFields}
+        loading={summaryLoading}
+        actions={
+          <>
             <button
               type="button"
               onClick={() => {
                 void pullToRefresh.refresh();
               }}
-              className="rounded-md border border-stellar-border px-4 py-2 text-sm text-white hover:bg-stellar-border"
+              className="rounded-full border border-stellar-border px-4 py-1.5 text-xs text-white hover:bg-stellar-border"
             >
               Refresh views
             </button>
-            <AddToWatchlistButton symbol={symbol} className="text-sm" />
-          </div>
-        </div>
-      </div>
+            <AddToWatchlistButton symbol={symbol} className="text-xs" />
+          </>
+        }
+      />
 
       <Tabs activeTab={activeTab} onTabChange={handleTabChange}>
         <TabList aria-label="Asset detail views" className="flex flex-wrap items-center gap-2 border-b border-stellar-border pb-4">

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -18,6 +18,8 @@ import AssetDiscoverySection from "../components/dashboard/AssetDiscoverySection
 import FavoriteTagChip from "../components/favorites/FavoriteTagChip";
 import AssetFilterPanel from "../components/Filters/AssetFilterPanel";
 import FilterPresetsMenu from "../components/Filters/FilterPresetsMenu";
+import DashboardTour from "../components/dashboard/DashboardTour";
+import { useDashboardTour, type TourStep } from "../hooks/useDashboardTour";
 import { useFavorites } from "../hooks/useFavorites";
 import ExportPickerDialog from "../components/ExportPickerDialog";
 import { Tabs, TabList, Tab, TabPanel } from "../components/Tabs";
@@ -41,6 +43,37 @@ type BridgeStatusFilter = "all" | "healthy" | "degraded" | "down" | "unknown";
 const VIEW_PARAM = "dashboard_view";
 const BRIDGE_STATUS_PARAM = "dashboard_bridge_status";
 const DRILLDOWN_PARAM = "drilldown";
+
+const dashboardTourSteps: TourStep[] = [
+  {
+    id: "toolbar",
+    target: '[data-tour="toolbar"]',
+    title: "Toolbar actions",
+    body: "Save filter presets, refresh data, export, and share the current view from here.",
+    placement: "bottom",
+  },
+  {
+    id: "filters",
+    target: '[data-tour="filters"]',
+    title: "Filters",
+    body: "Narrow the dashboard by assets, bridges, status, and time range. Active filters are encoded in the URL.",
+    placement: "right",
+  },
+  {
+    id: "kpis",
+    target: '[data-tour="kpis"]',
+    title: "Key metrics",
+    body: "Live KPIs summarise total value locked, monitored assets, active bridges, and system health. Inspect any card to drill down.",
+    placement: "bottom",
+  },
+  {
+    id: "status-cards",
+    target: '[data-tour="status-cards"]',
+    title: "Status at a glance",
+    body: "These cards highlight the assets and bridges that need attention right now.",
+    placement: "top",
+  },
+];
 
 const dashboardViews: Array<{ id: DashboardView; label: string; description: string }> = [
   { id: "overview", label: "Overview", description: "Assets and bridges together" },
@@ -183,6 +216,7 @@ export default function Dashboard() {
     setPresetShared,
     deletePreset,
   } = useDashboardFilters();
+  const tour = useDashboardTour({ stepCount: dashboardTourSteps.length });
   const pullToRefresh = usePullToRefresh({
     enabled: true,
     onRefresh: async () => {
@@ -476,21 +510,23 @@ export default function Dashboard() {
       />
 
       <div className="flex flex-col gap-6 md:flex-row">
-        <AssetFilterPanel
-          assets={availableAssets}
-          bridges={availableBridges}
-          filters={filters}
-          savedPresets={savedPresets}
-          hasActiveFilters={hasActiveFilters}
-          onToggleAsset={toggleAsset}
-          onToggleBridge={toggleBridge}
-          onStatusChange={setStatus}
-          onTimeRangeChange={setTimeRange}
-          onClearAll={clearAll}
-          onSavePreset={savePreset}
-          onApplyPreset={applyPreset}
-          onDeletePreset={deletePreset}
-        />
+        <div data-tour="filters" className="w-full md:w-80 md:shrink-0">
+          <AssetFilterPanel
+            assets={availableAssets}
+            bridges={availableBridges}
+            filters={filters}
+            savedPresets={savedPresets}
+            hasActiveFilters={hasActiveFilters}
+            onToggleAsset={toggleAsset}
+            onToggleBridge={toggleBridge}
+            onStatusChange={setStatus}
+            onTimeRangeChange={setTimeRange}
+            onClearAll={clearAll}
+            onSavePreset={savePreset}
+            onApplyPreset={applyPreset}
+            onDeletePreset={deletePreset}
+          />
+        </div>
 
         <main className="flex-1 space-y-8 min-w-0">
           <div className="space-y-4 rounded-2xl border border-stellar-border bg-gradient-to-br from-stellar-card via-stellar-card to-stellar-dark/40 p-6">
@@ -503,7 +539,7 @@ export default function Dashboard() {
             </p>
           </div>
 
-          <div className="flex flex-wrap items-center gap-2">
+          <div data-tour="toolbar" className="flex flex-wrap items-center gap-2">
             <FilterPresetsMenu
               filters={filters}
               presets={savedPresets}
@@ -513,6 +549,13 @@ export default function Dashboard() {
               onDeletePreset={deletePreset}
               onToggleShared={setPresetShared}
             />
+            <button
+              type="button"
+              onClick={tour.start}
+              className="rounded-full border border-stellar-border px-4 py-2 text-sm text-white transition-colors hover:bg-stellar-border"
+            >
+              {tour.completed ? "Replay tour" : "Take a tour"}
+            </button>
             <button
               type="button"
               onClick={() => {
@@ -581,19 +624,23 @@ export default function Dashboard() {
       </div>
 
       {/* Overview Stats */}
-      <KpiBanner
-        items={kpiItems}
-        loading={assetsLoading || bridgesLoading}
-        layout={dashboard.state.view === "overview" ? "expanded" : "compact"}
-        onDrilldown={(item) => setDrilldown(item.id)}
-        onInspectMetric={(item) => setInspectedMetricId(item.id)}
-      />
+      <div data-tour="kpis">
+        <KpiBanner
+          items={kpiItems}
+          loading={assetsLoading || bridgesLoading}
+          layout={dashboard.state.view === "overview" ? "expanded" : "compact"}
+          onDrilldown={(item) => setDrilldown(item.id)}
+          onInspectMetric={(item) => setInspectedMetricId(item.id)}
+        />
+      </div>
 
-      <InlineStatusCards
-        assets={filteredAssets}
-        bridges={filteredBridges}
-        loading={assetsLoading || bridgesLoading}
-      />
+      <div data-tour="status-cards">
+        <InlineStatusCards
+          assets={filteredAssets}
+          bridges={filteredBridges}
+          loading={assetsLoading || bridgesLoading}
+        />
+      </div>
 
       <section aria-labelledby="overview-stats">
         <h2 id="overview-stats" className="text-xl font-semibold text-white mb-4">
@@ -758,6 +805,14 @@ export default function Dashboard() {
           assetsWithHealth?.find((a) => a.symbol === insightsTraySymbol)?.name ?? null
         }
         onClose={closeInsightsTray}
+      />
+      <DashboardTour
+        steps={dashboardTourSteps}
+        activeStep={tour.activeStep}
+        onNext={tour.next}
+        onPrev={tour.prev}
+        onSkip={tour.skip}
+        onFinish={tour.finish}
       />
     </div>
   );

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -20,6 +20,7 @@ import AssetFilterPanel from "../components/Filters/AssetFilterPanel";
 import FilterPresetsMenu from "../components/Filters/FilterPresetsMenu";
 import DashboardTour from "../components/dashboard/DashboardTour";
 import { useDashboardTour, type TourStep } from "../hooks/useDashboardTour";
+import { LiveUpdatePill } from "../components/LiveUpdatePill";
 import { useFavorites } from "../hooks/useFavorites";
 import ExportPickerDialog from "../components/ExportPickerDialog";
 import { Tabs, TabList, Tab, TabPanel } from "../components/Tabs";
@@ -192,14 +193,22 @@ export default function Dashboard() {
   const {
     data: assetsWithHealth,
     isLoading: assetsLoading,
+    isFetching: assetsFetching,
+    dataUpdatedAt: assetsUpdatedAt,
     refetch: refetchAssets,
   } = useAssetsWithHealth();
   const { favoritesFilterMode, toggleFavoriteBridge, favoriteBridges } = useFavorites();
   const {
     data: bridgesData,
     isLoading: bridgesLoading,
+    isFetching: bridgesFetching,
+    dataUpdatedAt: bridgesUpdatedAt,
     refetch: refetchBridges,
   } = useBridges();
+  const dashboardUpdatedAt =
+    Math.max(assetsUpdatedAt, bridgesUpdatedAt) > 0
+      ? Math.max(assetsUpdatedAt, bridgesUpdatedAt)
+      : null;
   const dashboard = useDashboardUrlState();
   const {
     filters,
@@ -532,7 +541,13 @@ export default function Dashboard() {
           <div className="space-y-4 rounded-2xl border border-stellar-border bg-gradient-to-br from-stellar-card via-stellar-card to-stellar-dark/40 p-6">
         <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
           <div>
-            <h1 className="text-3xl font-bold text-white">Dashboard</h1>
+            <div className="flex flex-wrap items-center gap-3">
+              <h1 className="text-3xl font-bold text-white">Dashboard</h1>
+              <LiveUpdatePill
+                updatedAt={dashboardUpdatedAt}
+                polling={assetsFetching || bridgesFetching}
+              />
+            </div>
             <p className="mt-2 max-w-2xl text-stellar-text-secondary">
               Real-time monitoring of bridged assets on the Stellar network, with shareable
               views for assets, bridges, and the combined overview.

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -17,6 +17,7 @@ import { SummaryCard } from "../components/SummaryCard";
 import AssetDiscoverySection from "../components/dashboard/AssetDiscoverySection";
 import FavoriteTagChip from "../components/favorites/FavoriteTagChip";
 import AssetFilterPanel from "../components/Filters/AssetFilterPanel";
+import FilterPresetsMenu from "../components/Filters/FilterPresetsMenu";
 import { useFavorites } from "../hooks/useFavorites";
 import ExportPickerDialog from "../components/ExportPickerDialog";
 import { Tabs, TabList, Tab, TabPanel } from "../components/Tabs";
@@ -178,6 +179,8 @@ export default function Dashboard() {
     clearAll,
     savePreset,
     applyPreset,
+    renamePreset,
+    setPresetShared,
     deletePreset,
   } = useDashboardFilters();
   const pullToRefresh = usePullToRefresh({
@@ -501,6 +504,15 @@ export default function Dashboard() {
           </div>
 
           <div className="flex flex-wrap items-center gap-2">
+            <FilterPresetsMenu
+              filters={filters}
+              presets={savedPresets}
+              onSavePreset={savePreset}
+              onApplyPreset={applyPreset}
+              onRenamePreset={renamePreset}
+              onDeletePreset={deletePreset}
+              onToggleShared={setPresetShared}
+            />
             <button
               type="button"
               onClick={() => {


### PR DESCRIPTION
## Summary

This PR bundles four frontend dashboard UX enhancements, each on its own commit:

### 1. Filters presets menu (`feat: add filters presets menu`)
- Dedicated presets dropdown in the dashboard toolbar: **save**, **load**, **rename**, and **delete** filter combinations.
- **Shared access options**: mark a preset private/shared and copy a shareable link that re-applies the filters via URL params.
- **Persistent storage** in local storage with backward-compatible normalization of older preset records.

### 2. Entity summary banner (`feat: build entity summary banner`)
- Generic, **context-sensitive** `EntitySummaryBanner` surfacing the most important summary fields for a selected entity.
- **Compact and expanded** layout modes, **loading** skeletons, per-field status dots / trend chips, and **drilldown links**.
- Integrated into the asset detail page (health, price, liquidity, trend) with tab drilldowns.

### 3. Dashboard tour overlay (`feat: create dashboard tour overlay`)
- Lightweight **step-by-step** onboarding tour with a spotlight and tooltip per region.
- **Skip and resume**, **responsive positioning**, **accessible** keyboard navigation (←/→/Esc) and focus management.
- **Persists completion** (auto-starts once) plus a Take a tour / Replay tour trigger.

### 4. Live update pills (`feat: implement live update pills`)
- Compact pills showing **last updated time**, a **stale indicator**, and a **live polling state** (pulsing dot).
- **Accessible** via `role=status` / `aria-live` / `aria-label`; reused on the dashboard header and asset detail banner.

## Documentation
- `frontend/docs/filter-presets.md`
- `frontend/docs/entity-summary-banner.md`
- `frontend/docs/dashboard-tour.md`
- `frontend/docs/live-update-pills.md`

## Notes
- Type-check and lint pass on all changed files.

Closes #501
Closes #497
Closes #498
Closes #499
