### PR TITLE
ci: implement release shield checks

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -66,6 +66,18 @@ This directory contains the CI/CD pipeline configuration for Stellar Bridge Watc
 - `GITHUB_TOKEN` (automatically provided)
 - `NPM_TOKEN` (if NPM publishing is enabled)
 
+**Release Shield:**
+
+- Runs before a GitHub release or release artifact can be published.
+- Requires successful `CI`, `Code Quality`, and `Security Scanning` workflow runs for the exact release commit.
+- Probes every comma-separated readiness endpoint in the `RELEASE_HEALTH_URLS` repository variable.
+- Rebuilds the backend, frontend, and Soroban WASM artifacts from locked dependencies.
+- Blocks promotion if any gate fails. Frontend image publication failures are not ignored.
+- A manual dispatch can request an emergency override, but the actor must have `maintain` or `admin` permission and provide an audit reason of at least 10 characters. Overrides are unavailable to tag-triggered releases.
+- Set `RELEASE_REQUIRED_WORKFLOWS` to a comma-separated list to customize the required workflow names.
+
+The release dry-run calls the same shield with external health and prior-workflow evidence disabled; metadata and artifact gates still run. Every shield execution writes a gate-by-gate decision table to the GitHub Actions job summary.
+
 ### 4. Code Quality Workflow (`code-quality.yml`)
 
 **Trigger:** Pull Requests, Push to `main`/`develop` branches

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -13,11 +13,23 @@ on:
       - "backend/**"
       - "frontend/**"
       - ".github/workflows/release-dry-run.yml"
+      - ".github/workflows/release-shield.yml"
 
 jobs:
+  release-shield:
+    name: Release Shield Dry-Run
+    uses: ./.github/workflows/release-shield.yml
+    permissions:
+      actions: read
+      contents: read
+    with:
+      version: ${{ github.event_name == 'workflow_dispatch' && inputs.version || 'v0.0.0-dryrun' }}
+      enforce_external_gates: false
+
   validate-version:
     name: Validate Version
     runs-on: ubuntu-latest
+    needs: release-shield
 
     outputs:
       version: ${{ steps.version.outputs.value }}

