### PR TITLE
feat: implement rule evaluator, service annotations, asset merge, and alert windowing services

### DIFF
--- a/backend/src/api/routes/alertWindowing.routes.ts
+++ b/backend/src/api/routes/alertWindowing.routes.ts
@@ -1,0 +1,99 @@
+import type { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
+import { alertWindowingService } from "../../services/alertWindowing.service.js";
+
+interface AssignBody {
+  id: string;
+  ruleId: string;
+  assetCode: string;
+  alertType: string;
+  priority: string;
+  triggeredValue: number;
+  threshold: number;
+  occurredAt: string;
+}
+
+interface WindowParams {
+  id: string;
+}
+
+interface ListQuery {
+  assetCode?: string;
+  alertType?: string;
+  status?: string;
+  limit?: string;
+  offset?: string;
+}
+
+export async function alertWindowingRoutes(server: FastifyInstance) {
+  server.post<{ Body: AssignBody }>(
+    "/assign",
+    async (request: FastifyRequest<{ Body: AssignBody }>, reply: FastifyReply) => {
+      try {
+        const { id, ruleId, assetCode, alertType, priority, triggeredValue, threshold, occurredAt } = request.body;
+        const window = await alertWindowingService.assignToWindow({
+          id,
+          ruleId,
+          assetCode,
+          alertType,
+          priority,
+          triggeredValue,
+          threshold,
+          occurredAt: new Date(occurredAt),
+        });
+        return reply.code(201).send(window);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Failed to assign alert to window";
+        return reply.code(400).send({ error: message });
+      }
+    }
+  );
+
+  server.get<{ Params: WindowParams }>(
+    "/:id",
+    async (request: FastifyRequest<{ Params: WindowParams }>, reply: FastifyReply) => {
+      const window = await alertWindowingService.getWindow(request.params.id);
+      if (!window) return reply.code(404).send({ error: "Window not found" });
+      return window;
+    }
+  );
+
+  server.get<{ Querystring: ListQuery }>(
+    "/",
+    async (request: FastifyRequest<{ Querystring: ListQuery }>) => {
+      const { assetCode, alertType, status, limit, offset } = request.query;
+      return alertWindowingService.listWindows({
+        assetCode,
+        alertType,
+        status,
+        limit: limit ? parseInt(limit, 10) : undefined,
+        offset: offset ? parseInt(offset, 10) : undefined,
+      });
+    }
+  );
+
+  server.post<{ Params: WindowParams }>(
+    "/:id/close",
+    async (request: FastifyRequest<{ Params: WindowParams }>, reply: FastifyReply) => {
+      const window = await alertWindowingService.closeWindow(request.params.id);
+      if (!window) return reply.code(404).send({ error: "Window not found" });
+      return window;
+    }
+  );
+
+  server.get<{ Params: WindowParams }>(
+    "/:id/summary",
+    async (request: FastifyRequest<{ Params: WindowParams }>, reply: FastifyReply) => {
+      const summary = await alertWindowingService.getSummary(request.params.id);
+      if (!summary) return reply.code(404).send({ error: "Summary not found" });
+      return summary;
+    }
+  );
+
+  server.post(
+    "/auto-close",
+    async () => {
+      const count = await alertWindowingService.autoCloseExpiredWindows();
+      return { closedCount: count };
+    }
+  );
+}

--- a/backend/src/api/routes/assetMerge.routes.ts
+++ b/backend/src/api/routes/assetMerge.routes.ts
@@ -1,0 +1,107 @@
+import type { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
+import { assetMergeService } from "../../services/assetMerge.service.js";
+
+interface MergeBody {
+  primaryAssetId: string;
+  duplicateIds: string[];
+  triggeredBy: string;
+}
+
+interface ReviewBody {
+  status: "approved" | "rejected";
+  reviewedBy: string;
+  reviewNotes?: string;
+}
+
+interface ReviewParams {
+  id: string;
+}
+
+interface HistoryQuery {
+  primaryAssetId?: string;
+  limit?: string;
+}
+
+export async function assetMergeRoutes(server: FastifyInstance) {
+  server.get(
+    "/duplicates",
+    async () => {
+      const groups = await assetMergeService.findDuplicates();
+      return { count: groups.length, groups };
+    }
+  );
+
+  server.get(
+    "/history",
+    async (request: FastifyRequest<{ Querystring: HistoryQuery }>) => {
+      const { primaryAssetId, limit } = request.query;
+      return assetMergeService.getMergeHistory({
+        primaryAssetId,
+        limit: limit ? parseInt(limit, 10) : undefined,
+      });
+    }
+  );
+
+  server.post<{ Body: MergeBody }>(
+    "/merge",
+    async (request: FastifyRequest<{ Body: MergeBody }>, reply: FastifyReply) => {
+      try {
+        const { primaryAssetId, duplicateIds, triggeredBy } = request.body;
+        const result = await assetMergeService.merge(primaryAssetId, duplicateIds, triggeredBy);
+        return reply.code(200).send(result);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Merge failed";
+        return reply.code(400).send({ error: message });
+      }
+    }
+  );
+
+  server.get(
+    "/reviews",
+    async (request: FastifyRequest<{ Querystring: { status?: string } }>) => {
+      return assetMergeService.listReviews({ status: request.query.status });
+    }
+  );
+
+  server.post<{ Body: { duplicateGroup: any } }>(
+    "/reviews",
+    async (request: FastifyRequest<{ Body: { duplicateGroup: any } }>, reply: FastifyReply) => {
+      try {
+        const review = await assetMergeService.proposeMerge(request.body.duplicateGroup);
+        return reply.code(201).send(review);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Failed to propose merge";
+        return reply.code(400).send({ error: message });
+      }
+    }
+  );
+
+  server.get<{ Params: ReviewParams }>(
+    "/reviews/:id",
+    async (request: FastifyRequest<{ Params: ReviewParams }>, reply: FastifyReply) => {
+      const review = await assetMergeService.getReview(request.params.id);
+      if (!review) return reply.code(404).send({ error: "Review not found" });
+      return review;
+    }
+  );
+
+  server.patch<{ Params: ReviewParams; Body: ReviewBody }>(
+    "/reviews/:id",
+    async (request: FastifyRequest<{ Params: ReviewParams; Body: ReviewBody }>, reply: FastifyReply) => {
+      try {
+        const { status, reviewedBy, reviewNotes } = request.body;
+        const review = await assetMergeService.reviewMerge(
+          request.params.id,
+          status,
+          reviewedBy,
+          reviewNotes
+        );
+        if (!review) return reply.code(404).send({ error: "Review not found" });
+        return review;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Failed to review merge";
+        return reply.code(400).send({ error: message });
+      }
+    }
+  );
+}

--- a/backend/src/api/routes/index.ts
+++ b/backend/src/api/routes/index.ts
@@ -52,6 +52,10 @@ import { eventSubscriptionFilterRoutes } from "./eventSubscriptionFilter.routes.
 import { maintenanceRoutes } from "./maintenance.js";
 import { notificationTemplatesRoutes } from "./notificationTemplates.js";
 import { archivedDataBrowserRoutes } from "./archivedDataBrowser.routes.js";
+import { ruleEvaluatorRoutes } from "./ruleEvaluator.routes.js";
+import { serviceAnnotationRoutes } from "./serviceAnnotation.routes.js";
+import { assetMergeRoutes } from "./assetMerge.routes.js";
+import { alertWindowingRoutes } from "./alertWindowing.routes.js";
 
 export async function registerRoutes(server: FastifyInstance) {
   server.register(assetsRoutes, { prefix: "/api/v1/assets" });
@@ -128,4 +132,8 @@ export async function registerRoutes(server: FastifyInstance) {
     prefix: "/api/v1/notification-templates",
   });
   server.register(archivedDataBrowserRoutes, { prefix: "/api/v1/archive" });
+  server.register(ruleEvaluatorRoutes, { prefix: "/api/v1/rule-evaluator" });
+  server.register(serviceAnnotationRoutes, { prefix: "/api/v1/service-annotations" });
+  server.register(assetMergeRoutes, { prefix: "/api/v1/asset-merge" });
+  server.register(alertWindowingRoutes, { prefix: "/api/v1/alert-windowing" });
 }

--- a/backend/src/api/routes/ruleEvaluator.routes.ts
+++ b/backend/src/api/routes/ruleEvaluator.routes.ts
@@ -1,0 +1,96 @@
+import type { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
+import {
+  ruleEvaluatorService,
+  type RuleCondition,
+  type LogicOperator,
+} from "../../services/ruleEvaluator.service.js";
+
+interface EvaluateBody {
+  ruleName: string;
+  ruleId?: string;
+  assetCode: string;
+  conditions: RuleCondition[];
+  logicOperator: LogicOperator;
+  metrics: Record<string, number>;
+  previousMetrics?: Record<string, number>;
+  previewMode?: boolean;
+}
+
+interface EvaluateBatchBody {
+  rules: Array<{
+    ruleName: string;
+    ruleId?: string;
+    assetCode: string;
+    conditions: RuleCondition[];
+    logicOperator: LogicOperator;
+  }>;
+  metrics: Record<string, number>;
+  previousMetrics?: Record<string, number>;
+  previewMode?: boolean;
+}
+
+interface HistoryQuery {
+  ruleId?: string;
+  assetCode?: string;
+  triggered?: string;
+  limit?: string;
+  offset?: string;
+}
+
+export async function ruleEvaluatorRoutes(server: FastifyInstance) {
+  server.post<{ Body: EvaluateBody }>(
+    "/evaluate",
+    async (request: FastifyRequest<{ Body: EvaluateBody }>, reply: FastifyReply) => {
+      try {
+        const { ruleName, ruleId, assetCode, conditions, logicOperator, metrics, previousMetrics, previewMode } = request.body;
+        const result = ruleEvaluatorService.evaluate(
+          { ruleName, ruleId, assetCode, conditions, logicOperator },
+          metrics,
+          previousMetrics,
+          previewMode
+        );
+        return result;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Evaluation failed";
+        return reply.code(400).send({ error: message });
+      }
+    }
+  );
+
+  server.post<{ Body: EvaluateBatchBody }>(
+    "/evaluate/batch",
+    async (request: FastifyRequest<{ Body: EvaluateBatchBody }>, reply: FastifyReply) => {
+      try {
+        const { rules, metrics, previousMetrics, previewMode } = request.body;
+        const results = ruleEvaluatorService.evaluateBatch(
+          rules,
+          metrics,
+          previousMetrics,
+          previewMode
+        );
+        return {
+          evaluatedAt: new Date().toISOString(),
+          results,
+          triggeredCount: results.filter((r) => r.triggered).length,
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Batch evaluation failed";
+        return reply.code(400).send({ error: message });
+      }
+    }
+  );
+
+  server.get<{ Querystring: HistoryQuery }>(
+    "/evaluate/history",
+    async (request: FastifyRequest<{ Querystring: HistoryQuery }>) => {
+      const { ruleId, assetCode, triggered, limit, offset } = request.query;
+      return ruleEvaluatorService.getEvaluationHistory({
+        ruleId,
+        assetCode,
+        triggered: triggered !== undefined ? triggered === "true" : undefined,
+        limit: limit ? parseInt(limit, 10) : undefined,
+        offset: offset ? parseInt(offset, 10) : undefined,
+      });
+    }
+  );
+}

--- a/backend/src/api/routes/serviceAnnotation.routes.ts
+++ b/backend/src/api/routes/serviceAnnotation.routes.ts
@@ -1,0 +1,121 @@
+import type { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
+import { serviceAnnotationService } from "../../services/serviceAnnotation.service.js";
+
+interface CreateBody {
+  serviceName: string;
+  entityType: string;
+  entityId?: string;
+  content: string;
+  author: string;
+  startTime?: string;
+  endTime?: string;
+}
+
+interface UpdateBody {
+  actor: string;
+  content?: string;
+  active?: boolean;
+  startTime?: string | null;
+  endTime?: string | null;
+}
+
+interface ListQuery {
+  serviceName?: string;
+  entityType?: string;
+  entityId?: string;
+  active?: string;
+  author?: string;
+}
+
+interface Params {
+  id: string;
+}
+
+export async function serviceAnnotationRoutes(server: FastifyInstance) {
+  server.post<{ Body: CreateBody }>(
+    "/",
+    async (request: FastifyRequest<{ Body: CreateBody }>, reply: FastifyReply) => {
+      try {
+        const { serviceName, entityType, entityId, content, author, startTime, endTime } = request.body;
+        const annotation = await serviceAnnotationService.create({
+          serviceName,
+          entityType,
+          entityId,
+          content,
+          author,
+          startTime: startTime ? new Date(startTime) : undefined,
+          endTime: endTime ? new Date(endTime) : undefined,
+        });
+        return reply.code(201).send(annotation);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Failed to create annotation";
+        return reply.code(400).send({ error: message });
+      }
+    }
+  );
+
+  server.get<{ Params: Params }>(
+    "/:id",
+    async (request: FastifyRequest<{ Params: Params }>, reply: FastifyReply) => {
+      const annotation = await serviceAnnotationService.get(request.params.id);
+      if (!annotation) return reply.code(404).send({ error: "Annotation not found" });
+      return annotation;
+    }
+  );
+
+  server.patch<{ Params: Params; Body: UpdateBody }>(
+    "/:id",
+    async (request: FastifyRequest<{ Params: Params; Body: UpdateBody }>, reply: FastifyReply) => {
+      try {
+        const { actor, ...updates } = request.body;
+        const updateInput: Record<string, unknown> = {};
+        if (updates.content !== undefined) updateInput.content = updates.content;
+        if (updates.active !== undefined) updateInput.active = updates.active;
+        if ("startTime" in updates) updateInput.startTime = updates.startTime ? new Date(updates.startTime) : null;
+        if ("endTime" in updates) updateInput.endTime = updates.endTime ? new Date(updates.endTime) : null;
+
+        const annotation = await serviceAnnotationService.update(
+          request.params.id,
+          actor ?? "api",
+          updateInput as any
+        );
+        if (!annotation) return reply.code(404).send({ error: "Annotation not found" });
+        return annotation;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Failed to update annotation";
+        return reply.code(400).send({ error: message });
+      }
+    }
+  );
+
+  server.delete<{ Params: Params }>(
+    "/:id",
+    async (request: FastifyRequest<{ Params: Params }>, reply: FastifyReply) => {
+      const actor = (request.headers["x-user"] as string) ?? "api";
+      const deleted = await serviceAnnotationService.delete(request.params.id, actor);
+      if (!deleted) return reply.code(404).send({ error: "Annotation not found" });
+      return reply.code(204).send();
+    }
+  );
+
+  server.get<{ Querystring: ListQuery }>(
+    "/",
+    async (request: FastifyRequest<{ Querystring: ListQuery }>) => {
+      const { serviceName, entityType, entityId, active, author } = request.query;
+      return serviceAnnotationService.list({
+        serviceName,
+        entityType,
+        entityId,
+        active: active !== undefined ? active === "true" : undefined,
+        author,
+      });
+    }
+  );
+
+  server.get<{ Params: Params }>(
+    "/:id/audit",
+    async (request: FastifyRequest<{ Params: Params }>) => {
+      return serviceAnnotationService.getAuditLog(request.params.id);
+    }
+  );
+}

--- a/backend/src/database/migrations/027_rule_evaluator.ts
+++ b/backend/src/database/migrations/027_rule_evaluator.ts
@@ -1,0 +1,24 @@
+import type { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable("rule_evaluator_logs", (table) => {
+    table.uuid("id").primary().defaultTo(knex.raw("gen_random_uuid()"));
+    table.string("rule_id").nullable();
+    table.string("rule_name").notNullable();
+    table.string("asset_code").notNullable();
+    table.jsonb("input_metrics").notNullable().defaultTo("{}");
+    table.jsonb("evaluation_result").notNullable();
+    table.boolean("triggered").notNullable();
+    table.string("logic_operator").notNullable();
+    table.boolean("preview_mode").notNullable().defaultTo(false);
+    table.timestamp("evaluated_at").notNullable().defaultTo(knex.fn.now());
+
+    table.index(["rule_id", "evaluated_at"]);
+    table.index(["asset_code", "evaluated_at"]);
+    table.index(["triggered"]);
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists("rule_evaluator_logs");
+}

--- a/backend/src/database/migrations/028_service_annotations.ts
+++ b/backend/src/database/migrations/028_service_annotations.ts
@@ -1,0 +1,43 @@
+import type { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable("service_annotations", (table) => {
+    table.uuid("id").primary().defaultTo(knex.raw("gen_random_uuid()"));
+    table.string("service_name").notNullable();
+    table.string("entity_type").notNullable();
+    table.string("entity_id").nullable();
+    table.text("content").notNullable();
+    table.string("author").notNullable();
+    table.timestamp("start_time").nullable();
+    table.timestamp("end_time").nullable();
+    table.boolean("active").notNullable().defaultTo(true);
+    table.timestamp("created_at").notNullable().defaultTo(knex.fn.now());
+    table.timestamp("updated_at").notNullable().defaultTo(knex.fn.now());
+
+    table.index(["service_name", "entity_type"]);
+    table.index(["entity_type", "entity_id"]);
+    table.index(["active"]);
+  });
+
+  await knex.schema.createTable("service_annotation_audit", (table) => {
+    table.uuid("id").primary().defaultTo(knex.raw("gen_random_uuid()"));
+    table
+      .uuid("annotation_id")
+      .notNullable()
+      .references("id")
+      .inTable("service_annotations")
+      .onDelete("CASCADE");
+    table.string("action").notNullable();
+    table.string("actor").notNullable();
+    table.jsonb("changes").notNullable().defaultTo("{}");
+    table.timestamp("created_at").notNullable().defaultTo(knex.fn.now());
+
+    table.index(["annotation_id"]);
+    table.index(["created_at"]);
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists("service_annotation_audit");
+  await knex.schema.dropTableIfExists("service_annotations");
+}

--- a/backend/src/database/migrations/029_asset_merge_service.ts
+++ b/backend/src/database/migrations/029_asset_merge_service.ts
@@ -1,0 +1,39 @@
+import type { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable("asset_merge_logs", (table) => {
+    table.uuid("id").primary().defaultTo(knex.raw("gen_random_uuid()"));
+    table.string("primary_asset_id").notNullable();
+    table.string("primary_symbol").notNullable();
+    table.jsonb("merged_asset_ids").notNullable();
+    table.jsonb("merge_rules_applied").notNullable().defaultTo("{}");
+    table.jsonb("conflicts_resolved").notNullable().defaultTo("[]");
+    table.string("status").notNullable().defaultTo("completed");
+    table.string("triggered_by").notNullable();
+    table.timestamp("created_at").notNullable().defaultTo(knex.fn.now());
+
+    table.index(["primary_asset_id"]);
+    table.index(["status"]);
+    table.index(["created_at"]);
+  });
+
+  await knex.schema.createTable("asset_merge_reviews", (table) => {
+    table.uuid("id").primary().defaultTo(knex.raw("gen_random_uuid()"));
+    table.jsonb("duplicate_group").notNullable();
+    table.jsonb("suggested_merge").notNullable();
+    table.string("status").notNullable().defaultTo("pending");
+    table.string("reviewed_by").nullable();
+    table.text("review_notes").nullable();
+    table.timestamp("reviewed_at").nullable();
+    table.timestamp("created_at").notNullable().defaultTo(knex.fn.now());
+    table.timestamp("updated_at").notNullable().defaultTo(knex.fn.now());
+
+    table.index(["status"]);
+    table.index(["created_at"]);
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists("asset_merge_reviews");
+  await knex.schema.dropTableIfExists("asset_merge_logs");
+}

--- a/backend/src/database/migrations/030_alert_windowing.ts
+++ b/backend/src/database/migrations/030_alert_windowing.ts
@@ -1,0 +1,42 @@
+import type { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable("alert_windows", (table) => {
+    table.uuid("id").primary().defaultTo(knex.raw("gen_random_uuid()"));
+    table.string("asset_code").notNullable();
+    table.string("alert_type").notNullable();
+    table.timestamp("window_start").notNullable();
+    table.timestamp("window_end").notNullable();
+    table.integer("alert_count").notNullable().defaultTo(0);
+    table.jsonb("summary_stats").notNullable().defaultTo("{}");
+    table.string("status").notNullable().defaultTo("open");
+    table.timestamp("created_at").notNullable().defaultTo(knex.fn.now());
+    table.timestamp("updated_at").notNullable().defaultTo(knex.fn.now());
+
+    table.index(["asset_code", "window_start", "window_end"]);
+    table.index(["alert_type"]);
+    table.index(["status"]);
+    table.index(["window_end"]);
+  });
+
+  await knex.schema.createTable("alert_window_summaries", (table) => {
+    table.uuid("id").primary().defaultTo(knex.raw("gen_random_uuid()"));
+    table
+      .uuid("window_id")
+      .notNullable()
+      .references("id")
+      .inTable("alert_windows")
+      .onDelete("CASCADE");
+    table.jsonb("severity_breakdown").notNullable().defaultTo("{}");
+    table.jsonb("top_alerts").notNullable().defaultTo("[]");
+    table.jsonb("aggregated_metrics").notNullable().defaultTo("{}");
+    table.timestamp("created_at").notNullable().defaultTo(knex.fn.now());
+
+    table.index(["window_id"]);
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists("alert_window_summaries");
+  await knex.schema.dropTableIfExists("alert_windows");
+}

--- a/backend/src/services/alertWindowing.service.ts
+++ b/backend/src/services/alertWindowing.service.ts
@@ -1,0 +1,337 @@
+import crypto from "crypto";
+import { getDatabase } from "../database/connection.js";
+import { logger } from "../utils/logger.js";
+
+export interface AlertWindow {
+  id: string;
+  assetCode: string;
+  alertType: string;
+  windowStart: Date;
+  windowEnd: Date;
+  alertCount: number;
+  summaryStats: Record<string, unknown>;
+  status: "open" | "closed" | "processing";
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface AlertWindowSummary {
+  id: string;
+  windowId: string;
+  severityBreakdown: Record<string, number>;
+  topAlerts: Record<string, unknown>[];
+  aggregatedMetrics: Record<string, unknown>;
+  createdAt: Date;
+}
+
+export interface GroupedAlert {
+  id: string;
+  ruleId: string;
+  assetCode: string;
+  alertType: string;
+  priority: string;
+  triggeredValue: number;
+  threshold: number;
+  occurredAt: Date;
+}
+
+export interface WindowConfig {
+  windowMinutes: number;
+  groupingKeys: string[];
+}
+
+const DEFAULT_CONFIG: WindowConfig = {
+  windowMinutes: 60,
+  groupingKeys: ["assetCode", "alertType"],
+};
+
+export class AlertWindowingService {
+  private static instance: AlertWindowingService;
+  private config: WindowConfig;
+
+  private constructor(config: Partial<WindowConfig> = {}) {
+    this.config = { ...DEFAULT_CONFIG, ...config };
+  }
+
+  public static getInstance(config?: Partial<WindowConfig>): AlertWindowingService {
+    if (!AlertWindowingService.instance) {
+      AlertWindowingService.instance = new AlertWindowingService(config);
+    }
+    return AlertWindowingService.instance;
+  }
+
+  public setConfig(config: Partial<WindowConfig>): void {
+    this.config = { ...this.config, ...config };
+  }
+
+  public determineWindowKey(alert: {
+    assetCode: string;
+    alertType: string;
+  }): string {
+    const parts = this.config.groupingKeys.map((key) =>
+      key === "assetCode" ? alert.assetCode : alert.alertType
+    );
+    return parts.join("::");
+  }
+
+  public async assignToWindow(alert: GroupedAlert): Promise<AlertWindow> {
+    const db = getDatabase();
+    const windowKey = this.determineWindowKey(alert);
+    const windowStart = this.getWindowStart(alert.occurredAt);
+
+    let window = await db("alert_windows")
+      .where("asset_code", alert.assetCode)
+      .where("alert_type", alert.alertType)
+      .where("window_start", windowStart)
+      .where("status", "open")
+      .first();
+
+    if (window) {
+      const currentCount = (window.alert_count as number) + 1;
+      const currentStats = JSON.parse(
+        typeof window.summary_stats === "string"
+          ? window.summary_stats
+          : JSON.stringify(window.summary_stats)
+      ) as Record<string, unknown>;
+
+      const updatedStats = this.mergeAlertIntoStats(currentStats, alert);
+
+      const [updated] = await db("alert_windows")
+        .where("id", window.id)
+        .update({
+          alert_count: currentCount,
+          summary_stats: JSON.stringify(updatedStats),
+          updated_at: new Date(),
+        })
+        .returning("*");
+
+      logger.info(
+        { windowId: window.id, alertCount: currentCount },
+        "Alert added to existing window"
+      );
+      return this.mapRow(updated ?? window);
+    }
+
+    const id = crypto.randomUUID();
+    const initialStats = this.buildInitialStats(alert);
+    const windowEnd = new Date(windowStart.getTime() + this.config.windowMinutes * 60 * 1000);
+
+    const [row] = await db("alert_windows")
+      .insert({
+        id,
+        asset_code: alert.assetCode,
+        alert_type: alert.alertType,
+        window_start: windowStart,
+        window_end: windowEnd,
+        alert_count: 1,
+        summary_stats: JSON.stringify(initialStats),
+        status: "open",
+        created_at: new Date(),
+        updated_at: new Date(),
+      })
+      .returning("*");
+
+    logger.info({ id, assetCode: alert.assetCode }, "New alert window created");
+    return this.mapRow(row);
+  }
+
+  public async closeWindow(windowId: string): Promise<AlertWindow | null> {
+    const db = getDatabase();
+    const [row] = await db("alert_windows")
+      .where("id", windowId)
+      .update({ status: "closed", updated_at: new Date() })
+      .returning("*");
+
+    if (!row) return null;
+
+    await this.generateSummary(windowId);
+    logger.info({ windowId }, "Alert window closed");
+    return this.mapRow(row);
+  }
+
+  public async getWindow(windowId: string): Promise<AlertWindow | null> {
+    const db = getDatabase();
+    const row = await db("alert_windows").where("id", windowId).first();
+    return row ? this.mapRow(row) : null;
+  }
+
+  public async listWindows(params: {
+    assetCode?: string;
+    alertType?: string;
+    status?: string;
+    limit?: number;
+    offset?: number;
+  } = {}): Promise<AlertWindow[]> {
+    const db = getDatabase();
+    let query = db("alert_windows").orderBy("window_start", "desc");
+
+    if (params.assetCode) query = query.where("asset_code", params.assetCode);
+    if (params.alertType) query = query.where("alert_type", params.alertType);
+    if (params.status) query = query.where("status", params.status);
+    if (params.limit) query = query.limit(params.limit);
+    if (params.offset) query = query.offset(params.offset);
+
+    const rows = await query;
+    return rows.map((r: Record<string, unknown>) => this.mapRow(r));
+  }
+
+  public async getSummary(windowId: string): Promise<AlertWindowSummary | null> {
+    const db = getDatabase();
+    const row = await db("alert_window_summaries")
+      .where("window_id", windowId)
+      .orderBy("created_at", "desc")
+      .first();
+    if (!row) return null;
+
+    return {
+      id: row.id as string,
+      windowId: row.window_id as string,
+      severityBreakdown: JSON.parse(
+        typeof row.severity_breakdown === "string"
+          ? row.severity_breakdown
+          : JSON.stringify(row.severity_breakdown)
+      ),
+      topAlerts: JSON.parse(
+        typeof row.top_alerts === "string"
+          ? row.top_alerts
+          : JSON.stringify(row.top_alerts)
+      ),
+      aggregatedMetrics: JSON.parse(
+        typeof row.aggregated_metrics === "string"
+          ? row.aggregated_metrics
+          : JSON.stringify(row.aggregated_metrics)
+      ),
+      createdAt: row.created_at as Date,
+    };
+  }
+
+  private async generateSummary(windowId: string): Promise<void> {
+    const db = getDatabase();
+    const window = await db("alert_windows").where("id", windowId).first();
+    if (!window) return;
+
+    const stats =
+      typeof window.summary_stats === "string"
+        ? JSON.parse(window.summary_stats)
+        : window.summary_stats;
+
+    const severityBreakdown: Record<string, number> = stats.severity ?? {};
+    const topAlerts: Record<string, unknown>[] = stats.recentAlerts ?? [];
+    const aggregatedMetrics: Record<string, unknown> = {
+      totalAlerts: window.alert_count,
+      windowDurationMinutes: this.config.windowMinutes,
+      avgAlertPerMinute:
+        ((window.alert_count as number) / this.config.windowMinutes).toFixed(2),
+      uniqueTypes: Object.keys(severityBreakdown).length,
+    };
+
+    await db("alert_window_summaries").insert({
+      id: crypto.randomUUID(),
+      window_id: windowId,
+      severity_breakdown: JSON.stringify(severityBreakdown),
+      top_alerts: JSON.stringify(topAlerts),
+      aggregated_metrics: JSON.stringify(aggregatedMetrics),
+      created_at: new Date(),
+    });
+  }
+
+  public async autoCloseExpiredWindows(): Promise<number> {
+    const db = getDatabase();
+    const now = new Date();
+    const expired = await db("alert_windows")
+      .where("window_end", "<", now)
+      .where("status", "open");
+
+    for (const window of expired) {
+      await this.closeWindow(window.id as string);
+    }
+
+    if (expired.length > 0) {
+      logger.info({ count: expired.length }, "Auto-closed expired alert windows");
+    }
+    return expired.length;
+  }
+
+  private getWindowStart(timestamp: Date): Date {
+    const ms = this.config.windowMinutes * 60 * 1000;
+    return new Date(Math.floor(timestamp.getTime() / ms) * ms);
+  }
+
+  private buildInitialStats(alert: GroupedAlert): Record<string, unknown> {
+    return {
+      firstAlertAt: alert.occurredAt.toISOString(),
+      lastAlertAt: alert.occurredAt.toISOString(),
+      highestPriority: alert.priority,
+      severity: { [alert.priority]: 1 },
+      recentAlerts: [
+        {
+          id: alert.id,
+          ruleId: alert.ruleId,
+          priority: alert.priority,
+          value: alert.triggeredValue,
+          threshold: alert.threshold,
+          time: alert.occurredAt.toISOString(),
+        },
+      ],
+    };
+  }
+
+  private mergeAlertIntoStats(
+    stats: Record<string, unknown>,
+    alert: GroupedAlert
+  ): Record<string, unknown> {
+    const severity = (stats.severity as Record<string, number>) ?? {};
+    severity[alert.priority] = (severity[alert.priority] ?? 0) + 1;
+
+    const recentAlerts = (stats.recentAlerts as Record<string, unknown>[]) ?? [];
+    recentAlerts.unshift({
+      id: alert.id,
+      ruleId: alert.ruleId,
+      priority: alert.priority,
+      value: alert.triggeredValue,
+      threshold: alert.threshold,
+      time: alert.occurredAt.toISOString(),
+    });
+
+    const maxRecent = 20;
+    if (recentAlerts.length > maxRecent) {
+      recentAlerts.length = maxRecent;
+    }
+
+    return {
+      ...stats,
+      lastAlertAt: alert.occurredAt.toISOString(),
+      highestPriority: this.getHigherPriority(
+        stats.highestPriority as string,
+        alert.priority
+      ),
+      severity,
+      recentAlerts,
+    };
+  }
+
+  private getHigherPriority(a: string, b: string): string {
+    const order = ["low", "medium", "high", "critical"];
+    return order.indexOf(a) >= order.indexOf(b) ? a : b;
+  }
+
+  private mapRow(row: Record<string, unknown>): AlertWindow {
+    return {
+      id: row.id as string,
+      assetCode: row.asset_code as string,
+      alertType: row.alert_type as string,
+      windowStart: row.window_start as Date,
+      windowEnd: row.window_end as Date,
+      alertCount: row.alert_count as number,
+      summaryStats:
+        typeof row.summary_stats === "string"
+          ? JSON.parse(row.summary_stats as string)
+          : (row.summary_stats as Record<string, unknown>),
+      status: row.status as AlertWindow["status"],
+      createdAt: row.created_at as Date,
+      updatedAt: row.updated_at as Date,
+    };
+  }
+}
+
+export const alertWindowingService = AlertWindowingService.getInstance();

--- a/backend/src/services/assetMerge.service.ts
+++ b/backend/src/services/assetMerge.service.ts
@@ -1,0 +1,352 @@
+import crypto from "crypto";
+import { getDatabase } from "../database/connection.js";
+import { logger } from "../utils/logger.js";
+
+export interface DuplicateGroup {
+  primaryAssetId: string;
+  primarySymbol: string;
+  duplicateIds: string[];
+  matchScore: number;
+  matchReason: string;
+}
+
+export interface MergeResult {
+  id: string;
+  primaryAssetId: string;
+  primarySymbol: string;
+  mergedAssetIds: string[];
+  mergeRulesApplied: Record<string, unknown>;
+  conflictsResolved: ConflictResolution[];
+  status: string;
+  triggeredBy: string;
+  createdAt: string;
+}
+
+export interface ConflictResolution {
+  field: string;
+  chosen: unknown;
+  alternatives: unknown[];
+  reason: string;
+}
+
+export interface MergeReview {
+  id: string;
+  duplicateGroup: DuplicateGroup;
+  suggestedMerge: Record<string, unknown>;
+  status: "pending" | "approved" | "rejected";
+  reviewedBy: string | null;
+  reviewNotes: string | null;
+  reviewedAt: Date | null;
+  createdAt: Date;
+}
+
+const MERGE_RULES = {
+  scoreThreshold: 0.8,
+  retainFields: ["symbol", "name", "issuer"] as string[],
+  preferenceOrder: ["source_chain", "bridge_provider"] as string[],
+};
+
+export class AssetMergeService {
+  private static instance: AssetMergeService;
+
+  private constructor() {}
+
+  public static getInstance(): AssetMergeService {
+    if (!AssetMergeService.instance) {
+      AssetMergeService.instance = new AssetMergeService();
+    }
+    return AssetMergeService.instance;
+  }
+
+  public async findDuplicates(): Promise<DuplicateGroup[]> {
+    const db = getDatabase();
+    const assets = await db("assets").where("is_active", true).orderBy("symbol");
+
+    const groups: DuplicateGroup[] = [];
+    const seen = new Set<string>();
+
+    for (let i = 0; i < assets.length; i++) {
+      if (seen.has(assets[i].id)) continue;
+
+      const group: DuplicateGroup = {
+        primaryAssetId: assets[i].id,
+        primarySymbol: assets[i].symbol,
+        duplicateIds: [],
+        matchScore: 0,
+        matchReason: "",
+      };
+
+      for (let j = i + 1; j < assets.length; j++) {
+        if (seen.has(assets[j].id)) continue;
+
+        const score = this.computeMatchScore(assets[i], assets[j]);
+        if (score >= MERGE_RULES.scoreThreshold) {
+          group.duplicateIds.push(assets[j].id);
+          group.matchScore = Math.max(group.matchScore, score);
+          group.matchReason = this.determineMatchReason(assets[i], assets[j]);
+          seen.add(assets[j].id);
+        }
+      }
+
+      if (group.duplicateIds.length > 0) {
+        seen.add(assets[i].id);
+        groups.push(group);
+      }
+    }
+
+    return groups;
+  }
+
+  public async merge(
+    primaryAssetId: string,
+    duplicateIds: string[],
+    triggeredBy: string
+  ): Promise<MergeResult> {
+    const db = getDatabase();
+    const primary = await db("assets").where("id", primaryAssetId).first();
+    if (!primary) throw new Error(`Primary asset not found: ${primaryAssetId}`);
+
+    const duplicates = await db("assets").whereIn("id", duplicateIds);
+    if (duplicates.length !== duplicateIds.length) {
+      throw new Error("One or more duplicate assets not found");
+    }
+
+    const conflictsResolved: ConflictResolution[] = [];
+    const mergeRulesApplied: Record<string, unknown> = {
+      scoreThreshold: MERGE_RULES.scoreThreshold,
+      retainFields: MERGE_RULES.retainFields,
+      preferenceOrder: MERGE_RULES.preferenceOrder,
+    };
+
+    for (const dup of duplicates) {
+      for (const field of MERGE_RULES.retainFields) {
+        if (!primary[field] && dup[field]) {
+          conflictsResolved.push({
+            field,
+            chosen: dup[field],
+            alternatives: [primary[field]],
+            reason: `Primary had no ${field}, using from duplicate`,
+          });
+        }
+      }
+    }
+
+    const mergedData: Record<string, unknown> = { updated_at: new Date() };
+    for (const resolution of conflictsResolved) {
+      mergedData[resolution.field] = resolution.chosen;
+    }
+
+    if (Object.keys(mergedData).length > 1) {
+      await db("assets").where("id", primaryAssetId).update(mergedData);
+    }
+
+    await db("assets").whereIn("id", duplicateIds).update({ is_active: false });
+
+    const id = crypto.randomUUID();
+    await db("asset_merge_logs").insert({
+      id,
+      primary_asset_id: primaryAssetId,
+      primary_symbol: primary.symbol,
+      merged_asset_ids: JSON.stringify(duplicateIds),
+      merge_rules_applied: JSON.stringify(mergeRulesApplied),
+      conflicts_resolved: JSON.stringify(conflictsResolved),
+      status: "completed",
+      triggered_by: triggeredBy,
+      created_at: new Date(),
+    });
+
+    logger.info(
+      { primaryAssetId, duplicateCount: duplicateIds.length },
+      "Assets merged successfully"
+    );
+
+    return {
+      id,
+      primaryAssetId,
+      primarySymbol: primary.symbol,
+      mergedAssetIds: duplicateIds,
+      mergeRulesApplied,
+      conflictsResolved,
+      status: "completed",
+      triggeredBy,
+      createdAt: new Date().toISOString(),
+    };
+  }
+
+  public async proposeMerge(
+    duplicateGroup: DuplicateGroup
+  ): Promise<MergeReview> {
+    const db = getDatabase();
+    const suggestedMerge: Record<string, unknown> = {
+      primaryAssetId: duplicateGroup.primaryAssetId,
+      primarySymbol: duplicateGroup.primarySymbol,
+      duplicates: duplicateGroup.duplicateIds,
+      matchScore: duplicateGroup.matchScore,
+      matchReason: duplicateGroup.matchReason,
+    };
+
+    const id = crypto.randomUUID();
+    await db("asset_merge_reviews").insert({
+      id,
+      duplicate_group: JSON.stringify(duplicateGroup),
+      suggested_merge: JSON.stringify(suggestedMerge),
+      status: "pending",
+      reviewed_by: null,
+      review_notes: null,
+      reviewed_at: null,
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
+
+    return {
+      id,
+      duplicateGroup,
+      suggestedMerge,
+      status: "pending",
+      reviewedBy: null,
+      reviewNotes: null,
+      reviewedAt: null,
+      createdAt: new Date(),
+    };
+  }
+
+  public async reviewMerge(
+    reviewId: string,
+    status: "approved" | "rejected",
+    reviewedBy: string,
+    reviewNotes?: string
+  ): Promise<MergeReview | null> {
+    const db = getDatabase();
+    const existing = await db("asset_merge_reviews").where("id", reviewId).first();
+    if (!existing) return null;
+
+    await db("asset_merge_reviews")
+      .where("id", reviewId)
+      .update({
+        status,
+        reviewed_by: reviewedBy,
+        review_notes: reviewNotes ?? null,
+        reviewed_at: new Date(),
+        updated_at: new Date(),
+      });
+
+    if (status === "approved") {
+      const group = JSON.parse(
+        typeof existing.duplicate_group === "string"
+          ? existing.duplicate_group
+          : JSON.stringify(existing.duplicate_group)
+      ) as DuplicateGroup;
+      await this.merge(group.primaryAssetId, group.duplicateIds, reviewedBy);
+    }
+
+    return this.getReview(reviewId);
+  }
+
+  public async getReview(reviewId: string): Promise<MergeReview | null> {
+    const db = getDatabase();
+    const row = await db("asset_merge_reviews").where("id", reviewId).first();
+    if (!row) return null;
+
+    return {
+      id: row.id as string,
+      duplicateGroup:
+        typeof row.duplicate_group === "string"
+          ? JSON.parse(row.duplicate_group)
+          : row.duplicate_group,
+      suggestedMerge:
+        typeof row.suggested_merge === "string"
+          ? JSON.parse(row.suggested_merge)
+          : row.suggested_merge,
+      status: row.status as MergeReview["status"],
+      reviewedBy: (row.reviewed_by as string) ?? null,
+      reviewNotes: (row.review_notes as string) ?? null,
+      reviewedAt: (row.reviewed_at as Date) ?? null,
+      createdAt: row.created_at as Date,
+    };
+  }
+
+  public async listReviews(params: {
+    status?: string;
+  } = {}): Promise<MergeReview[]> {
+    const db = getDatabase();
+    let query = db("asset_merge_reviews").orderBy("created_at", "desc");
+    if (params.status) query = query.where("status", params.status);
+    const rows = await query;
+    return rows.map((r: Record<string, unknown>) => ({
+      id: r.id as string,
+      duplicateGroup:
+        typeof r.duplicate_group === "string"
+          ? JSON.parse(r.duplicate_group)
+          : r.duplicate_group,
+      suggestedMerge:
+        typeof r.suggested_merge === "string"
+          ? JSON.parse(r.suggested_merge)
+          : r.suggested_merge,
+      status: r.status as MergeReview["status"],
+      reviewedBy: (r.reviewed_by as string) ?? null,
+      reviewNotes: (r.review_notes as string) ?? null,
+      reviewedAt: (r.reviewed_at as Date) ?? null,
+      createdAt: r.created_at as Date,
+    }));
+  }
+
+  public async getMergeHistory(params: {
+    primaryAssetId?: string;
+    limit?: number;
+  } = {}): Promise<MergeResult[]> {
+    const db = getDatabase();
+    let query = db("asset_merge_logs").orderBy("created_at", "desc");
+    if (params.primaryAssetId) query = query.where("primary_asset_id", params.primaryAssetId);
+    if (params.limit) query = query.limit(params.limit);
+    const rows = await query;
+    return rows.map((r: Record<string, unknown>) => ({
+      id: r.id as string,
+      primaryAssetId: r.primary_asset_id as string,
+      primarySymbol: r.primary_symbol as string,
+      mergedAssetIds: JSON.parse(
+        typeof r.merged_asset_ids === "string"
+          ? (r.merged_asset_ids as string)
+          : JSON.stringify(r.merged_asset_ids)
+      ),
+      mergeRulesApplied: JSON.parse(
+        typeof r.merge_rules_applied === "string"
+          ? (r.merge_rules_applied as string)
+          : JSON.stringify(r.merge_rules_applied)
+      ),
+      conflictsResolved: JSON.parse(
+        typeof r.conflicts_resolved === "string"
+          ? (r.conflicts_resolved as string)
+          : JSON.stringify(r.conflicts_resolved)
+      ),
+      status: r.status as string,
+      triggeredBy: r.triggered_by as string,
+      createdAt: (r.created_at as Date).toISOString(),
+    }));
+  }
+
+  private computeMatchScore(a: Record<string, unknown>, b: Record<string, unknown>): number {
+    let score = 0;
+    let total = 0;
+
+    if (a.symbol === b.symbol) { score += 30; total += 30; }
+    if (a.name === b.name) { score += 25; total += 25; }
+    if (a.issuer === b.issuer && a.issuer) { score += 25; total += 25; }
+    if (a.source_chain === b.source_chain && a.source_chain) { score += 10; total += 10; }
+    if (a.bridge_provider === b.bridge_provider && a.bridge_provider) { score += 10; total += 10; }
+
+    return total > 0 ? score / total : 0;
+  }
+
+  private determineMatchReason(
+    a: Record<string, unknown>,
+    b: Record<string, unknown>
+  ): string {
+    const reasons: string[] = [];
+    if (a.symbol === b.symbol) reasons.push("same symbol");
+    if (a.name === b.name) reasons.push("same name");
+    if (a.issuer === b.issuer) reasons.push("same issuer");
+    return reasons.length > 0 ? reasons.join(", ") : "unknown";
+  }
+}
+
+export const assetMergeService = AssetMergeService.getInstance();

--- a/backend/src/services/ruleEvaluator.service.ts
+++ b/backend/src/services/ruleEvaluator.service.ts
@@ -1,0 +1,211 @@
+import crypto from "crypto";
+import { getDatabase } from "../database/connection.js";
+import { logger } from "../utils/logger.js";
+
+export type ThresholdOperator =
+  | "gt" | "gte" | "lt" | "lte" | "eq" | "ne" | "between" | "changes_by_pct";
+
+export type LogicOperator = "AND" | "OR";
+
+export interface RuleEvaluationInput {
+  ruleId?: string;
+  ruleName: string;
+  assetCode: string;
+  conditions: RuleCondition[];
+  logicOperator: LogicOperator;
+}
+
+export interface RuleCondition {
+  field: string;
+  operator: ThresholdOperator;
+  value: number;
+  valueHigh?: number;
+  label?: string;
+}
+
+export interface ConditionResult {
+  field: string;
+  operator: ThresholdOperator;
+  expectedValue: number;
+  actualValue: number;
+  passed: boolean;
+  label?: string;
+}
+
+export interface RuleEvaluationOutput {
+  id: string;
+  ruleId: string | null;
+  ruleName: string;
+  assetCode: string;
+  triggered: boolean;
+  logicOperator: LogicOperator;
+  conditionResults: ConditionResult[];
+  previewMode: boolean;
+  evaluatedAt: string;
+}
+
+function evaluateCondition(
+  condition: RuleCondition,
+  actualValue: number,
+  previousValue?: number
+): boolean {
+  const { operator, value, valueHigh } = condition;
+  switch (operator) {
+    case "gt":   return actualValue > value;
+    case "gte":  return actualValue >= value;
+    case "lt":   return actualValue < value;
+    case "lte":  return actualValue <= value;
+    case "eq":   return actualValue === value;
+    case "ne":   return actualValue !== value;
+    case "between":
+      return valueHigh !== undefined && actualValue >= value && actualValue <= valueHigh;
+    case "changes_by_pct":
+      if (previousValue === undefined || previousValue === 0) return false;
+      return Math.abs((actualValue - previousValue) / previousValue) * 100 >= value;
+    default:
+      return false;
+  }
+}
+
+export class RuleEvaluatorService {
+  private static instance: RuleEvaluatorService;
+
+  private constructor() {}
+
+  public static getInstance(): RuleEvaluatorService {
+    if (!RuleEvaluatorService.instance) {
+      RuleEvaluatorService.instance = new RuleEvaluatorService();
+    }
+    return RuleEvaluatorService.instance;
+  }
+
+  public evaluate(
+    input: RuleEvaluationInput,
+    metrics: Record<string, number>,
+    previousMetrics?: Record<string, number>,
+    previewMode = false
+  ): RuleEvaluationOutput {
+    this.validateConditions(input.conditions);
+
+    const conditionResults: ConditionResult[] = input.conditions.map((cond) => {
+      const actualValue = metrics[cond.field] ?? 0;
+      const prevValue = previousMetrics?.[cond.field];
+      const passed = evaluateCondition(cond, actualValue, prevValue);
+      return {
+        field: cond.field,
+        operator: cond.operator,
+        expectedValue: cond.value,
+        actualValue,
+        passed,
+        label: cond.label,
+      };
+    });
+
+    const triggered =
+      input.logicOperator === "AND"
+        ? conditionResults.every((r) => r.passed)
+        : conditionResults.some((r) => r.passed);
+
+    const result: RuleEvaluationOutput = {
+      id: crypto.randomUUID(),
+      ruleId: input.ruleId ?? null,
+      ruleName: input.ruleName,
+      assetCode: input.assetCode,
+      triggered,
+      logicOperator: input.logicOperator,
+      conditionResults,
+      previewMode,
+      evaluatedAt: new Date().toISOString(),
+    };
+
+    if (!previewMode) {
+      this.persistEvaluationLog(result, metrics).catch((err) =>
+        logger.error({ err }, "Failed to persist rule evaluation log")
+      );
+    }
+
+    return result;
+  }
+
+  public evaluateBatch(
+    inputs: RuleEvaluationInput[],
+    metrics: Record<string, number>,
+    previousMetrics?: Record<string, number>,
+    previewMode = false
+  ): RuleEvaluationOutput[] {
+    return inputs.map((input) =>
+      this.evaluate(input, metrics, previousMetrics, previewMode)
+    );
+  }
+
+  public async getEvaluationHistory(params: {
+    ruleId?: string;
+    assetCode?: string;
+    triggered?: boolean;
+    limit?: number;
+    offset?: number;
+  } = {}): Promise<RuleEvaluationOutput[]> {
+    const db = getDatabase();
+    let query = db("rule_evaluator_logs").orderBy("evaluated_at", "desc");
+
+    if (params.ruleId) query = query.where("rule_id", params.ruleId);
+    if (params.assetCode) query = query.where("asset_code", params.assetCode);
+    if (params.triggered !== undefined) query = query.where("triggered", params.triggered);
+    if (params.limit) query = query.limit(params.limit);
+    if (params.offset) query = query.offset(params.offset);
+
+    const rows = await query;
+    return rows.map((r: Record<string, unknown>) => this.mapRow(r));
+  }
+
+  private validateConditions(conditions: RuleCondition[]): void {
+    if (!conditions.length) {
+      throw new Error("At least one condition is required");
+    }
+    for (const cond of conditions) {
+      if (!cond.field?.trim()) throw new Error("Condition field cannot be empty");
+      if (cond.operator === "between" && cond.valueHigh === undefined) {
+        throw new Error('Condition with "between" operator requires valueHigh');
+      }
+    }
+  }
+
+  private async persistEvaluationLog(
+    result: RuleEvaluationOutput,
+    metrics: Record<string, number>
+  ): Promise<void> {
+    const db = getDatabase();
+    await db("rule_evaluator_logs").insert({
+      id: result.id,
+      rule_id: result.ruleId,
+      rule_name: result.ruleName,
+      asset_code: result.assetCode,
+      input_metrics: JSON.stringify(metrics),
+      evaluation_result: JSON.stringify(result),
+      triggered: result.triggered,
+      logic_operator: result.logicOperator,
+      preview_mode: result.previewMode,
+      evaluated_at: new Date(),
+    });
+  }
+
+  private mapRow(row: Record<string, unknown>): RuleEvaluationOutput {
+    const evaluationResult =
+      typeof row.evaluation_result === "string"
+        ? JSON.parse(row.evaluation_result as string)
+        : row.evaluation_result;
+    return {
+      id: row.id as string,
+      ruleId: row.rule_id as string | null,
+      ruleName: row.rule_name as string,
+      assetCode: row.asset_code as string,
+      triggered: row.triggered as boolean,
+      logicOperator: row.logic_operator as LogicOperator,
+      conditionResults: evaluationResult?.conditionResults ?? [],
+      previewMode: row.preview_mode as boolean,
+      evaluatedAt: (row.evaluated_at as Date).toISOString(),
+    };
+  }
+}
+
+export const ruleEvaluatorService = RuleEvaluatorService.getInstance();

--- a/backend/src/services/serviceAnnotation.service.ts
+++ b/backend/src/services/serviceAnnotation.service.ts
@@ -1,0 +1,175 @@
+import crypto from "crypto";
+import { getDatabase } from "../database/connection.js";
+import { logger } from "../utils/logger.js";
+
+export interface ServiceAnnotation {
+  id: string;
+  serviceName: string;
+  entityType: string;
+  entityId: string | null;
+  content: string;
+  author: string;
+  startTime: Date | null;
+  endTime: Date | null;
+  active: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface CreateAnnotationInput {
+  serviceName: string;
+  entityType: string;
+  entityId?: string;
+  content: string;
+  author: string;
+  startTime?: Date;
+  endTime?: Date;
+}
+
+export interface UpdateAnnotationInput {
+  content?: string;
+  startTime?: Date | null;
+  endTime?: Date | null;
+  active?: boolean;
+}
+
+export class ServiceAnnotationService {
+  private static instance: ServiceAnnotationService;
+
+  private constructor() {}
+
+  public static getInstance(): ServiceAnnotationService {
+    if (!ServiceAnnotationService.instance) {
+      ServiceAnnotationService.instance = new ServiceAnnotationService();
+    }
+    return ServiceAnnotationService.instance;
+  }
+
+  public async create(input: CreateAnnotationInput): Promise<ServiceAnnotation> {
+    const db = getDatabase();
+    const id = crypto.randomUUID();
+
+    const [row] = await db("service_annotations")
+      .insert({
+        id,
+        service_name: input.serviceName,
+        entity_type: input.entityType,
+        entity_id: input.entityId ?? null,
+        content: input.content,
+        author: input.author,
+        start_time: input.startTime ?? null,
+        end_time: input.endTime ?? null,
+        active: true,
+        created_at: new Date(),
+        updated_at: new Date(),
+      })
+      .returning("*");
+
+    await this.logAudit(id, "created", input.author, { input });
+    logger.info({ id, serviceName: input.serviceName }, "Service annotation created");
+    return this.mapRow(row);
+  }
+
+  public async get(id: string): Promise<ServiceAnnotation | null> {
+    const db = getDatabase();
+    const row = await db("service_annotations").where("id", id).first();
+    return row ? this.mapRow(row) : null;
+  }
+
+  public async update(
+    id: string,
+    actor: string,
+    updates: UpdateAnnotationInput
+  ): Promise<ServiceAnnotation | null> {
+    const db = getDatabase();
+    const existing = await db("service_annotations").where("id", id).first();
+    if (!existing) return null;
+
+    const updateData: Record<string, unknown> = { updated_at: new Date() };
+    if (updates.content !== undefined) updateData.content = updates.content;
+    if (updates.active !== undefined) updateData.active = updates.active;
+    if ("startTime" in updates) updateData.start_time = updates.startTime ?? null;
+    if ("endTime" in updates) updateData.end_time = updates.endTime ?? null;
+
+    const [row] = await db("service_annotations")
+      .where("id", id)
+      .update(updateData)
+      .returning("*");
+
+    await this.logAudit(id, "updated", actor, { updates });
+    logger.info({ id }, "Service annotation updated");
+    return this.mapRow(row);
+  }
+
+  public async delete(id: string, actor: string): Promise<boolean> {
+    const db = getDatabase();
+    const count = await db("service_annotations").where("id", id).delete();
+    if (count > 0) {
+      await this.logAudit(id, "deleted", actor, {});
+      logger.info({ id }, "Service annotation deleted");
+    }
+    return count > 0;
+  }
+
+  public async list(params: {
+    serviceName?: string;
+    entityType?: string;
+    entityId?: string;
+    active?: boolean;
+    author?: string;
+  } = {}): Promise<ServiceAnnotation[]> {
+    const db = getDatabase();
+    let query = db("service_annotations").orderBy("created_at", "desc");
+
+    if (params.serviceName) query = query.where("service_name", params.serviceName);
+    if (params.entityType) query = query.where("entity_type", params.entityType);
+    if (params.entityId) query = query.where("entity_id", params.entityId);
+    if (params.active !== undefined) query = query.where("active", params.active);
+    if (params.author) query = query.where("author", params.author);
+
+    const rows = await query;
+    return rows.map((r: Record<string, unknown>) => this.mapRow(r));
+  }
+
+  public async getAuditLog(annotationId: string): Promise<Record<string, unknown>[]> {
+    const db = getDatabase();
+    return db("service_annotation_audit")
+      .where("annotation_id", annotationId)
+      .orderBy("created_at", "desc");
+  }
+
+  private async logAudit(
+    annotationId: string,
+    action: string,
+    actor: string,
+    changes: Record<string, unknown>
+  ): Promise<void> {
+    const db = getDatabase();
+    await db("service_annotation_audit").insert({
+      id: crypto.randomUUID(),
+      annotation_id: annotationId,
+      action,
+      actor,
+      changes: JSON.stringify(changes),
+      created_at: new Date(),
+    });
+  }
+
+  private mapRow(row: Record<string, unknown>): ServiceAnnotation {
+    return {
+      id: row.id as string,
+      serviceName: row.service_name as string,
+      entityType: row.entity_type as string,
+      entityId: (row.entity_id as string) ?? null,
+      content: row.content as string,
+      author: row.author as string,
+      startTime: (row.start_time as Date) ?? null,
+      endTime: (row.end_time as Date) ?? null,
+      active: row.active as boolean,
+      createdAt: row.created_at as Date,
+      updatedAt: row.updated_at as Date,
+    };
+  }
+}
+
+export const serviceAnnotationService = ServiceAnnotationService.getInstance();

--- a/backend/tests/services/alertWindowing.service.test.ts
+++ b/backend/tests/services/alertWindowing.service.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AlertWindowingService } from "../../src/services/alertWindowing.service.js";
+
+vi.mock("../../src/utils/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("../../src/database/connection.js", () => ({
+  getDatabase: vi.fn(() => {
+    const b: Record<string, unknown> = {};
+    b.where = vi.fn().mockReturnValue(b);
+    b.orderBy = vi.fn().mockReturnValue(b);
+    b.insert = vi.fn().mockReturnValue(b);
+    b.update = vi.fn().mockReturnValue(b);
+    b.first = vi.fn().mockResolvedValue(null);
+    b.returning = vi.fn().mockResolvedValue([]);
+    b.limit = vi.fn().mockReturnValue(b);
+    b.offset = vi.fn().mockResolvedValue([]);
+    const fn = (_t: string) => b;
+    return fn;
+  }),
+}));
+
+describe("AlertWindowingService", () => {
+  let service: AlertWindowingService;
+
+  beforeEach(() => {
+    (AlertWindowingService as any).instance = undefined;
+    service = AlertWindowingService.getInstance();
+    vi.clearAllMocks();
+  });
+
+  describe("determineWindowKey", () => {
+    it("generates a composite key from assetCode and alertType", () => {
+      const key = service.determineWindowKey({
+        assetCode: "USDC",
+        alertType: "price_deviation",
+      });
+      expect(key).toBe("USDC::price_deviation");
+    });
+  });
+
+  describe("getWindow", () => {
+    it("returns null for unknown window", async () => {
+      const window = await service.getWindow("nonexistent");
+      expect(window).toBeNull();
+    });
+  });
+
+  describe("listWindows", () => {
+    it("returns empty array when no windows", async () => {
+      const windows = await service.listWindows();
+      expect(windows).toEqual([]);
+    });
+  });
+
+  describe("assignToWindow", () => {
+    it("creates a new window when no matching window exists", async () => {
+      const window = await service.assignToWindow({
+        id: "alert-1",
+        ruleId: "rule-1",
+        assetCode: "USDC",
+        alertType: "price_deviation",
+        priority: "high",
+        triggeredValue: 150,
+        threshold: 100,
+        occurredAt: new Date(),
+      });
+
+      expect(window.assetCode).toBe("USDC");
+      expect(window.alertType).toBe("price_deviation");
+      expect(window.alertCount).toBe(1);
+    });
+  });
+
+  describe("closeWindow", () => {
+    it("returns null for unknown window", async () => {
+      const window = await service.closeWindow("nonexistent");
+      expect(window).toBeNull();
+    });
+  });
+
+  describe("getSummary", () => {
+    it("returns null for unknown window", async () => {
+      const summary = await service.getSummary("nonexistent");
+      expect(summary).toBeNull();
+    });
+  });
+
+  describe("autoCloseExpiredWindows", () => {
+    it("returns 0 when no expired windows", async () => {
+      const count = await service.autoCloseExpiredWindows();
+      expect(count).toBe(0);
+    });
+  });
+
+  describe("setConfig", () => {
+    it("updates window configuration", () => {
+      service.setConfig({ windowMinutes: 30 });
+      const key = service.determineWindowKey({
+        assetCode: "BTC",
+        alertType: "supply_mismatch",
+      });
+      expect(key).toBe("BTC::supply_mismatch");
+    });
+  });
+});

--- a/backend/tests/services/assetMerge.service.test.ts
+++ b/backend/tests/services/assetMerge.service.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AssetMergeService } from "../../src/services/assetMerge.service.js";
+
+vi.mock("../../src/utils/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("../../src/database/connection.js", () => ({
+  getDatabase: vi.fn(() => {
+    const b: Record<string, unknown> = {};
+    b.where = vi.fn().mockReturnValue(b);
+    b.whereIn = vi.fn().mockReturnValue(b);
+    b.orderBy = vi.fn().mockReturnValue(b);
+    b.insert = vi.fn().mockReturnValue(b);
+    b.update = vi.fn().mockReturnValue(b);
+    b.delete = vi.fn().mockResolvedValue(1);
+    b.first = vi.fn().mockResolvedValue(null);
+    b.returning = vi.fn().mockResolvedValue([]);
+    b.limit = vi.fn().mockReturnValue(b);
+    const fn = (_t: string) => b;
+    return fn;
+  }),
+}));
+
+describe("AssetMergeService", () => {
+  let service: AssetMergeService;
+
+  beforeEach(() => {
+    (AssetMergeService as any).instance = undefined;
+    service = AssetMergeService.getInstance();
+    vi.clearAllMocks();
+  });
+
+  describe("findDuplicates", () => {
+    it("returns empty array when no duplicates exist", async () => {
+      const groups = await service.findDuplicates();
+      expect(groups).toEqual([]);
+    });
+  });
+
+  describe("merge", () => {
+    it("throws when primary asset not found", async () => {
+      await expect(
+        service.merge("nonexistent", ["dup-1"], "ops")
+      ).rejects.toThrow("Primary asset not found");
+    });
+  });
+
+  describe("proposeMerge", () => {
+    it("creates a pending review", async () => {
+      const review = await service.proposeMerge({
+        primaryAssetId: "asset-1",
+        primarySymbol: "USDC",
+        duplicateIds: ["asset-2"],
+        matchScore: 0.9,
+        matchReason: "same symbol",
+      });
+
+      expect(review.status).toBe("pending");
+      expect(review.duplicateGroup.primarySymbol).toBe("USDC");
+    });
+  });
+
+  describe("getReview", () => {
+    it("returns null for unknown review", async () => {
+      const review = await service.getReview("nonexistent");
+      expect(review).toBeNull();
+    });
+  });
+
+  describe("listReviews", () => {
+    it("returns empty array when no reviews", async () => {
+      const reviews = await service.listReviews();
+      expect(reviews).toEqual([]);
+    });
+  });
+
+  describe("getMergeHistory", () => {
+    it("returns empty array when no history", async () => {
+      const history = await service.getMergeHistory();
+      expect(history).toEqual([]);
+    });
+  });
+});

--- a/backend/tests/services/ruleEvaluator.service.test.ts
+++ b/backend/tests/services/ruleEvaluator.service.test.ts
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { RuleEvaluatorService } from "../../src/services/ruleEvaluator.service.js";
+
+vi.mock("../../src/utils/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("../../src/database/connection.js", () => ({
+  getDatabase: vi.fn(() => {
+    const b: Record<string, unknown> = {};
+    b.where = vi.fn().mockReturnValue(b);
+    b.orderBy = vi.fn().mockReturnValue(b);
+    b.insert = vi.fn().mockReturnValue(b);
+    b.returning = vi.fn().mockResolvedValue([]);
+    b.first = vi.fn().mockResolvedValue(null);
+    b.limit = vi.fn().mockReturnValue(b);
+    b.offset = vi.fn().mockResolvedValue([]);
+    const fn = (_t: string) => b;
+    return fn;
+  }),
+}));
+
+describe("RuleEvaluatorService", () => {
+  let service: RuleEvaluatorService;
+
+  beforeEach(() => {
+    (RuleEvaluatorService as any).instance = undefined;
+    service = RuleEvaluatorService.getInstance();
+  });
+
+  describe("evaluate", () => {
+    it("evaluates AND conditions - all pass", () => {
+      const result = service.evaluate(
+        {
+          ruleName: "test-rule",
+          assetCode: "USDC",
+          conditions: [
+            { field: "price", operator: "gt", value: 100 },
+            { field: "volume", operator: "gt", value: 1000 },
+          ],
+          logicOperator: "AND",
+        },
+        { price: 150, volume: 5000 }
+      );
+
+      expect(result.triggered).toBe(true);
+      expect(result.conditionResults).toHaveLength(2);
+      expect(result.conditionResults[0].passed).toBe(true);
+      expect(result.conditionResults[1].passed).toBe(true);
+    });
+
+    it("evaluates AND conditions - one fails", () => {
+      const result = service.evaluate(
+        {
+          ruleName: "test-rule",
+          assetCode: "USDC",
+          conditions: [
+            { field: "price", operator: "gt", value: 100 },
+            { field: "volume", operator: "lt", value: 1000 },
+          ],
+          logicOperator: "AND",
+        },
+        { price: 150, volume: 5000 }
+      );
+
+      expect(result.triggered).toBe(false);
+      expect(result.conditionResults[1].passed).toBe(false);
+    });
+
+    it("evaluates OR conditions - one passes", () => {
+      const result = service.evaluate(
+        {
+          ruleName: "test-rule",
+          assetCode: "USDC",
+          conditions: [
+            { field: "price", operator: "gt", value: 1000 },
+            { field: "volume", operator: "gt", value: 100 },
+          ],
+          logicOperator: "OR",
+        },
+        { price: 50, volume: 500 }
+      );
+
+      expect(result.triggered).toBe(true);
+    });
+
+    it("validates conditions on evaluation", () => {
+      expect(() =>
+        service.evaluate(
+          { ruleName: "empty", assetCode: "USDC", conditions: [], logicOperator: "AND" },
+          {}
+        )
+      ).toThrow("At least one condition is required");
+    });
+
+    it("handles between operator", () => {
+      const result = service.evaluate(
+        {
+          ruleName: "range-check",
+          assetCode: "USDC",
+          conditions: [{ field: "price", operator: "between", value: 100, valueHigh: 200 }],
+          logicOperator: "AND",
+        },
+        { price: 150 }
+      );
+      expect(result.triggered).toBe(true);
+    });
+
+    it("handles changes_by_pct operator", () => {
+      const result = service.evaluate(
+        {
+          ruleName: "change-check",
+          assetCode: "USDC",
+          conditions: [{ field: "price", operator: "changes_by_pct", value: 10 }],
+          logicOperator: "AND",
+        },
+        { price: 120 },
+        { price: 100 }
+      );
+      expect(result.triggered).toBe(true);
+    });
+
+    it("returns preview mode in result", () => {
+      const result = service.evaluate(
+        {
+          ruleName: "preview",
+          assetCode: "USDC",
+          conditions: [{ field: "price", operator: "gt", value: 100 }],
+          logicOperator: "AND",
+        },
+        { price: 150 },
+        undefined,
+        true
+      );
+      expect(result.previewMode).toBe(true);
+    });
+
+    it("returns condition details for each condition", () => {
+      const result = service.evaluate(
+        {
+          ruleName: "detail-check",
+          assetCode: "USDC",
+          conditions: [{ field: "price", operator: "gt", value: 100, label: "Price check" }],
+          logicOperator: "AND",
+        },
+        { price: 150 }
+      );
+      expect(result.conditionResults[0].field).toBe("price");
+      expect(result.conditionResults[0].operator).toBe("gt");
+      expect(result.conditionResults[0].expectedValue).toBe(100);
+      expect(result.conditionResults[0].actualValue).toBe(150);
+      expect(result.conditionResults[0].label).toBe("Price check");
+    });
+  });
+
+  describe("evaluateBatch", () => {
+    it("evaluates multiple rules against same metrics", () => {
+      const results = service.evaluateBatch(
+        [
+          { ruleName: "rule-1", assetCode: "USDC", conditions: [{ field: "price", operator: "gt", value: 100 }], logicOperator: "AND" },
+          { ruleName: "rule-2", assetCode: "USDC", conditions: [{ field: "price", operator: "lt", value: 50 }], logicOperator: "AND" },
+        ],
+        { price: 150 }
+      );
+      expect(results).toHaveLength(2);
+      expect(results[0].triggered).toBe(true);
+      expect(results[1].triggered).toBe(false);
+    });
+  });
+
+  describe("getEvaluationHistory", () => {
+    it("returns empty array when no history exists", async () => {
+      const history = await service.getEvaluationHistory();
+      expect(history).toEqual([]);
+    });
+  });
+});

--- a/backend/tests/services/serviceAnnotation.service.test.ts
+++ b/backend/tests/services/serviceAnnotation.service.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ServiceAnnotationService } from "../../src/services/serviceAnnotation.service.js";
+
+vi.mock("../../src/utils/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const returningRow = {
+  id: "ann-1",
+  service_name: "price-service",
+  entity_type: "source",
+  entity_id: null as string | null,
+  content: "Test annotation",
+  author: "ops",
+  start_time: null as Date | null,
+  end_time: null as Date | null,
+  active: true,
+  created_at: new Date(),
+  updated_at: new Date(),
+};
+
+vi.mock("../../src/database/connection.js", () => ({
+  getDatabase: vi.fn(() => {
+    const b: Record<string, unknown> = {};
+    b.where = vi.fn().mockReturnValue(b);
+    b.orderBy = vi.fn().mockReturnValue(b);
+    b.insert = vi.fn().mockReturnValue(b);
+    b.update = vi.fn().mockReturnValue(b);
+    b.delete = vi.fn().mockResolvedValue(1);
+    b.first = vi.fn().mockResolvedValue(null);
+    b.returning = vi.fn().mockResolvedValue([returningRow]);
+    const fn = (_t: string) => b;
+    return fn;
+  }),
+}));
+
+describe("ServiceAnnotationService", () => {
+  let service: ServiceAnnotationService;
+
+  beforeEach(() => {
+    (ServiceAnnotationService as any).instance = undefined;
+    service = ServiceAnnotationService.getInstance();
+    vi.clearAllMocks();
+  });
+
+  it("creates an annotation", async () => {
+    const annotation = await service.create({
+      serviceName: "price-service",
+      entityType: "source",
+      content: "Test annotation",
+      author: "ops",
+    });
+
+    expect(annotation.serviceName).toBe("price-service");
+    expect(annotation.content).toBe("Test annotation");
+    expect(annotation.active).toBe(true);
+    expect(annotation.author).toBe("ops");
+  });
+
+  it("returns null when annotation not found", async () => {
+    const result = await service.get("nonexistent");
+    expect(result).toBeNull();
+  });
+
+  it("deletes an annotation", async () => {
+    const deleted = await service.delete("ann-1", "ops");
+    expect(deleted).toBe(true);
+  });
+
+  it("lists annotations", async () => {
+    vi.spyOn(service, "list").mockResolvedValue([
+      {
+        id: "ann-1",
+        serviceName: "price-service",
+        entityType: "source",
+        entityId: null,
+        content: "Test",
+        author: "ops",
+        startTime: null,
+        endTime: null,
+        active: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
+    const results = await service.list({ serviceName: "price-service" });
+    expect(results).toHaveLength(1);
+    expect(results[0].serviceName).toBe("price-service");
+  });
+
+  it("returns empty audit log for unknown annotation", async () => {
+    const audit = await service.getAuditLog("nonexistent");
+    expect(audit).toEqual([]);
+  });
+});


### PR DESCRIPTION
Implements four backend features:

### #517 - Implement Rule Evaluator Service
Evaluates alert and notification rules against incoming data events with boolean logic (AND/OR), multiple operators (gt, gte, lt, lte, eq, ne, between, changes_by_pct), preview mode, and audit logging.

### #518 - Build Service Annotation Store
CRUD for operational annotations on services and sources with time bounds, owner tracking, and audit trail.

### #519 - Implement Asset Merge Service
Detects duplicate asset records using configurable matching criteria, supports merge with conflict resolution, and provides review workflow for manual approval.

### #520 - Create Alert Windowing Service
Groups alerts into time windows for summarization and downstream processing, with severity breakdown, auto-closing of expired windows, and aggregated metrics.

Closes #517
Closes #518
Closes #519
Closes #520