### PR TITLE
feat: implement alert simulation sandbox

### DIFF
--- a/backend/src/api/routes/alertRoutingAdmin.ts
+++ b/backend/src/api/routes/alertRoutingAdmin.ts
@@ -1,12 +1,20 @@
 import type { FastifyInstance } from "fastify";
 import { authMiddleware } from "../middleware/auth.js";
 import { alertRoutingService } from "../../services/alertRouting.service.js";
+import type { RoutingSeverity } from "../../services/alertRouting.service.js";
 import {
   createAlertRoutingRuleSchema,
   listAlertRoutingAuditQuerySchema,
   listAlertRoutingRulesQuerySchema,
   updateAlertRoutingRuleSchema,
 } from "../validations/alertRouting.schema.js";
+
+const VALID_SEVERITIES = new Set<string>(["critical", "high", "medium", "low"]);
+
+function parseSeverity(value: string): RoutingSeverity {
+  if (VALID_SEVERITIES.has(value)) return value as RoutingSeverity;
+  return "medium";
+}
 
 export async function alertRoutingAdminRoutes(server: FastifyInstance) {
   const requireAdmin = authMiddleware({ requiredScopes: ["admin:api-keys"] });
@@ -203,6 +211,175 @@ export async function alertRoutingAdminRoutes(server: FastifyInstance) {
 
       const entries = await alertRoutingService.getAuditHistory(parsed.data);
       return { entries };
+    }
+  );
+
+  server.post(
+    "/simulate",
+    {
+      preHandler: requireAdmin,
+      schema: {
+        tags: ["Config"],
+        summary: "Dry-run alert routing simulation (no dispatches)",
+        description:
+          "Evaluates which active routing rules would match a simulated alert and which channels would fire, without dispatching anything to real endpoints.",
+        security: [{ ApiKeyAuth: [] }],
+        body: {
+          type: "object",
+          required: ["severity"],
+          additionalProperties: false,
+          properties: {
+            severity: {
+              type: "string",
+              enum: ["critical", "high", "medium", "low"],
+            },
+            assetCode: { type: "string", maxLength: 20 },
+            sourceType: { type: "string", maxLength: 80 },
+            ownerAddress: { type: "string" },
+            label: { type: "string", maxLength: 120 },
+            triggeredValue: { type: "number" },
+            threshold: { type: "number" },
+            metric: { type: "string", maxLength: 80 },
+          },
+        },
+      },
+    },
+    async (request, reply) => {
+      const body = request.body as {
+        severity: string;
+        assetCode?: string;
+        sourceType?: string;
+        ownerAddress?: string;
+        label?: string;
+        triggeredValue?: number;
+        threshold?: number;
+        metric?: string;
+      };
+
+      if (!VALID_SEVERITIES.has(body.severity)) {
+        return reply.code(400).send({ error: "Invalid severity value" });
+      }
+
+      const severity = parseSeverity(body.severity);
+      const assetCode = (body.assetCode ?? "").trim().toUpperCase();
+      const sourceType = (body.sourceType ?? "").trim();
+
+      // Load rules — scope by ownerAddress if provided
+      const allRules = await alertRoutingService.listRules(body.ownerAddress);
+      const activeRules = allRules.filter((rule) => rule.isActive);
+      const inactiveRules = allRules.filter((rule) => !rule.isActive);
+
+      // Evaluate each active rule in priority order
+      const ruleResults = activeRules
+        .slice()
+        .sort((a, b) => a.priorityOrder - b.priorityOrder)
+        .map((rule) => {
+          const severityMatch =
+            rule.severityLevels.length === 0 ||
+            rule.severityLevels.includes(severity);
+
+          const assetMatch =
+            rule.assetCodes.length === 0 ||
+            (assetCode !== "" &&
+              rule.assetCodes
+                .map((c) => c.toUpperCase())
+                .includes(assetCode));
+
+          const sourceMatch =
+            rule.sourceTypes.length === 0 ||
+            (sourceType !== "" && rule.sourceTypes.includes(sourceType));
+
+          const matched = severityMatch && assetMatch && sourceMatch;
+
+          const reasons: string[] = [];
+
+          if (rule.severityLevels.length === 0) {
+            reasons.push("Severity: matches any (no filter set)");
+          } else if (severityMatch) {
+            reasons.push(
+              `Severity: "${severity}" is in [${rule.severityLevels.join(", ")}]`
+            );
+          } else {
+            reasons.push(
+              `Severity: "${severity}" not in [${rule.severityLevels.join(", ")}] — no match`
+            );
+          }
+
+          if (rule.assetCodes.length === 0) {
+            reasons.push("Asset: matches any (no filter set)");
+          } else if (assetMatch) {
+            reasons.push(
+              `Asset: "${assetCode}" is in [${rule.assetCodes.join(", ")}]`
+            );
+          } else {
+            reasons.push(
+              `Asset: "${assetCode || "(empty)"}" not in [${rule.assetCodes.join(", ")}] — no match`
+            );
+          }
+
+          if (rule.sourceTypes.length === 0) {
+            reasons.push("Source type: matches any (no filter set)");
+          } else if (sourceMatch) {
+            reasons.push(
+              `Source type: "${sourceType}" is in [${rule.sourceTypes.join(", ")}]`
+            );
+          } else {
+            reasons.push(
+              `Source type: "${sourceType || "(empty)"}" not in [${rule.sourceTypes.join(", ")}] — no match`
+            );
+          }
+
+          return {
+            ruleId: rule.id,
+            ruleName: rule.name,
+            priorityOrder: rule.priorityOrder,
+            ownerAddress: rule.ownerAddress,
+            matched,
+            reasons,
+            channels: matched ? rule.channels : [],
+            fallbackChannels: matched ? rule.fallbackChannels : [],
+            suppressionWindowSeconds: rule.suppressionWindowSeconds,
+          };
+        });
+
+      const matchedResults = ruleResults.filter((r) => r.matched);
+      const firstMatch = matchedResults[0] ?? null;
+
+      const simulationId = `sim_${Date.now()}_${Math.random()
+        .toString(36)
+        .slice(2, 8)}`;
+
+      return reply.send({
+        simulationId,
+        timestamp: new Date().toISOString(),
+        input: {
+          severity,
+          assetCode,
+          sourceType,
+          ownerAddress: body.ownerAddress ?? null,
+          label: body.label ?? null,
+          triggeredValue: body.triggeredValue ?? null,
+          threshold: body.threshold ?? null,
+          metric: body.metric ?? null,
+        },
+        results: ruleResults,
+        skippedInactive: inactiveRules.map((r) => ({
+          ruleId: r.id,
+          ruleName: r.name,
+          priorityOrder: r.priorityOrder,
+        })),
+        summary: {
+          totalActiveRules: activeRules.length,
+          totalMatched: matchedResults.length,
+          firstMatchingRule: firstMatch
+            ? { ruleId: firstMatch.ruleId, ruleName: firstMatch.ruleName }
+            : null,
+          wouldDispatch: firstMatch !== null,
+          effectiveChannels: firstMatch?.channels ?? [],
+          effectiveFallbackChannels: firstMatch?.fallbackChannels ?? [],
+          suppressionWindowSeconds: firstMatch?.suppressionWindowSeconds ?? 0,
+        },
+      });
     }
   );
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -28,6 +28,7 @@ const RelationshipExplorer = lazy(() => import("./pages/RelationshipExplorer"));
 const SearchResultsPage = lazy(() => import("./pages/SearchResultsPage"));
 const Alerts = lazy(() => import("./pages/Alerts"));
 const DataProvenanceGraph = lazy(() => import("./pages/DataProvenanceGraph"));