--- a/.github/workflows/release-shield.yml
+++ b/.github/workflows/release-shield.yml
@@ -1,0 +1,277 @@
+name: Release Shield
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: Release version being evaluated
+        required: true
+        type: string
+      health_urls:
+        description: Comma-separated readiness endpoints
+        required: false
+        default: ""
+        type: string
+      required_workflows:
+        description: Comma-separated workflow names that must have succeeded for the release SHA
+        required: false
+        default: "CI,Code Quality,Security Scanning"
+        type: string
+      enforce_external_gates:
+        description: Require health endpoints and completed workflow evidence
+        required: false
+        default: true
+        type: boolean
+      override:
+        description: Allow an authorized maintainer to bypass failed gates
+        required: false
+        default: false
+        type: boolean
+      override_reason:
+        description: Audit reason for a manual override
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  shield:
+    name: Release Shield
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate release metadata
+        id: metadata
+        continue-on-error: true
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid release version: $VERSION"
+            exit 1
+          fi
+
+          if [ "${{ github.event_name }}" = "push" ] && [ "${GITHUB_REF_TYPE}" != "tag" ]; then
+            echo "Automatic releases must originate from a tag."
+            exit 1
+          fi
+
+          echo "Release metadata is valid for $VERSION at $GITHUB_SHA."
+
+      - name: Check deployment health
+        id: health
+        continue-on-error: true
+        env:
+          HEALTH_URLS: ${{ inputs.health_urls }}
+          ENFORCE_EXTERNAL_GATES: ${{ inputs.enforce_external_gates }}
+        run: |
+          if [ "$ENFORCE_EXTERNAL_GATES" != "true" ]; then
+            echo "Health evidence is not required for this dry run."
+            exit 0
+          fi
+
+          if [ -z "${HEALTH_URLS// }" ]; then
+            echo "No health endpoints configured. Set the RELEASE_HEALTH_URLS repository variable."
+            exit 1
+          fi
+
+          failed=0
+          IFS=',' read -ra urls <<< "$HEALTH_URLS"
+          for raw_url in "${urls[@]}"; do
+            url="$(echo "$raw_url" | xargs)"
+            [ -z "$url" ] && continue
+            if curl --fail --silent --show-error --location \
+              --retry 3 --retry-all-errors --connect-timeout 5 --max-time 20 \
+              "$url" >/dev/null; then
+              echo "Healthy: $url"
+            else
+              echo "Unhealthy: $url"
+              failed=1
+            fi
+          done
+          exit "$failed"
+
+      - name: Verify test evidence for release commit
+        id: tests
+        continue-on-error: true
+        uses: actions/github-script@v7
+        env:
+          REQUIRED_WORKFLOWS: ${{ inputs.required_workflows }}
+          ENFORCE_EXTERNAL_GATES: ${{ inputs.enforce_external_gates }}
+        with:
+          script: |
+            if (process.env.ENFORCE_EXTERNAL_GATES !== 'true') {
+              core.info('External workflow evidence is not required for this dry run.');
+              return;
+            }
+
+            const required = process.env.REQUIRED_WORKFLOWS
+              .split(',')
+              .map((name) => name.trim())
+              .filter(Boolean);
+
+            if (required.length === 0) {
+              core.setFailed('No required workflows configured.');
+              return;
+            }
+
+            const { data } = await github.rest.actions.listWorkflowRunsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head_sha: context.sha,
+              status: 'completed',
+              per_page: 100,
+            });
+
+            const failures = [];
+            for (const name of required) {
+              const runs = data.workflow_runs
+                .filter((run) => run.name === name)
+                .sort((a, b) => new Date(b.updated_at) - new Date(a.updated_at));
+              const run = runs[0];
+              if (!run) {
+                failures.push(`${name}: no completed run for ${context.sha}`);
+              } else if (run.conclusion !== 'success') {
+                failures.push(`${name}: ${run.conclusion} (${run.html_url})`);
+              } else {
+                core.info(`${name}: success (${run.html_url})`);
+              }
+            }
+
+            if (failures.length > 0) {
+              core.setFailed(failures.join('\n'));
+            }
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install locked dependencies
+        id: dependencies
+        continue-on-error: true
+        run: npm ci
+
+      - name: Build backend artifact
+        id: backend
+        continue-on-error: true
+        run: |
+          npm --workspace=backend run build
+          test -f backend/dist/index.js
+
+      - name: Build frontend artifact
+        id: frontend
+        continue-on-error: true
+        run: |
+          npm --workspace=frontend run build
+          test -f frontend/dist/index.html
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Build contract artifacts
+        id: contracts
+        continue-on-error: true
+        working-directory: contracts
+        run: |
+          cargo build --workspace --target wasm32-unknown-unknown --release
+          find target/wasm32-unknown-unknown/release -maxdepth 1 -name '*.wasm' -print -quit | grep -q .
+
+      - name: Authorize manual override
+        id: override
+        if: always()
+        continue-on-error: true
+        uses: actions/github-script@v7
+        env:
+          OVERRIDE_REQUESTED: ${{ inputs.override }}
+          OVERRIDE_REASON: ${{ inputs.override_reason }}
+        with:
+          script: |
+            core.setOutput('authorized', 'false');
+            if (process.env.OVERRIDE_REQUESTED !== 'true') return;
+
+            if (context.eventName !== 'workflow_dispatch') {
+              core.setFailed('Overrides are only allowed for manually dispatched releases.');
+              return;
+            }
+            if (process.env.OVERRIDE_REASON.trim().length < 10) {
+              core.setFailed('Override reason must contain at least 10 characters.');
+              return;
+            }
+
+            const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.actor,
+            });
+            if (!['admin', 'maintain'].includes(data.permission)) {
+              core.setFailed(`@${context.actor} does not have maintain or admin permission.`);
+              return;
+            }
+            core.setOutput('authorized', 'true');
+
+      - name: Publish shield report and enforce decision
+        if: always()
+        env:
+          VERSION: ${{ inputs.version }}
+          OVERRIDE_REQUESTED: ${{ inputs.override }}
+          OVERRIDE_REASON: ${{ inputs.override_reason }}
+          OVERRIDE_AUTHORIZED: ${{ steps.override.outputs.authorized }}
+          METADATA_RESULT: ${{ steps.metadata.outcome }}
+          HEALTH_RESULT: ${{ steps.health.outcome }}
+          TEST_RESULT: ${{ steps.tests.outcome }}
+          DEPENDENCIES_RESULT: ${{ steps.dependencies.outcome }}
+          BACKEND_RESULT: ${{ steps.backend.outcome }}
+          FRONTEND_RESULT: ${{ steps.frontend.outcome }}
+          CONTRACTS_RESULT: ${{ steps.contracts.outcome }}
+        run: |
+          {
+            echo "## Release Shield"
+            echo
+            echo "| Gate | Result |"
+            echo "| --- | --- |"
+            echo "| Release metadata | $METADATA_RESULT |"
+            echo "| Deployment health | $HEALTH_RESULT |"
+            echo "| Test evidence | $TEST_RESULT |"
+            echo "| Locked dependency install | $DEPENDENCIES_RESULT |"
+            echo "| Backend artifact | $BACKEND_RESULT |"
+            echo "| Frontend artifact | $FRONTEND_RESULT |"
+            echo "| Contract artifacts | $CONTRACTS_RESULT |"
+            echo
+            echo "- Version: \`$VERSION\`"
+            echo "- Commit: \`$GITHUB_SHA\`"
+            echo "- Actor: \`$GITHUB_ACTOR\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          failed=0
+          for result in \
+            "$METADATA_RESULT" "$HEALTH_RESULT" "$TEST_RESULT" "$DEPENDENCIES_RESULT" \
+            "$BACKEND_RESULT" "$FRONTEND_RESULT" "$CONTRACTS_RESULT"; do
+            [ "$result" = "success" ] || failed=1
+          done
+
+          if [ "$failed" -eq 0 ]; then
+            echo "Decision: **PROMOTION APPROVED**" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          if [ "$OVERRIDE_REQUESTED" = "true" ] && [ "$OVERRIDE_AUTHORIZED" = "true" ]; then
+            {
+              echo "Decision: **PROMOTION APPROVED BY MANUAL OVERRIDE**"
+              echo
+              echo "Override reason: $OVERRIDE_REASON"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "Decision: **PROMOTION BLOCKED**" >> "$GITHUB_STEP_SUMMARY"
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,11 +10,34 @@ on:
         description: "Version to release (e.g., v1.0.0)"
         required: true
         type: string
+      override_release_shield:
+        description: "Emergency override of failed release gates"
+        required: false
+        default: false
+        type: boolean
+      override_reason:
+        description: "Required audit reason when overriding release gates"
+        required: false
+        type: string
 
 jobs:
+  release-shield:
+    name: Release Shield
+    uses: ./.github/workflows/release-shield.yml
+    permissions:
+      actions: read
+      contents: read
+    with:
+      version: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref_name }}
+      health_urls: ${{ vars.RELEASE_HEALTH_URLS }}
+      required_workflows: ${{ vars.RELEASE_REQUIRED_WORKFLOWS || 'CI,Code Quality,Security Scanning' }}
+      override: ${{ github.event_name == 'workflow_dispatch' && inputs.override_release_shield || false }}
+      override_reason: ${{ github.event_name == 'workflow_dispatch' && inputs.override_reason || '' }}
+
   create-release:
     name: Create Release
     runs-on: ubuntu-latest
