### PR TITLE
test: create api fixture validator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,9 @@ jobs:
       - name: Lint backend
         run: npm --workspace=backend run lint
 
+      - name: Validate API fixtures
+        run: npm --workspace=backend run fixtures:validate
+
       - name: Build backend
         run: npm --workspace=backend run build
 

--- a/backend/docs/FIXTURE_VALIDATION.md
+++ b/backend/docs/FIXTURE_VALIDATION.md
@@ -1,0 +1,65 @@
+# API Fixture Validation
+
+Test fixtures (the static JSON payloads under `e2e/fixtures/`) are easy to forget
+when an API response shape changes. When they drift, tests pass against payloads
+that no longer resemble what the API actually returns. The fixture validator
+guards against this by checking every registered fixture against a schema that
+mirrors the current API/domain shape.
+
+## What it checks
+
+- **Fixture drift** — fields that have been added, removed, or renamed in the API
+  but not in the fixture.
+- **Schema matching** — types and enum values match the current shapes defined in
+  `frontend/src/types`.
+- **Readable diffs** — each mismatch is reported with the exact path
+  (e.g. `USDC.factors.liquidityDepth`) and a description.
+
+Findings are classified by severity:
+
+| Severity | Meaning | Fails CI? |
+| --- | --- | --- |
+| `error` | Missing/mistyped required field, bad enum, unreadable/invalid JSON | Yes |
+| `warning` | A property that is no longer part of the current API shape | Only with `--strict` |
+
+## Running it
+
+```bash
+# From the repo root
+npm --workspace=backend run fixtures:validate
+
+# Treat warnings (stale extra fields) as failures too
+npm --workspace=backend run fixtures:validate -- --strict
+
+# Machine-readable output
+npm --workspace=backend run fixtures:validate -- --json
+```
+
+The command exits non-zero when there are errors (or any findings under
+`--strict`), which is what makes it usable as a CI gate. It runs in the `node-ci`
+job in `.github/workflows/ci.yml`, right after linting.
+
+The same checks also run as part of the backend unit test suite
+(`tests/testing/fixtureValidator.test.ts`), so `npm --workspace=backend run test`
+will fail if a fixture drifts.
+
+## Updating fixtures when the API changes
+
+1. Update the schema in
+   `backend/src/testing/fixtureValidator/schemas.ts` to reflect the new API shape
+   (keep it aligned with the canonical types in `frontend/src/types`).
+2. Run `npm --workspace=backend run fixtures:validate`. The report lists every
+   fixture and field that no longer matches.
+3. Update the offending fixture JSON in `e2e/fixtures/` to match.
+4. Re-run the validator until it reports **PASS**.
+
+## Adding a new fixture
+
+1. Add the fixture file under `e2e/fixtures/`.
+2. Add a schema describing its shape to `schemas.ts`.
+3. Register the fixture in
+   `backend/src/testing/fixtureValidator/registry.ts` with its file path, schema,
+   and a short description of the API surface it represents.
+
+That's it — the new fixture is now covered by both the CLI check and the test
+suite.

--- a/backend/package.json
+++ b/backend/package.json
@@ -28,7 +28,8 @@
     "migrate:unlock": "tsx src/database/migrate.ts unlock",
     "seed": "tsx src/database/seed.ts",
     "seed:specific": "tsx src/database/seed.ts run",
