### PR TITLE
feat: add duplicate alert check service

### DIFF
--- a/backend/src/api/routes/duplicateAlertCheck.routes.ts
+++ b/backend/src/api/routes/duplicateAlertCheck.routes.ts
@@ -1,0 +1,230 @@
+import type { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
+import { duplicateAlertCheckService } from "../../services/duplicateAlertCheck.service.js";
+import { authMiddleware } from "../middleware/auth.js";
+
+export async function duplicateAlertCheckRoutes(server: FastifyInstance) {
+  server.addHook("preHandler", authMiddleware());
+
+  // GET /dedup-rules — list all configured dedup rules
+  server.get(
+    "/dedup-rules",
+    {
+      schema: {
+        tags: ["Duplicate Alert Check"],
+        summary: "List all dedup rules",
+        security: [{ ApiKeyAuth: [] }],
+        response: {
+          200: {
+            type: "object",
+            properties: {
+              rules: { type: "array", items: { type: "object", additionalProperties: true } },
+            },
+          },
+        },
+      },
+    },
+    async () => ({ rules: duplicateAlertCheckService.getDedupRules() })
+  );
+
+  // GET /dedup-rules/:id — get single rule
+  server.get<{ Params: { id: string } }>(
+    "/dedup-rules/:id",
+    {
+      schema: {
+        tags: ["Duplicate Alert Check"],
+        summary: "Get a single dedup rule",
+        security: [{ ApiKeyAuth: [] }],
+        params: {
+          type: "object",
+          required: ["id"],
+          properties: { id: { type: "string" } },
+        },
+        response: {
+          200: { type: "object", additionalProperties: true },
+          404: { $ref: "Error#" },
+        },
+      },
+    },
+    async (request, reply) => {
+      const rule = duplicateAlertCheckService.getDedupRule(request.params.id);
+      if (!rule) return reply.status(404).send({ error: "Rule not found" });
+      return rule;
+    }
+  );
+
+  // POST /dedup-rules — add a new dedup rule
+  server.post(
+    "/dedup-rules",
+    {
+      schema: {
+        tags: ["Duplicate Alert Check"],
+        summary: "Add a dedup rule",
+        security: [{ ApiKeyAuth: [] }],
+        body: {
+          type: "object",
+          required: ["name", "windowMs", "matchFields", "severityBehavior"],
+          properties: {
+            name: { type: "string" },
+            alertType: { type: "string", default: "*" },
+            assetCode: { type: "string", default: "*" },
+            windowMs: { type: "integer", minimum: 1000 },
+            matchFields: {
+              type: "array",
+              items: { type: "string", enum: ["assetCode", "alertType", "metric", "source"] },
+            },
+            severityBehavior: { type: "string", enum: ["block", "escalate", "review"] },
+            isActive: { type: "boolean", default: true },
+          },
+        },
+        response: {
+          201: { type: "object", additionalProperties: true },
+          400: { $ref: "Error#" },
+        },
+      },
+    },
+    async (request: FastifyRequest<{ Body: any }>, reply: FastifyReply) => {
+      const { name, alertType, assetCode, windowMs, matchFields, severityBehavior, isActive } =
+        request.body;
+      const rule = duplicateAlertCheckService.addDedupRule({
+        name,
+        alertType: alertType ?? "*",
+        assetCode: assetCode ?? "*",
+        windowMs,
+        matchFields,
+        severityBehavior,
+        isActive: isActive ?? true,
+      });
+      return reply.status(201).send(rule);
+    }
+  );
+
+  // PATCH /dedup-rules/:id — update a dedup rule
+  server.patch<{ Params: { id: string }; Body: any }>(
+    "/dedup-rules/:id",
+    {
+      schema: {
+        tags: ["Duplicate Alert Check"],
+        summary: "Update a dedup rule",
+        security: [{ ApiKeyAuth: [] }],
+        params: {
+          type: "object",
+          required: ["id"],
+          properties: { id: { type: "string" } },
+        },
+        body: { type: "object", additionalProperties: true },
+        response: {
+          200: { type: "object", additionalProperties: true },
+          404: { $ref: "Error#" },
+        },
+      },
+    },
+    async (request, reply) => {
+      const updated = duplicateAlertCheckService.updateDedupRule(
+        request.params.id,
+        request.body
+      );
+      if (!updated) return reply.status(404).send({ error: "Rule not found" });
+      return updated;
+    }
+  );
+
+  // DELETE /dedup-rules/:id — delete a dedup rule
+  server.delete<{ Params: { id: string } }>(
+    "/dedup-rules/:id",
+    {
+      schema: {
+        tags: ["Duplicate Alert Check"],
+        summary: "Delete a dedup rule",
+        security: [{ ApiKeyAuth: [] }],
+        params: {
+          type: "object",
+          required: ["id"],
+          properties: { id: { type: "string" } },
+        },
+        response: {
+          204: { type: "null" },
+          404: { $ref: "Error#" },
+        },
+      },
+    },
+    async (request, reply) => {
+      const ok = duplicateAlertCheckService.deleteDedupRule(request.params.id);
+      if (!ok) return reply.status(404).send({ error: "Rule not found" });
+      return reply.status(204).send();
+    }
+  );
+
+  // GET /review-queue — list review queue entries
+  server.get<{ Querystring: { status?: string } }>(
+    "/review-queue",
+    {
+      schema: {
+        tags: ["Duplicate Alert Check"],
+        summary: "List near-duplicate alerts pending review",
+        security: [{ ApiKeyAuth: [] }],
+        querystring: {
+          type: "object",
+          properties: {
+            status: { type: "string", enum: ["pending", "approved", "rejected"] },
+          },
+        },
+        response: {
+          200: {
+            type: "object",
+            properties: {
+              entries: { type: "array", items: { type: "object", additionalProperties: true } },
+            },
+          },
+        },
+      },
+    },
+    async (request) => {
+      const { status } = request.query;
+      const entries = duplicateAlertCheckService.getReviewQueue(
+        status as "pending" | "approved" | "rejected" | undefined
+      );
+      return { entries };
+    }
+  );
+
+  // POST /review-queue/:id/resolve — approve or reject a review entry
+  server.post<{ Params: { id: string }; Body: { action: "approved" | "rejected"; reviewedBy: string } }>(
+    "/review-queue/:id/resolve",
+    {
+      schema: {
+        tags: ["Duplicate Alert Check"],
+        summary: "Approve or reject a review queue entry",
+        security: [{ ApiKeyAuth: [] }],
+        params: {
+          type: "object",
+          required: ["id"],
+          properties: { id: { type: "string" } },
+        },
+        body: {
+          type: "object",
+          required: ["action", "reviewedBy"],
+          properties: {
+            action: { type: "string", enum: ["approved", "rejected"] },
+            reviewedBy: { type: "string" },
+          },
+        },
+        response: {
+          200: { type: "object", additionalProperties: true },
+          404: { $ref: "Error#" },
+          409: { $ref: "Error#" },
+        },
+      },
+    },
+    async (request, reply) => {
+      const entry = duplicateAlertCheckService.reviewEntry(
+        request.params.id,
+        request.body.action,
+        request.body.reviewedBy
+      );
+      if (!entry) {
+        return reply.status(404).send({ error: "Entry not found or already resolved" });
+      }
+      return entry;
+    }
+  );
+}

--- a/backend/src/api/routes/index.ts
+++ b/backend/src/api/routes/index.ts
@@ -58,6 +58,7 @@ import { serviceAnnotationRoutes } from "./serviceAnnotation.routes.js";
 import { assetMergeRoutes } from "./assetMerge.routes.js";
 import { alertWindowingRoutes } from "./alertWindowing.routes.js";
 import { queryPresetsRoutes } from "./queryPresets.js";
+import { duplicateAlertCheckRoutes } from "./duplicateAlertCheck.routes.js";
 
 export async function registerRoutes(server: FastifyInstance) {
   server.register(assetsRoutes, { prefix: "/api/v1/assets" });
@@ -146,4 +147,5 @@ export async function registerRoutes(server: FastifyInstance) {
   server.register(assetMergeRoutes, { prefix: "/api/v1/asset-merge" });
   server.register(alertWindowingRoutes, { prefix: "/api/v1/alert-windowing" });
   server.register(queryPresetsRoutes, { prefix: "/api/v1/query-presets" });
+  server.register(duplicateAlertCheckRoutes, { prefix: "/api/v1/duplicate-alert-check" });
 }

--- a/backend/src/services/__tests__/duplicateAlertCheck.service.unit.ts
+++ b/backend/src/services/__tests__/duplicateAlertCheck.service.unit.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { DuplicateAlertCheckService } from "../duplicateAlertCheck.service";
+import type { AlertEvent } from "../alert.service";
+
+function makeEvent(overrides: Partial<AlertEvent> = {}): Omit<AlertEvent, "eventId"> {
+  return {
+    ruleId: "rule-1",
+    assetCode: "USDC",
+    alertType: "price_deviation",
+    priority: "medium",
+    triggeredValue: 0.98,
+    threshold: 0.99,
+    metric: "price",
+    webhookDelivered: false,
+    onChainEventId: null,
+    lifecycleState: "open",
+    acknowledgedAt: null,
+    acknowledgedBy: null,
+    assignedAt: null,
+    assignedTo: null,
+    closedAt: null,
+    closedBy: null,
+    closureNote: null,
+    updatedAt: new Date(),
+    time: new Date(),
+    ...overrides,
+  };
+}
+
+describe("DuplicateAlertCheckService", () => {
+  let svc: DuplicateAlertCheckService;
+
+  beforeEach(() => {
+    // Reset singleton for test isolation
+    (DuplicateAlertCheckService as any).instance = undefined;
+    svc = DuplicateAlertCheckService.getInstance();
+  });
+
+  describe("check — no prior events", () => {
+    it("allows a fresh alert with no recorded events", () => {
+      const result = svc.check(makeEvent());
+      expect(result.isDuplicate).toBe(false);
+      expect(result.action).toBe("allow");
+    });
+  });
+
+  describe("check — block behavior", () => {
+    it("blocks an identical alert within the dedup window", () => {
+      const event = makeEvent();
+      svc.record({ ...event, eventId: "evt-001" });
+
+      const result = svc.check(event);
+      expect(result.isDuplicate).toBe(true);
+      expect(result.action).toBe("block");
+      expect(result.matchedEventId).toBe("evt-001");
+    });
+
+    it("allows an identical alert outside the dedup window", () => {
+      // Record an event 15 minutes in the past (beyond default 10-min block window)
+      const pastTime = new Date(Date.now() - 15 * 60 * 1000);
+      svc.record({ ...makeEvent(), eventId: "evt-old", time: pastTime });
+
+      const result = svc.check(makeEvent());
+      expect(result.action).toBe("allow");
+    });
+  });
+
+  describe("check — source matching", () => {
+    it("treats different assetCodes as distinct alerts", () => {
+      svc.record({ ...makeEvent({ assetCode: "USDC" }), eventId: "evt-usdc" });
+
+      const result = svc.check(makeEvent({ assetCode: "USDT" }));
+      expect(result.action).toBe("allow");
+    });
+
+    it("treats different alertTypes as distinct alerts (block rule)", () => {
+      svc.record({ ...makeEvent({ alertType: "bridge_downtime" }), eventId: "evt-down" });
+
+      const result = svc.check(makeEvent({ alertType: "price_deviation" }));
+      // block rule matches on [assetCode, alertType, metric] — different alertType so no match
+      expect(result.action).toBe("allow");
+    });
+  });
+
+  describe("check — severity handling (escalate)", () => {
+    it("escalates priority when the same asset+type re-fires within the escalation window", () => {
+      // Remove non-escalate rules so only the escalate rule fires
+      const rules = svc.getDedupRules();
+      for (const r of rules) {
+        if (r.id !== "default-critical-escalate") svc.deleteDedupRule(r.id);
+      }
+
+      svc.record({ ...makeEvent({ priority: "low" }), eventId: "evt-low" });
+
+      const result = svc.check(makeEvent({ priority: "high" }));
+      expect(result.isDuplicate).toBe(true);
+      expect(result.action).toBe("escalate");
+      expect(result.escalatedPriority).toBe("high");
+    });
+
+    it("keeps existing priority when incoming is lower", () => {
+      const rules = svc.getDedupRules();
+      for (const r of rules) {
+        if (r.id !== "default-critical-escalate") svc.deleteDedupRule(r.id);
+      }
+
+      svc.record({ ...makeEvent({ priority: "critical" }), eventId: "evt-critical" });
+
+      const result = svc.check(makeEvent({ priority: "low" }));
+      expect(result.escalatedPriority).toBe("critical");
+    });
+  });
+
+  describe("check — review queue", () => {
+    it("enqueues a near-duplicate for review", () => {
+      // Keep only the review rule
+      const rules = svc.getDedupRules();
+      for (const r of rules) {
+        if (r.id !== "default-cross-source") svc.deleteDedupRule(r.id);
+      }
+
+      svc.record({ ...makeEvent(), eventId: "evt-original" });
+
+      const result = svc.check(makeEvent({ alertType: "supply_mismatch" }));
+      // cross-source rule matches on [assetCode, metric] only — same assetCode + metric
+      expect(result.isDuplicate).toBe(true);
+      expect(result.action).toBe("review");
+
+      const queue = svc.getReviewQueue("pending");
+      expect(queue.length).toBe(1);
+      expect(queue[0].matchedEventId).toBe("evt-original");
+    });
+  });
+
+  describe("dedup rule management", () => {
+    it("adds and retrieves a custom rule", () => {
+      const rule = svc.addDedupRule({
+        name: "custom rule",
+        alertType: "bridge_downtime",
+        assetCode: "*",
+        windowMs: 60_000,
+        matchFields: ["assetCode", "alertType"],
+        severityBehavior: "block",
+        isActive: true,
+      });
+      expect(svc.getDedupRule(rule.id)).toMatchObject({ name: "custom rule" });
+    });
+
+    it("updates a rule", () => {
+      const rule = svc.addDedupRule({
+        name: "to-update",
+        alertType: "*",
+        assetCode: "*",
+        windowMs: 1000,
+        matchFields: ["assetCode"],
+        severityBehavior: "block",
+        isActive: true,
+      });
+      const updated = svc.updateDedupRule(rule.id, { isActive: false });
+      expect(updated?.isActive).toBe(false);
+    });
+
+    it("deletes a rule", () => {
+      const rule = svc.addDedupRule({
+        name: "to-delete",
+        alertType: "*",
+        assetCode: "*",
+        windowMs: 1000,
+        matchFields: ["assetCode"],
+        severityBehavior: "block",
+        isActive: true,
+      });
+      expect(svc.deleteDedupRule(rule.id)).toBe(true);
+      expect(svc.getDedupRule(rule.id)).toBeUndefined();
+    });
+
+    it("returns null when updating a non-existent rule", () => {
+      expect(svc.updateDedupRule("non-existent", { isActive: false })).toBeNull();
+    });
+
+    it("returns false when deleting a non-existent rule", () => {
+      expect(svc.deleteDedupRule("non-existent")).toBe(false);
+    });
+  });
+
+  describe("review queue management", () => {
+    it("resolves a pending entry as approved", () => {
+      const rules = svc.getDedupRules();
+      for (const r of rules) {
+        if (r.id !== "default-cross-source") svc.deleteDedupRule(r.id);
+      }
+
+      svc.record({ ...makeEvent(), eventId: "evt-base" });
+      svc.check(makeEvent({ alertType: "supply_mismatch" }));
+
+      const queue = svc.getReviewQueue("pending");
+      const entry = svc.reviewEntry(queue[0].id, "approved", "admin@example.com");
+
+      expect(entry?.status).toBe("approved");
+      expect(entry?.reviewedBy).toBe("admin@example.com");
+      expect(svc.getReviewQueue("pending").length).toBe(0);
+    });
+
+    it("returns null when resolving a non-existent entry", () => {
+      expect(svc.reviewEntry("no-such-id", "approved", "admin")).toBeNull();
+    });
+  });
+});

--- a/backend/src/services/alert.service.ts
+++ b/backend/src/services/alert.service.ts
@@ -7,6 +7,7 @@ import {
   alertSuppressionService,
   type AlertSuppressionService,
 } from "./alertSuppression.service.js";
+import { duplicateAlertCheckService } from "./duplicateAlertCheck.service.js";
 
 export type AlertType =
   | "price_deviation"
@@ -322,7 +323,7 @@ export class AlertService {
           continue;
         }
 
-        const event: AlertEvent = {
+        const candidateEvent = {
           eventId: "",
           ruleId: rule.id,
           assetCode: snapshot.assetCode,
@@ -333,7 +334,7 @@ export class AlertService {
           metric,
           webhookDelivered: false,
           onChainEventId: null,
-          lifecycleState: "open",
+          lifecycleState: "open" as const,
           acknowledgedAt: null,
           acknowledgedBy: null,
           assignedAt: null,
@@ -345,7 +346,29 @@ export class AlertService {
           time: now,
         };
 
+        const dedupResult = duplicateAlertCheckService.check(candidateEvent);
+        if (dedupResult.action === "block") {
+          logger.info(
+            { ruleId: rule.id, matchedEventId: dedupResult.matchedEventId, reason: dedupResult.reason },
+            "Alert blocked as duplicate"
+          );
+          continue;
+        }
+        if (dedupResult.action === "review") {
+          logger.info(
+            { ruleId: rule.id, matchedEventId: dedupResult.matchedEventId, reason: dedupResult.reason },
+            "Alert queued for duplicate review"
+          );
+          continue;
+        }
+
+        const event: AlertEvent = {
+          ...candidateEvent,
+          priority: dedupResult.escalatedPriority ?? candidateEvent.priority,
+        };
+
         await this.persistEvent(event);
+        duplicateAlertCheckService.record(event);
         await this.markRuleTriggered(rule.id, now);
         triggered.push(event);
 

--- a/backend/src/services/duplicateAlertCheck.service.ts
+++ b/backend/src/services/duplicateAlertCheck.service.ts
@@ -1,0 +1,321 @@
+import crypto from "crypto";
+import { logger } from "../utils/logger.js";
+import type { AlertEvent, AlertPriority, AlertType } from "./alert.service.js";
+
+export interface DedupRule {
+  id: string;
+  name: string;
+  alertType: AlertType | "*";
+  assetCode: string | "*";
+  windowMs: number;
+  matchFields: Array<"assetCode" | "alertType" | "metric" | "source">;
+  /** block = drop silently; escalate = allow but upgrade severity; review = queue for manual review */
+  severityBehavior: "block" | "escalate" | "review";
+  isActive: boolean;
+  createdAt: Date;
+}
+
+export interface DuplicateCheckResult {
+  isDuplicate: boolean;
+  action: "allow" | "block" | "escalate" | "review";
+  matchedEventId?: string;
+  matchedRule?: DedupRule;
+  escalatedPriority?: AlertPriority;
+  reason?: string;
+}
+
+export interface ReviewQueueEntry {
+  id: string;
+  incomingEvent: Omit<AlertEvent, "eventId">;
+  matchedEventId: string;
+  matchScore: number;
+  reason: string;
+  status: "pending" | "approved" | "rejected";
+  createdAt: Date;
+  reviewedAt?: Date;
+  reviewedBy?: string;
+}
+
+const SEVERITY_ORDER: AlertPriority[] = ["low", "medium", "high", "critical"];
+
+const DEFAULT_DEDUP_RULES: DedupRule[] = [
+  {
+    id: "default-exact",
+    name: "Exact duplicate (same asset + type within 10 min)",
+    alertType: "*",
+    assetCode: "*",
+    windowMs: 10 * 60 * 1000,
+    matchFields: ["assetCode", "alertType", "metric"],
+    severityBehavior: "block",
+    isActive: true,
+    createdAt: new Date(),
+  },
+  {
+    id: "default-cross-source",
+    name: "Cross-source duplicate (same asset + metric within 5 min)",
+    alertType: "*",
+    assetCode: "*",
+    windowMs: 5 * 60 * 1000,
+    matchFields: ["assetCode", "metric"],
+    severityBehavior: "review",
+    isActive: true,
+    createdAt: new Date(),
+  },
+  {
+    id: "default-critical-escalate",
+    name: "Critical severity re-trigger escalation within 30 min",
+    alertType: "*",
+    assetCode: "*",
+    windowMs: 30 * 60 * 1000,
+    matchFields: ["assetCode", "alertType"],
+    severityBehavior: "escalate",
+    isActive: true,
+    createdAt: new Date(),
+  },
+];
+
+export class DuplicateAlertCheckService {
+  private static instance: DuplicateAlertCheckService;
+
+  private rules: Map<string, DedupRule> = new Map(
+    DEFAULT_DEDUP_RULES.map((r) => [r.id, r])
+  );
+
+  // In-memory ring buffer keyed by fingerprint -> { eventId, time, priority }
+  private recentEvents: Map<string, { eventId: string; time: Date; priority: AlertPriority }> =
+    new Map();
+
+  private reviewQueue: ReviewQueueEntry[] = [];
+
+  private constructor() {}
+
+  public static getInstance(): DuplicateAlertCheckService {
+    if (!DuplicateAlertCheckService.instance) {
+      DuplicateAlertCheckService.instance = new DuplicateAlertCheckService();
+    }
+    return DuplicateAlertCheckService.instance;
+  }
+
+  /**
+   * Check an incoming alert event for duplicates before it is persisted or dispatched.
+   * Returns the action to take and any escalation details.
+   */
+  public check(event: Omit<AlertEvent, "eventId">): DuplicateCheckResult {
+    this.evict();
+
+    const activeRules = [...this.rules.values()]
+      .filter((r) => r.isActive)
+      .filter(
+        (r) =>
+          (r.alertType === "*" || r.alertType === event.alertType) &&
+          (r.assetCode === "*" || r.assetCode === event.assetCode)
+      );
+
+    for (const rule of activeRules) {
+      const fp = this.fingerprint(event, rule.matchFields);
+      const recent = this.recentEvents.get(fp);
+      if (!recent) continue;
+
+      const age = Date.now() - recent.time.getTime();
+      if (age > rule.windowMs) continue;
+
+      // Found a duplicate within the window.
+      if (rule.severityBehavior === "block") {
+        logger.debug(
+          { matchedEventId: recent.eventId, ruleId: rule.id, age },
+          "Duplicate alert blocked"
+        );
+        return {
+          isDuplicate: true,
+          action: "block",
+          matchedEventId: recent.eventId,
+          matchedRule: rule,
+          reason: `Matched rule "${rule.name}" (age ${Math.round(age / 1000)}s)`,
+        };
+      }
+
+      if (rule.severityBehavior === "escalate") {
+        const escalated = this.escalate(recent.priority, event.priority);
+        logger.debug(
+          { matchedEventId: recent.eventId, ruleId: rule.id, escalated },
+          "Duplicate alert escalated"
+        );
+        return {
+          isDuplicate: true,
+          action: "escalate",
+          matchedEventId: recent.eventId,
+          matchedRule: rule,
+          escalatedPriority: escalated,
+          reason: `Severity escalated by rule "${rule.name}"`,
+        };
+      }
+
+      if (rule.severityBehavior === "review") {
+        const score = this.matchScore(event, recent.priority);
+        this.enqueueReview(event, recent.eventId, score, rule.name);
+        logger.debug(
+          { matchedEventId: recent.eventId, ruleId: rule.id, score },
+          "Duplicate alert queued for review"
+        );
+        return {
+          isDuplicate: true,
+          action: "review",
+          matchedEventId: recent.eventId,
+          matchedRule: rule,
+          reason: `Queued for review by rule "${rule.name}" (score ${score.toFixed(2)})`,
+        };
+      }
+    }
+
+    return { isDuplicate: false, action: "allow" };
+  }
+
+  /**
+   * Record a newly persisted event so future alerts can be matched against it.
+   */
+  public record(event: AlertEvent): void {
+    // Record under every active rule's fingerprint.
+    for (const rule of this.rules.values()) {
+      if (!rule.isActive) continue;
+      if (rule.alertType !== "*" && rule.alertType !== event.alertType) continue;
+      if (rule.assetCode !== "*" && rule.assetCode !== event.assetCode) continue;
+      const fp = this.fingerprint(event, rule.matchFields);
+      this.recentEvents.set(fp, { eventId: event.eventId, time: event.time, priority: event.priority });
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Dedup rule management
+  // ---------------------------------------------------------------------------
+
+  public getDedupRules(): DedupRule[] {
+    return [...this.rules.values()];
+  }
+
+  public getDedupRule(id: string): DedupRule | undefined {
+    return this.rules.get(id);
+  }
+
+  public addDedupRule(
+    rule: Omit<DedupRule, "id" | "createdAt">
+  ): DedupRule {
+    const newRule: DedupRule = {
+      ...rule,
+      id: crypto.randomUUID(),
+      createdAt: new Date(),
+    };
+    this.rules.set(newRule.id, newRule);
+    logger.info({ ruleId: newRule.id, name: newRule.name }, "Dedup rule added");
+    return newRule;
+  }
+
+  public updateDedupRule(
+    id: string,
+    updates: Partial<Omit<DedupRule, "id" | "createdAt">>
+  ): DedupRule | null {
+    const existing = this.rules.get(id);
+    if (!existing) return null;
+    const updated = { ...existing, ...updates };
+    this.rules.set(id, updated);
+    logger.info({ ruleId: id }, "Dedup rule updated");
+    return updated;
+  }
+
+  public deleteDedupRule(id: string): boolean {
+    const deleted = this.rules.delete(id);
+    if (deleted) logger.info({ ruleId: id }, "Dedup rule deleted");
+    return deleted;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Review queue management
+  // ---------------------------------------------------------------------------
+
+  public getReviewQueue(status?: ReviewQueueEntry["status"]): ReviewQueueEntry[] {
+    return status ? this.reviewQueue.filter((e) => e.status === status) : [...this.reviewQueue];
+  }
+
+  public reviewEntry(
+    entryId: string,
+    action: "approved" | "rejected",
+    reviewedBy: string
+  ): ReviewQueueEntry | null {
+    const entry = this.reviewQueue.find((e) => e.id === entryId);
+    if (!entry || entry.status !== "pending") return null;
+    entry.status = action;
+    entry.reviewedAt = new Date();
+    entry.reviewedBy = reviewedBy;
+    logger.info({ entryId, action, reviewedBy }, "Review queue entry resolved");
+    return entry;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private fingerprint(
+    event: Omit<AlertEvent, "eventId">,
+    fields: DedupRule["matchFields"]
+  ): string {
+    const parts: string[] = [];
+    for (const f of fields) {
+      if (f === "assetCode") parts.push(event.assetCode);
+      else if (f === "alertType") parts.push(event.alertType);
+      else if (f === "metric") parts.push(event.metric);
+      else if (f === "source") parts.push(event.alertType); // source maps to alertType here
+    }
+    return crypto.createHash("sha1").update(parts.join("|")).digest("hex");
+  }
+
+  private escalate(current: AlertPriority, incoming: AlertPriority): AlertPriority {
+    const ci = SEVERITY_ORDER.indexOf(current);
+    const ii = SEVERITY_ORDER.indexOf(incoming);
+    return ii > ci ? incoming : current;
+  }
+
+  private matchScore(
+    event: Omit<AlertEvent, "eventId">,
+    existingPriority: AlertPriority
+  ): number {
+    let score = 0.5;
+    const si = SEVERITY_ORDER.indexOf(event.priority);
+    const ei = SEVERITY_ORDER.indexOf(existingPriority);
+    if (si === ei) score += 0.3;
+    else if (Math.abs(si - ei) === 1) score += 0.1;
+    return Math.min(score, 1.0);
+  }
+
+  /** Remove records older than the longest active window to prevent unbounded growth. */
+  private evict(): void {
+    const maxWindow = Math.max(
+      ...([...this.rules.values()]
+        .filter((r) => r.isActive)
+        .map((r) => r.windowMs)),
+      0
+    );
+    if (maxWindow === 0) return;
+    const cutoff = Date.now() - maxWindow;
+    for (const [fp, rec] of this.recentEvents) {
+      if (rec.time.getTime() < cutoff) this.recentEvents.delete(fp);
+    }
+  }
+
+  private enqueueReview(
+    event: Omit<AlertEvent, "eventId">,
+    matchedEventId: string,
+    matchScore: number,
+    reason: string
+  ): void {
+    this.reviewQueue.push({
+      id: crypto.randomUUID(),
+      incomingEvent: event,
+      matchedEventId,
+      matchScore,
+      reason,
+      status: "pending",
+      createdAt: new Date(),
+    });
+  }
+}
+
+export const duplicateAlertCheckService = DuplicateAlertCheckService.getInstance();


### PR DESCRIPTION
## Summary

Closes #511

- Adds `DuplicateAlertCheckService` — a pre-save/pre-dispatch gate that fingerprints incoming alert events and matches them against recently-seen alerts within configurable time windows
- Three configurable severity behaviors per rule: **block** (drop silently), **escalate** (allow but upgrade priority), **review** (queue for manual resolution)
- Ships 3 sensible default dedup rules (exact-match block at 10 min, cross-source review at 5 min, critical escalation at 30 min) with full CRUD to add/update/delete custom rules
- `alert.service.ts` calls `duplicateAlertCheckService.check()` before `persistEvent` and `record()` after, so every persisted alert is tracked for future dedup
- REST API under `/api/v1/duplicate-alert-check`: rule management (`/dedup-rules`) and review queue (`/review-queue` + `/review-queue/:id/resolve`)
- Unit tests covering: block within window, allow outside window, source matching, severity escalation, review queue enqueue/resolve

## Test plan

- [ ] `npm run test:unit` passes for `duplicateAlertCheck.service.unit.ts`
- [ ] POST an alert that matches an existing event within 10 min → confirm it is blocked (not persisted)
- [ ] POST a higher-priority re-trigger within 30 min → confirm priority escalated on the stored event
- [ ] GET `/api/v1/duplicate-alert-check/dedup-rules` returns the 3 default rules
- [ ] POST `/api/v1/duplicate-alert-check/dedup-rules` with a custom rule → rule appears in list and influences future checks
- [ ] GET `/api/v1/duplicate-alert-check/review-queue?status=pending` lists queued near-duplicates
- [ ] POST `/api/v1/duplicate-alert-check/review-queue/:id/resolve` with `{ action: "approved", reviewedBy: "..." }` resolves the entry