+const AlertSimulationSandbox = lazy(() => import("./pages/AlertSimulationSandbox"));
 
 function NotificationInitializer() {
   useNotifications();
@@ -72,6 +73,7 @@ function App() {
               <Route path="/relationship-explorer" element={<RelationshipExplorer />} />
               <Route path="/search" element={<SearchResultsPage />} />
               <Route path="/data-provenance" element={<DataProvenanceGraph />} />
+              <Route path="/alert-sandbox" element={<AlertSimulationSandbox />} />
             </Route>
           </Routes>
         </Suspense>

--- a/frontend/src/components/MobileNav/navigation.ts
+++ b/frontend/src/components/MobileNav/navigation.ts
@@ -37,6 +37,11 @@ export const navGroups: NavGroup[] = [
         label: "Alert Routing",
         description: "Manage alert dispatch routing and audit",
       },
+      {
+        to: "/alert-sandbox",
+        label: "Alert Sandbox",
+        description: "Dry-run alert rules against synthetic data before enabling in production",
+      },
       { to: "/settings", label: "Settings", description: "Notification and dashboard preferences" },
     ],
   },

--- a/frontend/src/hooks/useAlertSimulation.ts
+++ b/frontend/src/hooks/useAlertSimulation.ts
@@ -1,0 +1,146 @@
+import { useState, useCallback } from "react";
+
+export type SimulationSeverity = "critical" | "high" | "medium" | "low";
+
+export interface SimulationInput {
+  severity: SimulationSeverity;
+  assetCode: string;
+  sourceType: string;
+  ownerAddress: string;
+  label: string;
+  triggeredValue: number | null;
+  threshold: number | null;
+  metric: string;
+}
+
+export interface SimulationRuleResult {
+  ruleId: string;
+  ruleName: string;
+  priorityOrder: number;
+  ownerAddress: string | null;
+  matched: boolean;
+  reasons: string[];
+  channels: string[];
+  fallbackChannels: string[];
+  suppressionWindowSeconds: number;
+}
+
+export interface SimulationSummary {
+  totalActiveRules: number;
+  totalMatched: number;
+  firstMatchingRule: { ruleId: string; ruleName: string } | null;
+  wouldDispatch: boolean;
+  effectiveChannels: string[];
+  effectiveFallbackChannels: string[];
+  suppressionWindowSeconds: number;
+}
+
+export interface SimulationResult {
+  simulationId: string;
+  timestamp: string;
+  input: SimulationInput & {
+    ownerAddress: string | null;
+    label: string | null;
+    triggeredValue: number | null;
+    threshold: number | null;
+    metric: string | null;
+  };
+  results: SimulationRuleResult[];
+  skippedInactive: { ruleId: string; ruleName: string; priorityOrder: number }[];
+  summary: SimulationSummary;
+}
+
+const HISTORY_KEY = "bw_sim_history";
+const MAX_HISTORY = 20;
+
+function loadHistory(): SimulationResult[] {
+  try {
+    const raw = localStorage.getItem(HISTORY_KEY);
+    return raw ? (JSON.parse(raw) as SimulationResult[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function persistHistory(items: SimulationResult[]): void {
+  try {
+    localStorage.setItem(HISTORY_KEY, JSON.stringify(items.slice(0, MAX_HISTORY)));
+  } catch {
+    // ignore quota errors
+  }
+}
+
+export function useAlertSimulation(adminToken: string) {
+  const [isRunning, setIsRunning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [currentResult, setCurrentResult] = useState<SimulationResult | null>(null);
+  const [history, setHistory] = useState<SimulationResult[]>(loadHistory);
+
+  const runSimulation = useCallback(
+    async (input: SimulationInput) => {
+      setIsRunning(true);
+      setError(null);
+
+      try {
+        const payload: Record<string, unknown> = { severity: input.severity };
+        if (input.assetCode.trim()) payload.assetCode = input.assetCode.trim();
+        if (input.sourceType.trim()) payload.sourceType = input.sourceType.trim();
+        if (input.ownerAddress.trim()) payload.ownerAddress = input.ownerAddress.trim();
+        if (input.label.trim()) payload.label = input.label.trim();
+        if (input.metric.trim()) payload.metric = input.metric.trim();
+        if (input.triggeredValue !== null) payload.triggeredValue = input.triggeredValue;
+        if (input.threshold !== null) payload.threshold = input.threshold;
+
+        const res = await fetch("/api/v1/admin/alert-routing/simulate", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-API-Key": adminToken,
+          },
+          body: JSON.stringify(payload),
+        });
+
+        if (!res.ok) {
+          const data = (await res.json()) as { error?: unknown };
+          throw new Error(
+            typeof data.error === "string"
+              ? data.error
+              : `HTTP ${res.status}`
+          );
+        }
+
+        const result = (await res.json()) as SimulationResult;
+        setCurrentResult(result);
+        setHistory((prev) => {
+          const next = [result, ...prev].slice(0, MAX_HISTORY);
+          persistHistory(next);
+          return next;
+        });
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Simulation failed");
+      } finally {
+        setIsRunning(false);
+      }
+    },
+    [adminToken]
+  );
+
+  const restoreFromHistory = useCallback((result: SimulationResult) => {
+    setCurrentResult(result);
+  }, []);
+
+  const clearHistory = useCallback(() => {
+    setHistory([]);
+    persistHistory([]);
+  }, []);
+
+  return {
+    isRunning,
+    error,
+    currentResult,
+    history,
+    runSimulation,
+    restoreFromHistory,
+    clearHistory,
+  };
+}

--- a/frontend/src/pages/AlertSimulationSandbox.tsx
+++ b/frontend/src/pages/AlertSimulationSandbox.tsx
@@ -1,0 +1,872 @@
+import { useState } from "react";
+import {
+  useAlertSimulation,
+  type SimulationInput,
+  type SimulationResult,
+  type SimulationSeverity,
+} from "../hooks/useAlertSimulation";
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const SEVERITY_STYLES: Record<SimulationSeverity, { badge: string; dot: string }> = {
+  critical: { badge: "bg-red-900/50 text-red-400 border border-red-700", dot: "bg-red-500" },
+  high: { badge: "bg-orange-900/50 text-orange-400 border border-orange-700", dot: "bg-orange-500" },
+  medium: { badge: "bg-yellow-900/50 text-yellow-400 border border-yellow-700", dot: "bg-yellow-500" },
+  low: { badge: "bg-blue-900/50 text-blue-400 border border-blue-700", dot: "bg-blue-500" },
+};
+
+const CHANNEL_LABELS: Record<string, string> = {
+  in_app: "In-App",
+  webhook: "Webhook",
+  email: "Email",
+};
+
+const PRESETS = [
+  {
+    id: "critical_bridge",
+    label: "Critical Bridge Failure",
+    description: "Complete bridge outage, funds at risk",
+    input: {
+      severity: "critical" as SimulationSeverity,
+      assetCode: "USDC",
+      sourceType: "bridge",
+      metric: "bridge_health",
+      triggeredValue: 0,
+      threshold: 100,
+    },
+  },
+  {
+    id: "token_exploit",
+    label: "Token Exploit",
+    description: "Security vulnerability detected",
+    input: {
+      severity: "critical" as SimulationSeverity,
+      assetCode: "ETH",
+      sourceType: "security",
+      metric: "exploit_severity",
+      triggeredValue: 1,
+      threshold: 0,
+    },
+  },
+  {
+    id: "tvl_anomaly",
+    label: "TVL Anomaly",
+    description: "Significant total value locked drop",
+    input: {
+      severity: "high" as SimulationSeverity,
+      assetCode: "WBTC",
+      sourceType: "analytics",
+      metric: "tvl_usd",
+      triggeredValue: 8500000,
+      threshold: 10000000,
+    },
+  },
+  {
+    id: "reserve_drift",
+    label: "Reserve Backing Drift",
+    description: "Collateral ratio below threshold",
+    input: {
+      severity: "high" as SimulationSeverity,
+      assetCode: "USDT",
+      sourceType: "reconciliation",
+      metric: "backing_ratio",
+      triggeredValue: 0.94,
+      threshold: 0.98,
+    },
+  },
+  {
+    id: "gas_spike",
+    label: "Gas Price Spike",
+    description: "Network fees impacting operations",
+    input: {
+      severity: "medium" as SimulationSeverity,
+      assetCode: "",
+      sourceType: "network",
+      metric: "gas_gwei",
+      triggeredValue: 250,
+      threshold: 100,
+    },
+  },
+  {
+    id: "maintenance",
+    label: "Scheduled Maintenance",
+    description: "Low-priority maintenance window",
+    input: {
+      severity: "low" as SimulationSeverity,
+      assetCode: "",
+      sourceType: "maintenance",
+      metric: "maintenance_flag",
+      triggeredValue: 1,
+      threshold: 0,
+    },
+  },
+] as const;
+
+const ADMIN_TOKEN_KEY = "bw_admin_token";
+
+function loadToken(): string {
+  try {
+    return localStorage.getItem(ADMIN_TOKEN_KEY) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+const DEFAULT_INPUT: SimulationInput = {
+  severity: "high",
+  assetCode: "",
+  sourceType: "",
+  ownerAddress: "",
+  label: "",
+  triggeredValue: null,
+  threshold: null,
+  metric: "",
+};
+
+// ─── Main page ───────────────────────────────────────────────────────────────
+
+export default function AlertSimulationSandbox() {
+  const [adminToken, setAdminToken] = useState(loadToken);
+  const [input, setInput] = useState<SimulationInput>(DEFAULT_INPUT);
+  const [activeTab, setActiveTab] = useState<"results" | "history">("results");
+
+  const { isRunning, error, currentResult, history, runSimulation, restoreFromHistory, clearHistory } =
+    useAlertSimulation(adminToken);
+
+  function applyPreset(preset: (typeof PRESETS)[number]) {
+    setInput({
+      ...DEFAULT_INPUT,
+      severity: preset.input.severity,
+      assetCode: preset.input.assetCode,
+      sourceType: preset.input.sourceType,
+      metric: preset.input.metric,
+      triggeredValue: preset.input.triggeredValue,
+      threshold: preset.input.threshold,
+    });
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    void runSimulation(input);
+  }
+
+  const inputCls =
+    "bg-stellar-card border border-stellar-border rounded px-3 py-2 text-sm text-white placeholder-stellar-text-muted focus:outline-none focus:border-stellar-blue w-full";
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold text-stellar-text-primary">
+            Alert Simulation Sandbox
+          </h1>
+          <p className="mt-2 text-stellar-text-secondary">
+            Dry-run alert rules against synthetic data before enabling in production. No alerts are dispatched.
+          </p>
+        </div>
+        <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-amber-900/30 border border-amber-600/40 text-amber-400 text-xs font-medium">
+          <svg
+            className="w-3.5 h-3.5 flex-shrink-0"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+            />
+          </svg>
+          Simulation only — no real dispatches
+        </span>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-5 gap-6 items-start">
+        {/* ── Left: configuration panel ──────────────────────────── */}
+        <div className="lg:col-span-2 space-y-4">
+          {/* Admin token */}
+          <div className="bg-stellar-card border border-stellar-border rounded-lg p-4">
+            <label
+              htmlFor="sim-admin-token"
+              className="block text-xs font-semibold uppercase tracking-wider text-stellar-text-muted mb-2"
+            >
+              Admin API Token
+            </label>
+            <input
+              id="sim-admin-token"
+              type="password"
+              value={adminToken}
+              onChange={(e) => {
+                setAdminToken(e.target.value);
+                try {
+                  localStorage.setItem(ADMIN_TOKEN_KEY, e.target.value);
+                } catch {
+                  // ignore
+                }
+              }}
+              placeholder="Enter admin API key"
+              className={inputCls}
+              autoComplete="current-password"
+            />
+          </div>
+
+          {/* Scenario presets */}
+          <div className="bg-stellar-card border border-stellar-border rounded-lg p-4">
+            <h3 className="text-sm font-semibold text-white mb-3">Scenario Presets</h3>
+            <div className="grid grid-cols-2 gap-2">
+              {PRESETS.map((preset) => (
+                <button
+                  key={preset.id}
+                  type="button"
+                  onClick={() => applyPreset(preset)}
+                  className="text-left p-2.5 rounded-md border border-stellar-border/70 bg-stellar-dark/30 hover:border-stellar-blue hover:bg-stellar-blue/5 transition-colors"
+                >
+                  <div className="flex items-center gap-1.5 mb-0.5">
+                    <span
+                      className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${SEVERITY_STYLES[preset.input.severity].dot}`}
+                    />
+                    <span className="text-xs font-medium text-white truncate">{preset.label}</span>
+                  </div>
+                  <p className="text-xs text-stellar-text-muted truncate">{preset.description}</p>
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Input form */}
+          <form
+            onSubmit={handleSubmit}
+            className="bg-stellar-card border border-stellar-border rounded-lg p-4 space-y-4"
+          >
+            <h3 className="text-sm font-semibold text-white">Alert Parameters</h3>
+
+            {/* Severity selector */}
+            <fieldset>
+              <legend className="block text-xs font-semibold text-stellar-text-muted uppercase tracking-wider mb-1.5">
+                Severity <span className="text-red-400" aria-hidden="true">*</span>
+              </legend>
+              <div className="grid grid-cols-4 gap-1" role="group" aria-label="Select severity">
+                {(["critical", "high", "medium", "low"] as SimulationSeverity[]).map((sev) => (
+                  <button
+                    key={sev}
+                    type="button"
+                    onClick={() => setInput((p) => ({ ...p, severity: sev }))}
+                    aria-pressed={input.severity === sev}
+                    className={`py-1.5 rounded text-xs font-semibold uppercase transition-colors ${
+                      input.severity === sev
+                        ? SEVERITY_STYLES[sev].badge
+                        : "bg-stellar-dark/30 text-stellar-text-muted border border-stellar-border/50 hover:text-stellar-text-secondary"
+                    }`}
+                  >
+                    {sev}
+                  </button>
+                ))}
+              </div>
+            </fieldset>
+
+            {/* Asset code */}
+            <div>
+              <label
+                htmlFor="sim-asset"
+                className="block text-xs font-semibold text-stellar-text-muted uppercase tracking-wider mb-1.5"
+              >
+                Asset Code
+              </label>
+              <input
+                id="sim-asset"
+                type="text"
+                value={input.assetCode}
+                onChange={(e) =>
+                  setInput((p) => ({ ...p, assetCode: e.target.value.toUpperCase() }))
+                }
+                placeholder="e.g. USDC, ETH, WBTC"
+                className={inputCls}
+              />
+            </div>
+
+            {/* Source type */}
+            <div>
+              <label
+                htmlFor="sim-source"
+                className="block text-xs font-semibold text-stellar-text-muted uppercase tracking-wider mb-1.5"
+              >
+                Source Type
+              </label>
+              <input
+                id="sim-source"
+                type="text"
+                value={input.sourceType}
+                onChange={(e) => setInput((p) => ({ ...p, sourceType: e.target.value }))}
+                placeholder="e.g. bridge, security, analytics"
+                className={inputCls}
+              />
+            </div>
+
+            {/* Triggered value / threshold */}
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label
+                  htmlFor="sim-triggered"
+                  className="block text-xs font-semibold text-stellar-text-muted uppercase tracking-wider mb-1.5"
+                >
+                  Triggered Value
+                </label>
+                <input
+                  id="sim-triggered"
+                  type="number"
+                  value={input.triggeredValue ?? ""}
+                  onChange={(e) =>
+                    setInput((p) => ({
+                      ...p,
+                      triggeredValue: e.target.value === "" ? null : Number(e.target.value),
+                    }))
+                  }
+                  placeholder="0"
+                  className={inputCls}
+                />
+              </div>
+              <div>
+                <label
+                  htmlFor="sim-threshold"
+                  className="block text-xs font-semibold text-stellar-text-muted uppercase tracking-wider mb-1.5"
+                >
+                  Threshold
+                </label>
+                <input
+                  id="sim-threshold"
+                  type="number"
+                  value={input.threshold ?? ""}
+                  onChange={(e) =>
+                    setInput((p) => ({
+                      ...p,
+                      threshold: e.target.value === "" ? null : Number(e.target.value),
+                    }))
+                  }
+                  placeholder="0"
+                  className={inputCls}
+                />
+              </div>
+            </div>
+
+            {/* Metric */}
+            <div>
+              <label
+                htmlFor="sim-metric"
+                className="block text-xs font-semibold text-stellar-text-muted uppercase tracking-wider mb-1.5"
+              >
+                Metric
+              </label>
+              <input
+                id="sim-metric"
+                type="text"
+                value={input.metric}
+                onChange={(e) => setInput((p) => ({ ...p, metric: e.target.value }))}
+                placeholder="e.g. bridge_health, backing_ratio"
+                className={inputCls}
+              />
+            </div>
+
+            {/* Owner address */}
+            <div>
+              <label
+                htmlFor="sim-owner"
+                className="block text-xs font-semibold text-stellar-text-muted uppercase tracking-wider mb-1.5"
+              >
+                Owner Address <span className="text-stellar-text-muted/60 normal-case font-normal">(optional)</span>
+              </label>
+              <input
+                id="sim-owner"
+                type="text"
+                value={input.ownerAddress}
+                onChange={(e) => setInput((p) => ({ ...p, ownerAddress: e.target.value }))}
+                placeholder="Filter rules by owner"
+                className={inputCls}
+              />
+            </div>
+
+            {/* Run label */}
+            <div>
+              <label
+                htmlFor="sim-label"
+                className="block text-xs font-semibold text-stellar-text-muted uppercase tracking-wider mb-1.5"
+              >
+                Run Label <span className="text-stellar-text-muted/60 normal-case font-normal">(optional)</span>
+              </label>
+              <input
+                id="sim-label"
+                type="text"
+                value={input.label}
+                onChange={(e) => setInput((p) => ({ ...p, label: e.target.value }))}
+                placeholder="e.g. Pre-launch validation"
+                maxLength={120}
+                className={inputCls}
+              />
+            </div>
+
+            <button
+              type="submit"
+              disabled={isRunning || !adminToken.trim()}
+              className="w-full py-2.5 px-4 rounded-md bg-stellar-blue text-white text-sm font-semibold hover:bg-stellar-blue/80 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center justify-center gap-2"
+            >
+              {isRunning ? (
+                <>
+                  <svg
+                    className="w-4 h-4 animate-spin"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                    aria-hidden="true"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M12 3v3M12 18v3M4.22 4.22l2.12 2.12M17.66 17.66l2.12 2.12M3 12H6M18 12h3M4.22 19.78l2.12-2.12M17.66 6.34l2.12-2.12"
+                    />
+                  </svg>
+                  Running simulation…
+                </>
+              ) : (
+                "Run Simulation"
+              )}
+            </button>
+
+            {!adminToken.trim() && (
+              <p className="text-xs text-amber-400 text-center" role="alert">
+                Admin API token required to run simulations
+              </p>
+            )}
+          </form>
+        </div>
+
+        {/* ── Right: results / history ───────────────────────────── */}
+        <div className="lg:col-span-3 space-y-4">
+          {/* Tab bar */}
+          <div className="flex gap-1 border-b border-stellar-border">
+            {(["results", "history"] as const).map((tab) => (
+              <button
+                key={tab}
+                type="button"
+                onClick={() => setActiveTab(tab)}
+                className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
+                  activeTab === tab
+                    ? "text-white border-stellar-blue"
+                    : "text-stellar-text-muted border-transparent hover:text-stellar-text-secondary"
+                }`}
+                aria-selected={activeTab === tab}
+                role="tab"
+              >
+                {tab === "results" ? "Results" : `History (${history.length})`}
+              </button>
+            ))}
+          </div>
+
+          {/* Results tab */}
+          {activeTab === "results" && (
+            <div>
+              {error && (
+                <div
+                  role="alert"
+                  className="rounded-lg border border-red-700 bg-red-900/20 p-4 text-sm text-red-400"
+                >
+                  {error}
+                </div>
+              )}
+
+              {!currentResult && !isRunning && !error && (
+                <div className="rounded-lg border border-stellar-border bg-stellar-card/50 p-12 text-center">
+                  <svg
+                    className="w-12 h-12 mx-auto mb-4 text-stellar-text-muted"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    aria-hidden="true"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={1}
+                      d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01"
+                    />
+                  </svg>
+                  <p className="text-stellar-text-secondary font-medium">No simulation run yet</p>
+                  <p className="text-sm text-stellar-text-muted mt-1">
+                    Choose a preset or configure parameters, then click Run Simulation.
+                  </p>
+                </div>
+              )}
+
+              {isRunning && (
+                <div className="rounded-lg border border-stellar-border bg-stellar-card/50 p-12 text-center">
+                  <svg
+                    className="w-10 h-10 mx-auto mb-4 text-stellar-blue animate-spin"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                    aria-label="Running simulation"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M12 3v3M12 18v3M4.22 4.22l2.12 2.12M17.66 17.66l2.12 2.12M3 12H6M18 12h3M4.22 19.78l2.12-2.12M17.66 6.34l2.12-2.12"
+                    />
+                  </svg>
+                  <p className="text-stellar-text-secondary">Evaluating routing rules…</p>
+                </div>
+              )}
+
+              {currentResult && !isRunning && (
+                <SimulationResults result={currentResult} />
+              )}
+            </div>
+          )}
+
+          {/* History tab */}
+          {activeTab === "history" && (
+            <SimulationHistory
+              history={history}
+              onRestore={(r) => {
+                restoreFromHistory(r);
+                setActiveTab("results");
+              }}
+              onClear={clearHistory}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+function SimulationResults({ result }: { result: SimulationResult }) {
+  const { summary, input, results, skippedInactive } = result;
+  const [showSkipped, setShowSkipped] = useState(false);
+
+  return (
+    <div className="space-y-4" aria-label="Simulation results">
+      {/* Run metadata */}
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-stellar-text-muted">
+        <span className="font-mono text-stellar-text-secondary">{result.simulationId}</span>
+        <span aria-hidden="true">·</span>
+        <time dateTime={result.timestamp}>{new Date(result.timestamp).toLocaleString()}</time>
+        {input.label && (
+          <>
+            <span aria-hidden="true">·</span>
+            <span className="text-stellar-text-primary">"{input.label}"</span>
+          </>
+        )}
+      </div>
+
+      {/* Summary cards */}
+      <div className="grid grid-cols-3 gap-3">
+        <div
+          className={`rounded-lg border p-3 text-center ${
+            summary.wouldDispatch
+              ? "border-green-700 bg-green-900/20"
+              : "border-stellar-border bg-stellar-card"
+          }`}
+        >
+          <p
+            className={`text-xl font-bold ${
+              summary.wouldDispatch ? "text-green-400" : "text-stellar-text-muted"
+            }`}
+          >
+            {summary.wouldDispatch ? "FIRES" : "SILENT"}
+          </p>
+          <p className="text-xs text-stellar-text-muted mt-0.5">Would dispatch</p>
+        </div>
+        <div className="rounded-lg border border-stellar-border bg-stellar-card p-3 text-center">
+          <p className="text-xl font-bold text-white">{summary.totalMatched}</p>
+          <p className="text-xs text-stellar-text-muted mt-0.5">Rules matched</p>
+        </div>
+        <div className="rounded-lg border border-stellar-border bg-stellar-card p-3 text-center">
+          <p className="text-xl font-bold text-white">{summary.totalActiveRules}</p>
+          <p className="text-xs text-stellar-text-muted mt-0.5">Rules checked</p>
+        </div>
+      </div>
+
+      {/* Simulated input echo */}
+      <div className="rounded-lg border border-stellar-border bg-stellar-dark/30 px-4 py-3 flex flex-wrap gap-x-4 gap-y-1 text-xs">
+        <span className="text-stellar-text-muted">Severity:</span>
+        <span className={`font-semibold uppercase px-1.5 py-0.5 rounded ${SEVERITY_STYLES[input.severity as SimulationSeverity]?.badge ?? ""}`}>
+          {input.severity}
+        </span>
+        {input.assetCode && (
+          <>
+            <span className="text-stellar-text-muted">Asset:</span>
+            <span className="text-stellar-text-primary">{input.assetCode}</span>
+          </>
+        )}
+        {input.sourceType && (
+          <>
+            <span className="text-stellar-text-muted">Source:</span>
+            <span className="text-stellar-text-primary">{input.sourceType}</span>
+          </>
+        )}
+        {input.metric && (
+          <>
+            <span className="text-stellar-text-muted">Metric:</span>
+            <span className="text-stellar-text-primary">{input.metric}</span>
+          </>
+        )}
+        {input.triggeredValue !== null && (
+          <>
+            <span className="text-stellar-text-muted">Value:</span>
+            <span className="text-stellar-text-primary">
+              {input.triggeredValue}
+              {input.threshold !== null && ` / ${input.threshold}`}
+            </span>
+          </>
+        )}
+      </div>
+
+      {/* Effective channels */}
+      {summary.wouldDispatch && (
+        <div className="rounded-lg border border-stellar-border bg-stellar-card p-4">
+          <p className="text-xs font-semibold uppercase tracking-wider text-stellar-text-muted mb-2">
+            Effective Channels
+            {summary.firstMatchingRule && (
+              <span className="ml-2 normal-case font-normal text-stellar-text-secondary">
+                via "{summary.firstMatchingRule.ruleName}"
+              </span>
+            )}
+          </p>
+          <div className="flex flex-wrap items-center gap-2">
+            {summary.effectiveChannels.map((ch) => (
+              <span
+                key={ch}
+                className="px-2.5 py-1 rounded-full border border-stellar-blue/50 bg-stellar-blue/10 text-stellar-blue text-xs font-medium"
+              >
+                {CHANNEL_LABELS[ch] ?? ch}
+              </span>
+            ))}
+            {summary.effectiveFallbackChannels.length > 0 && (
+              <span className="text-xs text-stellar-text-muted self-center">
+                · Fallback:{" "}
+                {summary.effectiveFallbackChannels
+                  .map((ch) => CHANNEL_LABELS[ch] ?? ch)
+                  .join(", ")}
+              </span>
+            )}
+          </div>
+          {summary.suppressionWindowSeconds > 0 && (
+            <p className="text-xs text-amber-400 mt-2 flex items-center gap-1">
+              <svg className="w-3.5 h-3.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              Suppression window: {summary.suppressionWindowSeconds}s — rapid repeats may be suppressed in production
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Per-rule breakdown */}
+      <div>
+        <h4 className="text-sm font-semibold text-white mb-2">
+          Rule Evaluation ({results.length} active)
+        </h4>
+        <div className="space-y-2">
+          {results.map((r) => (
+            <div
+              key={r.ruleId}
+              className={`rounded-lg border p-3 transition-opacity ${
+                r.matched
+                  ? "border-green-700/60 bg-green-900/10"
+                  : "border-stellar-border/40 bg-stellar-card/30 opacity-60"
+              }`}
+            >
+              <div className="flex items-start justify-between gap-2 mb-2">
+                <div className="flex items-center gap-2 min-w-0">
+                  {r.matched ? (
+                    <svg className="w-4 h-4 text-green-400 flex-shrink-0" viewBox="0 0 20 20" fill="currentColor" aria-label="Matched">
+                      <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+                    </svg>
+                  ) : (
+                    <svg className="w-4 h-4 text-stellar-text-muted flex-shrink-0" viewBox="0 0 20 20" fill="currentColor" aria-label="No match">
+                      <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd" />
+                    </svg>
+                  )}
+                  <span
+                    className={`text-sm font-medium truncate ${
+                      r.matched ? "text-white" : "text-stellar-text-secondary"
+                    }`}
+                  >
+                    {r.ruleName}
+                  </span>
+                </div>
+                <div className="flex items-center gap-2 flex-shrink-0">
+                  <span className="text-xs text-stellar-text-muted">P{r.priorityOrder}</span>
+                  {r.matched && (
+                    <span className="text-xs font-medium px-1.5 py-0.5 rounded bg-green-900/40 text-green-400 border border-green-700/50">
+                      MATCH
+                    </span>
+                  )}
+                </div>
+              </div>
+
+              <ul className="space-y-0.5" aria-label="Match reasons">
+                {r.reasons.map((reason, i) => (
+                  <li key={i} className="text-xs text-stellar-text-muted flex items-start gap-1.5">
+                    <span className="text-stellar-text-muted/40 flex-shrink-0" aria-hidden="true">•</span>
+                    {reason}
+                  </li>
+                ))}
+              </ul>
+
+              {r.matched && r.channels.length > 0 && (
+                <div className="flex flex-wrap gap-1.5 mt-2 pt-2 border-t border-stellar-border/30">
+                  {r.channels.map((ch) => (
+                    <span
+                      key={ch}
+                      className="text-xs px-1.5 py-0.5 rounded border border-stellar-blue/40 text-stellar-blue bg-stellar-blue/5"
+                    >
+                      {CHANNEL_LABELS[ch] ?? ch}
+                    </span>
+                  ))}
+                  {r.suppressionWindowSeconds > 0 && (
+                    <span className="text-xs text-amber-400 self-center ml-1">
+                      {r.suppressionWindowSeconds}s suppression
+                    </span>
+                  )}
+                </div>
+              )}
+            </div>
+          ))}
+
+          {results.length === 0 && (
+            <div className="rounded-lg border border-stellar-border p-6 text-center text-sm text-stellar-text-secondary">
+              No active routing rules found for this owner.
+            </div>
+          )}
+        </div>
+
+        {skippedInactive.length > 0 && (
+          <div className="mt-3">
+            <button
+              type="button"
+              onClick={() => setShowSkipped((s) => !s)}
+              className="text-xs text-stellar-text-muted hover:text-stellar-text-secondary transition-colors flex items-center gap-1"
+            >
+              <svg
+                className={`w-3 h-3 transition-transform ${showSkipped ? "rotate-90" : ""}`}
+                fill="none"
+                viewBox="0 0 12 12"
+                stroke="currentColor"
+                strokeWidth={2}
+                aria-hidden="true"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="M3 4.5L6 7.5 9 4.5" />
+              </svg>
+              {skippedInactive.length} inactive rule{skippedInactive.length !== 1 ? "s" : ""} skipped
+            </button>
+            {showSkipped && (
+              <ul className="mt-2 space-y-1 pl-4">
+                {skippedInactive.map((r) => (
+                  <li key={r.ruleId} className="text-xs text-stellar-text-muted">
+                    P{r.priorityOrder} — {r.ruleName}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SimulationHistory({
+  history,
+  onRestore,
+  onClear,
+}: {
+  history: SimulationResult[];
+  onRestore: (r: SimulationResult) => void;
+  onClear: () => void;
+}) {
+  if (history.length === 0) {
+    return (
+      <div className="rounded-lg border border-stellar-border bg-stellar-card/50 p-8 text-center">
+        <p className="text-stellar-text-secondary text-sm">No simulation runs recorded yet.</p>
+        <p className="text-xs text-stellar-text-muted mt-1">Runs are saved locally in your browser.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <p className="text-xs text-stellar-text-muted">
+          {history.length} run{history.length !== 1 ? "s" : ""} — stored locally
+        </p>
+        <button
+          type="button"
+          onClick={onClear}
+          className="text-xs text-red-400 hover:text-red-300 transition-colors"
+        >
+          Clear all
+        </button>
+      </div>
+
+      <div className="space-y-2" role="list" aria-label="Simulation history">
+        {history.map((run) => (
+          <button
+            key={run.simulationId}
+            type="button"
+            role="listitem"
+            onClick={() => onRestore(run)}
+            className="w-full text-left rounded-lg border border-stellar-border bg-stellar-card/50 hover:bg-stellar-card-hover hover:border-stellar-blue/40 p-3 transition-colors"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <span
+                    className={`text-xs font-semibold uppercase px-1.5 py-0.5 rounded flex-shrink-0 ${
+                      SEVERITY_STYLES[run.input.severity as SimulationSeverity]?.badge ?? ""
+                    }`}
+                  >
+                    {run.input.severity}
+                  </span>
+                  {run.input.label && (
+                    <span className="text-xs text-white truncate">"{run.input.label}"</span>
+                  )}
+                </div>
+                <div className="flex items-center gap-2 mt-0.5 text-xs text-stellar-text-muted">
+                  {run.input.assetCode && <span>{run.input.assetCode}</span>}
+                  {run.input.assetCode && run.input.sourceType && (
+                    <span aria-hidden="true">·</span>
+                  )}
+                  {run.input.sourceType && <span>{run.input.sourceType}</span>}
+                </div>
+              </div>
+              <div className="text-right flex-shrink-0">
+                <span
+                  className={`text-xs font-medium ${
+                    run.summary.wouldDispatch ? "text-green-400" : "text-stellar-text-muted"
+                  }`}
+                >
+                  {run.summary.wouldDispatch ? "Fires" : "Silent"}
+                </span>
+                <p className="text-xs text-stellar-text-muted">
+                  {run.summary.totalMatched}/{run.summary.totalActiveRules} matched
+                </p>
+              </div>
+            </div>
+            <time
+              dateTime={run.timestamp}
+              className="block text-xs text-stellar-text-muted mt-1.5"
+            >
+              {new Date(run.timestamp).toLocaleString()}
+            </time>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What was done

Added a complete alert simulation sandbox that lets operators safely test routing rules against synthetic data before enabling them in production. No real alerts are dispatched during simulation.

### Backend — `POST /api/v1/admin/alert-routing/simulate`
- New dry-run endpoint added to the existing alert routing admin route
- Loads all active routing rules (optionally scoped by `ownerAddress`)
- Evaluates each rule against the simulated alert using the same matching logic as the live router (severity, assetCode, sourceType)
- Returns per-rule results with human-readable match reasons, effective channels, fallback channels, and suppression window info
- Inactive rules are listed separately (skipped from evaluation) and can be disclosed in the UI
- No DB writes, no channel dispatches — pure evaluation

### Frontend — `AlertSimulationSandbox` page at `/alert-sandbox`

**Left panel — configuration:**
- Admin API token input (persisted in localStorage)
- Six scenario presets for common failure modes: Critical Bridge Failure, Token Exploit, TVL Anomaly, Reserve Backing Drift, Gas Price Spike, Scheduled Maintenance
- Full parameter form: severity selector, asset code, source type, triggered value, threshold, metric, owner address, run label

**Right panel — Results tab:**
- Summary cards: FIRES / SILENT status, rules matched, rules checked
- Simulated input echo bar
- Effective channels panel with suppression window warning
- Per-rule breakdown with green check / grey X indicators and condition-level explanations
- Disclosure toggle for skipped inactive rules

**Right panel — History tab:**
- Up to 20 simulation runs stored in `localStorage` via `useAlertSimulation` hook
- Each entry shows severity, label, asset/source, result, timestamp
- Click any entry to restore its results in the Results tab
- "Clear all" button

### Navigation
- "Alert Sandbox" added to the Operations group in `navigation.ts`
- Route registered in `App.tsx`

## Test plan
- [ ] Visit `/alert-sandbox` — page renders with preset buttons and input form
- [ ] Enter admin API token and click "Critical Bridge Failure" preset — fields populate
- [ ] Click "Run Simulation" — results panel shows FIRES/SILENT, per-rule cards
- [ ] Verify match reasons explain each condition clearly
- [ ] Select different severity/asset/source combinations and confirm rule matching changes
- [ ] Check suppression window note appears when matched rule has `suppressionWindowSeconds > 0`
- [ ] Switch to History tab — past runs listed, click one to restore results
- [ ] Click "Clear all" — history cleared
- [ ] Confirm no actual alert is dispatched (check backend logs / audit history)
- [ ] Responsive: page adapts correctly on mobile breakpoints

Closes #590