-    "docs:generate": "tsx scripts/generate-openapi.ts"
+    "docs:generate": "tsx scripts/generate-openapi.ts",
+    "fixtures:validate": "tsx scripts/validate-fixtures.ts"
   },
   "dependencies": {
     "@fastify/cors": "^11.2.0",

--- a/backend/scripts/validate-fixtures.ts
+++ b/backend/scripts/validate-fixtures.ts
@@ -1,0 +1,24 @@
+import {
+  formatReport,
+  summarise,
+  validateAllFixtures,
+} from "../src/testing/fixtureValidator/index.js";
+
+function main() {
+  const args = process.argv.slice(2);
+  const asJson = args.includes("--json");
+  const strict = args.includes("--strict");
+
+  const results = validateAllFixtures();
+  const summary = summarise(results, { strict });
+
+  if (asJson) {
+    console.log(JSON.stringify(summary, null, 2));
+  } else {
+    console.log(formatReport(summary));
+  }
+
+  process.exit(summary.failed ? 1 : 0);
+}
+
+main();

--- a/backend/src/testing/fixtureValidator/format.ts
+++ b/backend/src/testing/fixtureValidator/format.ts
@@ -1,0 +1,41 @@
+import type { FixtureValidationResult, ValidationSummary } from "./validator.js";
+
+const SYMBOLS = {
+  pass: "✓",
+  fail: "✗",
+  warn: "!",
+};
+
+function formatResult(result: FixtureValidationResult): string {
+  const lines: string[] = [];
+  const status = result.ok ? SYMBOLS.pass : SYMBOLS.fail;
+  lines.push(`${status} ${result.name}  (${result.file})`);
+  lines.push(`    ${result.description}`);
+
+  for (const finding of result.findings) {
+    const marker = finding.severity === "error" ? SYMBOLS.fail : SYMBOLS.warn;
+    const label = finding.severity.toUpperCase();
+    lines.push(`    ${marker} ${label} at ${finding.path}: ${finding.message}`);
+  }
+
+  return lines.join("\n");
+}
+
+export function formatReport(summary: ValidationSummary): string {
+  const sections = summary.results.map(formatResult);
+  const total = summary.results.length;
+  const failedFixtures = summary.results.filter((r) => !r.ok).length;
+
+  const footer = [
+    "",
+    `Fixtures checked: ${total}  |  ` +
+      `passed: ${total - failedFixtures}  |  ` +
+      `with errors: ${failedFixtures}`,
+    `Findings: ${summary.errorCount} error(s), ${summary.warningCount} warning(s)`,
+    summary.failed
+      ? "Result: FAIL — fixtures have drifted from the current API shapes."
+      : "Result: PASS — all fixtures match the current API shapes.",
+  ];
+
+  return [...sections, ...footer].join("\n");
+}

--- a/backend/src/testing/fixtureValidator/index.ts
+++ b/backend/src/testing/fixtureValidator/index.ts
@@ -1,0 +1,4 @@
+export * from "./schemas.js";
+export * from "./registry.js";
+export * from "./validator.js";
+export * from "./format.js";

--- a/backend/src/testing/fixtureValidator/registry.ts
+++ b/backend/src/testing/fixtureValidator/registry.ts
@@ -1,0 +1,55 @@
+import { existsSync } from "fs";
+import { dirname, join, relative } from "path";
+import type { ZodTypeAny } from "zod";
+import {
+  AssetHealthFixtureSchema,
+  AssetsFixtureSchema,
+  BridgesFixtureSchema,
+} from "./schemas.js";
+
+function findRepoRoot(start: string = process.cwd()): string {
+  let dir = start;
+  let parent = dirname(dir);
+  while (parent !== dir) {
+    if (existsSync(join(dir, "e2e", "fixtures"))) return dir;
+    dir = parent;
+    parent = dirname(dir);
+  }
+  return existsSync(join(dir, "e2e", "fixtures")) ? dir : start;
+}
+
+export const REPO_ROOT = findRepoRoot();
+
+const FIXTURES_DIR = join(REPO_ROOT, "e2e", "fixtures");
+
+export interface FixtureRegistryEntry {
+  name: string;
+  file: string;
+  schema: ZodTypeAny;
+  description: string;
+}
+
+export const fixtureRegistry: FixtureRegistryEntry[] = [
+  {
+    name: "assets",
+    file: join(FIXTURES_DIR, "assets.json"),
+    schema: AssetsFixtureSchema,
+    description: "Asset listing payload (GET /api/v1/assets)",
+  },
+  {
+    name: "bridges",
+    file: join(FIXTURES_DIR, "bridges.json"),
+    schema: BridgesFixtureSchema,
+    description: "Bridge status payload (GET /api/v1/bridges)",
+  },
+  {
+    name: "asset-health",
+    file: join(FIXTURES_DIR, "asset-health.json"),
+    schema: AssetHealthFixtureSchema,
+    description: "Per-asset health scores (GET /api/v1/assets/:symbol/health)",
+  },
+];
+
+export function toRepoRelative(file: string): string {
+  return relative(REPO_ROOT, file);
+}

--- a/backend/src/testing/fixtureValidator/schemas.ts
+++ b/backend/src/testing/fixtureValidator/schemas.ts
@@ -1,0 +1,60 @@
+import { z } from "zod";
+
+export const AssetSchema = z
+  .object({
+    symbol: z.string().min(1),
+    name: z.string().min(1),
+    sourceChain: z.string().min(1).optional(),
+    issuerAddress: z.string().min(1).optional(),
+  })
+  .strict();
+
+export const HealthFactorsSchema = z
+  .object({
+    liquidityDepth: z.number(),
+    priceStability: z.number(),
+    bridgeUptime: z.number(),
+    reserveBacking: z.number(),
+    volumeTrend: z.number(),
+  })
+  .strict();
+
+export const HealthTrendSchema = z.enum(["improving", "stable", "deteriorating"]);
+
+export const HealthScoreSchema = z
+  .object({
+    symbol: z.string().min(1),
+    overallScore: z.number(),
+    factors: HealthFactorsSchema,
+    trend: HealthTrendSchema,
+    lastUpdated: z.string().min(1),
+  })
+  .strict();
+
+export const BridgeStatusSchema = z.enum(["healthy", "degraded", "down", "unknown"]);
+
+export const BridgeSchema = z
+  .object({
+    name: z.string().min(1),
+    status: BridgeStatusSchema,
+    totalValueLocked: z.number(),
+    supplyOnStellar: z.number(),
+    supplyOnSource: z.number(),
+    mismatchPercentage: z.number(),
+  })
+  .strict();
+
+export const AssetsFixtureSchema = z
+  .object({
+    assets: z.array(AssetSchema),
+    total: z.number().int().nonnegative(),
+  })
+  .strict();
+
+export const BridgesFixtureSchema = z
+  .object({
+    bridges: z.array(BridgeSchema),
+  })
+  .strict();
+
+export const AssetHealthFixtureSchema = z.record(z.string(), HealthScoreSchema);

--- a/backend/src/testing/fixtureValidator/validator.ts
+++ b/backend/src/testing/fixtureValidator/validator.ts
@@ -1,0 +1,145 @@
+import { readFileSync } from "fs";
+import type { ZodError, ZodTypeAny } from "zod";
+import {
+  fixtureRegistry,
+  toRepoRelative,
+  type FixtureRegistryEntry,
+} from "./registry.js";
+
+export type FindingSeverity = "error" | "warning";
+
+export interface FixtureFinding {
+  path: string;
+  code: string;
+  message: string;
+  severity: FindingSeverity;
+}
+
+export interface FixtureValidationResult {
+  name: string;
+  file: string;
+  description: string;
+  loaded: boolean;
+  ok: boolean;
+  findings: FixtureFinding[];
+}
+
+function formatPath(path: ReadonlyArray<string | number>): string {
+  if (path.length === 0) return "(root)";
+  return path.reduce<string>((acc, segment) => {
+    if (typeof segment === "number") return `${acc}[${segment}]`;
+    return acc ? `${acc}.${segment}` : segment;
+  }, "");
+}
+
+function issuesToFindings(error: ZodError): FixtureFinding[] {
+  const findings: FixtureFinding[] = [];
+
+  for (const issue of error.issues) {
+    if (issue.code === "unrecognized_keys") {
+      const base = formatPath(issue.path);
+      for (const key of issue.keys) {
+        findings.push({
+          path: base === "(root)" ? key : `${base}.${key}`,
+          code: issue.code,
+          message: `Unexpected property "${key}" is not part of the current API shape`,
+          severity: "warning",
+        });
+      }
+      continue;
+    }
+
+    findings.push({
+      path: formatPath(issue.path),
+      code: issue.code,
+      message: issue.message,
+      severity: "error",
+    });
+  }
+
+  return findings;
+}
+
+export function validateData(data: unknown, schema: ZodTypeAny): FixtureFinding[] {
+  const result = schema.safeParse(data);
+  if (result.success) return [];
+  return issuesToFindings(result.error);
+}
+
+export function validateFixture(entry: FixtureRegistryEntry): FixtureValidationResult {
+  const file = toRepoRelative(entry.file);
+  const base = { name: entry.name, file, description: entry.description };
+
+  let raw: string;
+  try {
+    raw = readFileSync(entry.file, "utf8");
+  } catch (err) {
+    return {
+      ...base,
+      loaded: false,
+      ok: false,
+      findings: [
+        {
+          path: "(file)",
+          code: "file_unreadable",
+          message: `Cannot read fixture file: ${(err as Error).message}`,
+          severity: "error",
+        },
+      ],
+    };
+  }
+
+  let data: unknown;
+  try {
+    data = JSON.parse(raw);
+  } catch (err) {
+    return {
+      ...base,
+      loaded: false,
+      ok: false,
+      findings: [
+        {
+          path: "(file)",
+          code: "invalid_json",
+          message: `Fixture is not valid JSON: ${(err as Error).message}`,
+          severity: "error",
+        },
+      ],
+    };
+  }
+
+  const findings = validateData(data, entry.schema);
+  const ok = !findings.some((f) => f.severity === "error");
+  return { ...base, loaded: true, ok, findings };
+}
+
+export function validateAllFixtures(
+  entries: FixtureRegistryEntry[] = fixtureRegistry,
+): FixtureValidationResult[] {
+  return entries.map(validateFixture);
+}
+
+export interface ValidationSummary {
+  results: FixtureValidationResult[];
+  errorCount: number;
+  warningCount: number;
+  failed: boolean;
+}
+
+export function summarise(
+  results: FixtureValidationResult[],
+  { strict = false }: { strict?: boolean } = {},
+): ValidationSummary {
+  let errorCount = 0;
+  let warningCount = 0;
+
+  for (const result of results) {
+    for (const finding of result.findings) {
+      if (finding.severity === "error") errorCount += 1;
+      else warningCount += 1;
+    }
+  }
+
+  const failed = errorCount > 0 || (strict && warningCount > 0);
+  return { results, errorCount, warningCount, failed };
+}

--- a/backend/tests/testing/fixtureValidator.test.ts
+++ b/backend/tests/testing/fixtureValidator.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from "vitest";
+import {
+  AssetHealthFixtureSchema,
+  BridgeSchema,
+  HealthScoreSchema,
+  summarise,
+  validateAllFixtures,
+  validateData,
+} from "../../src/testing/fixtureValidator/index.js";
+
+describe("fixture validator", () => {
+  describe("registered fixtures", () => {
+    it("validates every registered fixture against the current API shapes", () => {
+      const results = validateAllFixtures();
+
+      expect(results.length).toBeGreaterThan(0);
+      for (const result of results) {
+        expect(result.loaded).toBe(true);
+        const errors = result.findings.filter((f) => f.severity === "error");
+        expect(
+          errors,
+          `${result.file} drifted from the API shape: ${JSON.stringify(errors, null, 2)}`,
+        ).toEqual([]);
+        expect(result.ok).toBe(true);
+      }
+    });
+
+    it("produces no findings of any severity for the committed fixtures", () => {
+      const summary = summarise(validateAllFixtures(), { strict: true });
+      expect(summary.errorCount).toBe(0);
+      expect(summary.warningCount).toBe(0);
+      expect(summary.failed).toBe(false);
+    });
+  });
+
+  describe("drift detection", () => {
+    const validBridge = {
+      name: "Allbridge",
+      status: "healthy",
+      totalValueLocked: 1525000,
+      supplyOnStellar: 1200000,
+      supplyOnSource: 1201500,
+      mismatchPercentage: 0.124,
+    };
+
+    it("accepts a payload matching the schema", () => {
+      expect(validateData(validBridge, BridgeSchema)).toEqual([]);
+    });
+
+    it("flags a missing required field as an error", () => {
+      const { mismatchPercentage, ...withoutMismatch } = validBridge;
+      void mismatchPercentage;
+      const findings = validateData(withoutMismatch, BridgeSchema);
+
+      expect(findings).toHaveLength(1);
+      expect(findings[0].severity).toBe("error");
+      expect(findings[0].path).toBe("mismatchPercentage");
+    });
+
+    it("flags a wrong type as an error", () => {
+      const findings = validateData(
+        { ...validBridge, totalValueLocked: "lots" },
+        BridgeSchema,
+      );
+
+      expect(findings.some((f) => f.severity === "error")).toBe(true);
+      expect(findings.some((f) => f.path === "totalValueLocked")).toBe(true);
+    });
+
+    it("flags an invalid enum value as an error", () => {
+      const findings = validateData(
+        { ...validBridge, status: "on-fire" },
+        BridgeSchema,
+      );
+
+      expect(findings.some((f) => f.path === "status" && f.severity === "error")).toBe(
+        true,
+      );
+    });
+
+    it("reports an unexpected property as a warning, not an error", () => {
+      const findings = validateData(
+        { ...validBridge, legacyField: true },
+        BridgeSchema,
+      );
+
+      const warning = findings.find((f) => f.path === "legacyField");
+      expect(warning).toBeDefined();
+      expect(warning?.severity).toBe("warning");
+      expect(findings.some((f) => f.severity === "error")).toBe(false);
+    });
+
+    it("points at the correct nested path for record fixtures", () => {
+      const findings = validateData(
+        {
+          USDC: {
+            symbol: "USDC",
+            overallScore: 92,
+            factors: {
+              liquidityDepth: "high",
+              priceStability: 89,
+              bridgeUptime: 96,
+              reserveBacking: 93,
+              volumeTrend: 90,
+            },
+            trend: "improving",
+            lastUpdated: "2026-01-01T00:00:00.000Z",
+          },
+        },
+        AssetHealthFixtureSchema,
+      );
+
+      expect(findings.some((f) => f.path === "USDC.factors.liquidityDepth")).toBe(true);
+    });
+  });
+
+  describe("summarise", () => {
+    const validHealth = {
+      symbol: "USDC",
+      overallScore: 92,
+      factors: {
+        liquidityDepth: 94,
+        priceStability: 89,
+        bridgeUptime: 96,
+        reserveBacking: 93,
+        volumeTrend: 90,
+      },
+      trend: "improving",
+      lastUpdated: "2026-01-01T00:00:00.000Z",
+    };
+
+    it("does not fail on warnings unless strict mode is enabled", () => {
+      const findings = validateData(
+        { ...validHealth, deprecated: 1 },
+        HealthScoreSchema,
+      );
+      const result = {
+        name: "synthetic",
+        file: "synthetic.json",
+        description: "synthetic",
+        loaded: true,
+        ok: true,
+        findings,
+      };
+
+      expect(summarise([result]).failed).toBe(false);
+      expect(summarise([result], { strict: true }).failed).toBe(true);
+    });
+  });
+});

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
             "tests/services/**/*.test.ts",
             "tests/workers/**/*.test.ts",
             "tests/jobs/**/*.test.ts",
+            "tests/testing/**/*.test.ts",
           ],
           setupFiles: ["./tests/setup.ts"],
         },