+    needs: release-shield
     permissions:
       contents: write
       packages: write
@@ -111,7 +134,9 @@ jobs:
 
       - name: Extract version
         id: version
-        run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+        env:
+          RELEASE_VERSION: ${{ needs.create-release.outputs.version }}
+        run: echo "version=${RELEASE_VERSION#v}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push backend image
         uses: docker/build-push-action@v5
@@ -136,7 +161,6 @@ jobs:
             ghcr.io/${{ github.repository }}/frontend:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
-        continue-on-error: true
 
   publish-npm:
     name: Publish NPM Packages

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -4,6 +4,9 @@ Use this checklist for every production deployment so readiness, verification, r
 
 ## Release Gates
 
+- Confirm the automated `Release Shield` job reports **PROMOTION APPROVED** before creating or promoting a release.
+- Configure `RELEASE_HEALTH_URLS` with comma-separated readiness endpoints (for example, production and critical dependency readiness URLs).
+- Confirm `RELEASE_REQUIRED_WORKFLOWS` matches the workflow names that protect the release commit; the default is `CI,Code Quality,Security Scanning`.
 - Confirm the release owner, reviewer, and on-call engineer are assigned before work starts.
 - Confirm the deployment window, target environment, and rollback owner are documented in the release ticket.
 - Confirm the PR references all closing issues and includes the release notes summary.
@@ -27,6 +30,18 @@ Use this checklist for every production deployment so readiness, verification, r
 - Tag the release commit or record the deploy SHA before rollout.
 - Record backend image tag, frontend build identifier, contract artifact version, and migration batch number.
 - Store the final deployment metadata in the release ticket or deployment log.
+
+## Emergency Override
+
+Use the release shield override only for an incident or time-critical recovery where the failed gate is understood and separately mitigated.
+
+1. Dispatch the `Release` workflow manually.
+2. Enable `override_release_shield`.
+3. Enter an audit reason of at least 10 characters, including the incident or change reference.
+4. Confirm the operator has repository `maintain` or `admin` permission.
+5. Copy the shield report and override reason into the release ticket.
+
+Tag-triggered releases cannot bypass the shield. An unauthorized or unexplained override remains blocked.
 
 ## Data Migration Checks
 


### PR DESCRIPTION
## Description

Adds a fail-closed pre-release shield so unstable builds cannot be promoted before health, test, and artifact gates have passed.

Closes #560

## Type of Change

- [x] CI/CD change
- [x] Documentation update

## Changes Made

- add a reusable release shield with version validation, readiness probes, exact-commit workflow evidence, and locked backend/frontend/contract artifact builds
- gate both release and release dry-run workflows, remove the ignored frontend image failure, and fix version tagging for manual releases
- add an authorized, reason-required manual override with an auditable GitHub Actions summary
- document repository variables, shield decisions, and emergency override behavior

## Testing

- [x] Changed workflows pass `actionlint`
- [x] Workflow YAML parses successfully
- [x] Backend artifact build passes locally
- [x] `git diff --check` passes
- [ ] Frontend artifact build passes locally — currently blocked by the pre-existing unused `ci` variable at `frontend/src/pages/DataProvenanceGraph.tsx:597` on upstream `main`; the new shield correctly reports this as a blocking artifact failure
- [ ] Contract WASM build reproduced locally — Rust is not installed in the development container; the shield installs the required target on the GitHub runner

## Migration Changes

- [x] No database migrations in this PR

## Documentation

- [x] Relevant `docs/` file updated
- [x] Workflow README updated

## Additional Notes

Configure `RELEASE_HEALTH_URLS` before promotion. `RELEASE_REQUIRED_WORKFLOWS` is optional and defaults to `CI,Code Quality,Security Scanning`.