--- a/backend/vitest.unit.config.ts
+++ b/backend/vitest.unit.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
       "tests/services/**/*.test.ts",
       "tests/workers/**/*.test.ts",
       "tests/jobs/**/*.test.ts",
+      "tests/testing/**/*.test.ts",
     ],
   },
 });

--- a/e2e/fixtures/asset-health.json
+++ b/e2e/fixtures/asset-health.json
@@ -9,7 +9,8 @@
       "reserveBacking": 93,
       "volumeTrend": 90
     },
-    "trend": "improving"
+    "trend": "improving",
+    "lastUpdated": "2026-01-01T00:00:00.000Z"
   },
   "EURC": {
     "symbol": "EURC",
@@ -21,6 +22,7 @@
       "reserveBacking": 74,
       "volumeTrend": 75
     },
-    "trend": "stable"
+    "trend": "stable",
+    "lastUpdated": "2026-01-01T00:00:00.000Z"
   }
 }


### PR DESCRIPTION
## Summary

Implements an **API Fixture Validator** that checks the JSON fixtures under `e2e/fixtures/` against Zod schemas mirroring the **current** API/domain shapes (the canonical types in `frontend/src/types`). This catches fixture drift — fields added, removed, renamed, or retyped in the API but not in the fixtures — before stale fixtures silently weaken the tests.

Closes #561

## What's included

- **Validator core** (`backend/src/testing/fixtureValidator/`)
  - `schemas.ts` — Zod schemas mirroring `Asset`, `HealthScore`, `HealthFactors`, `Bridge`, and the fixture-file envelopes.
  - `registry.ts` — maps each fixture file to the schema describing its API shape.
  - `validator.ts` — reads, parses, and validates fixtures; emits **readable, path-pointed diffs** (e.g. `USDC.factors.liquidityDepth`).
  - `format.ts` — CI-friendly text report.
- **Severity model**
  - `error` — missing/mistyped required field, invalid enum, unreadable/invalid JSON → **fails CI**.
  - `warning` — a property no longer part of the current API shape → fails only under `--strict`.
- **CLI** — `npm --workspace=backend run fixtures:validate` (supports `--json` and `--strict`), exits non-zero on drift.
- **CI** — runs in the `node-ci` job right after lint.
- **Unit tests** — `backend/tests/testing/fixtureValidator.test.ts` (validates every registered fixture + covers missing field, wrong type, bad enum, unexpected property, and nested record paths).
- **Docs** — `backend/docs/FIXTURE_VALIDATION.md` covering how to run it, the update workflow when the API changes, and how to add a new fixture.

## Drift fixed in this PR

While building the validator it flagged real drift: `e2e/fixtures/asset-health.json` was missing the required `HealthScore.lastUpdated` field. Fixed so the committed fixtures match the current shape.

## Verification

- `npm --workspace=backend run lint` ✅
- `npm --workspace=backend run build` ✅
- `npm --workspace=backend run fixtures:validate` → **PASS** ✅
- `npm --workspace=backend run test -- tests/testing` → 9/9 passing ✅
- Confirmed the validator **fails** with readable diffs + exit code 1 when a fixture is intentionally broken.

## How to extend

Add a fixture file, add a schema to `schemas.ts`, and register it in `registry.ts` — it's then covered by both the CLI check and the test suite.
