### PR TITLE
feat: add bridge health timeline, export scheduler, asset comparison …

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,6 +31,10 @@ const DataProvenanceGraph = lazy(() => import("./pages/DataProvenanceGraph"));
 const AlertSimulationSandbox = lazy(() => import("./pages/AlertSimulationSandbox"));
 const LiquidityFragmentation = lazy(() => import("./pages/LiquidityFragmentation"));
 const OperationalAccessAudit = lazy(() => import("./pages/OperationalAccessAudit"));
+const BridgeHealthTimeline = lazy(() => import("./pages/BridgeHealthTimeline"));
+const ExportScheduler = lazy(() => import("./pages/ExportScheduler"));
+const AssetComparison = lazy(() => import("./pages/AssetComparison"));
+const MetricsSidebarPage = lazy(() => import("./pages/MetricsSidebar"));
 
 function NotificationInitializer() {
   useNotifications();
@@ -78,6 +82,10 @@ function App() {
               <Route path="/data-provenance" element={<DataProvenanceGraph />} />
               <Route path="/alert-sandbox" element={<AlertSimulationSandbox />} />
               <Route path="/liquidity-fragmentation" element={<LiquidityFragmentation />} />
+              <Route path="/bridge-health-timeline" element={<BridgeHealthTimeline />} />
+              <Route path="/export-scheduler" element={<ExportScheduler />} />
+              <Route path="/asset-comparison" element={<AssetComparison />} />
+              <Route path="/metrics-sidebar" element={<MetricsSidebarPage />} />
             </Route>
           </Routes>
         </Suspense>

--- a/frontend/src/components/AssetComparison/AssetComparisonMatrix.tsx
+++ b/frontend/src/components/AssetComparison/AssetComparisonMatrix.tsx
@@ -1,0 +1,275 @@
+import { useState, useMemo, useCallback } from "react";
+import type { AssetWithHealth } from "../../types";
+
+type SortDir = "asc" | "desc";
+type ColId =
+  | "symbol"
+  | "health"
+  | "liquidityDepth"
+  | "priceStability"
+  | "bridgeUptime"
+  | "reserveBacking"
+  | "volumeTrend"
+  | "trend";
+
+interface Column {
+  id: ColId;
+  label: string;
+  hint: string;
+}
+
+const COLUMNS: Column[] = [
+  { id: "symbol", label: "Asset", hint: "Asset code" },
+  { id: "health", label: "Health", hint: "Overall health score (0–100)" },
+  { id: "liquidityDepth", label: "Liquidity", hint: "Liquidity depth score" },
+  { id: "priceStability", label: "Price Stab.", hint: "Price stability score" },
+  { id: "bridgeUptime", label: "Uptime", hint: "Bridge uptime score" },
+  { id: "reserveBacking", label: "Reserves", hint: "Reserve backing score" },
+  { id: "volumeTrend", label: "Volume", hint: "Volume trend score" },
+  { id: "trend", label: "Trend", hint: "Overall trend direction" },
+];
+
+function scoreColor(score: number | null): string {
+  if (score === null) return "text-stellar-text-secondary";
+  if (score >= 80) return "text-green-400";
+  if (score >= 50) return "text-yellow-400";
+  return "text-red-400";
+}
+
+function trendIcon(trend: string | undefined): string {
+  if (!trend) return "—";
+  if (trend === "improving") return "↑";
+  if (trend === "deteriorating") return "↓";
+  return "→";
+}
+
+function trendColor(trend: string | undefined): string {
+  if (!trend) return "text-stellar-text-secondary";
+  if (trend === "improving") return "text-green-400";
+  if (trend === "deteriorating") return "text-red-400";
+  return "text-yellow-400";
+}
+
+function getValue(asset: AssetWithHealth, col: ColId): number | string | null {
+  if (col === "symbol") return asset.symbol;
+  if (col === "trend") return asset.health?.trend ?? null;
+  if (col === "health") return asset.health?.overallScore ?? null;
+  return asset.health?.factors[col as keyof typeof asset.health.factors] ?? null;
+}
+
+function exportCsv(assets: AssetWithHealth[]) {
+  const header = COLUMNS.map((c) => c.label).join(",");
+  const rows = assets.map((a) =>
+    COLUMNS.map((c) => {
+      const v = getValue(a, c.id);
+      return v === null ? "" : String(v);
+    }).join(",")
+  );
+  const csv = [header, ...rows].join("\n");
+  const blob = new Blob([csv], { type: "text/csv" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = "asset-comparison.csv";
+  link.click();
+  URL.revokeObjectURL(url);
+}
+
+interface Props {
+  assets: AssetWithHealth[];
+  filter: string;
+}
+
+export default function AssetComparisonMatrix({ assets, filter }: Props) {
+  const [sortCol, setSortCol] = useState<ColId>("health");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
+  const [visibleCols, setVisibleCols] = useState<Set<ColId>>(
+    new Set(COLUMNS.map((c) => c.id))
+  );
+
+  const toggleCol = useCallback((id: ColId) => {
+    setVisibleCols((prev) => {
+      const next = new Set(prev);
+      if (next.has(id) && next.size > 2) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleSort = useCallback(
+    (id: ColId) => {
+      if (sortCol === id) {
+        setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+      } else {
+        setSortCol(id);
+        setSortDir("desc");
+      }
+    },
+    [sortCol]
+  );
+
+  const sorted = useMemo(() => {
+    const filtered = filter
+      ? assets.filter(
+          (a) =>
+            a.symbol.toLowerCase().includes(filter.toLowerCase()) ||
+            a.name.toLowerCase().includes(filter.toLowerCase())
+        )
+      : assets;
+
+    return [...filtered].sort((a, b) => {
+      const va = getValue(a, sortCol);
+      const vb = getValue(b, sortCol);
+
+      if (va === null && vb === null) return 0;
+      if (va === null) return 1;
+      if (vb === null) return -1;
+
+      if (typeof va === "string" && typeof vb === "string") {
+        return sortDir === "asc" ? va.localeCompare(vb) : vb.localeCompare(va);
+      }
+      const na = Number(va);
+      const nb = Number(vb);
+      return sortDir === "asc" ? na - nb : nb - na;
+    });
+  }, [assets, filter, sortCol, sortDir]);
+
+  const visibleColumns = COLUMNS.filter((c) => visibleCols.has(c.id));
+
+  if (assets.length === 0) {
+    return (
+      <div className="text-center py-12 text-stellar-text-secondary text-sm">
+        Select assets above to see the comparison matrix.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {/* Column visibility + export */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-wrap items-center gap-1">
+          <span className="text-xs text-stellar-text-secondary mr-1">Columns:</span>
+          {COLUMNS.slice(1).map((col) => (
+            <button
+              key={col.id}
+              type="button"
+              onClick={() => toggleCol(col.id)}
+              aria-pressed={visibleCols.has(col.id)}
+              title={col.hint}
+              className={`rounded px-2 py-0.5 text-xs transition-colors focus:outline-none ${
+                visibleCols.has(col.id)
+                  ? "bg-stellar-blue/20 text-stellar-blue border border-stellar-blue/40"
+                  : "border border-stellar-border text-stellar-text-muted"
+              }`}
+            >
+              {col.label}
+            </button>
+          ))}
+        </div>
+        <button
+          type="button"
+          onClick={() => exportCsv(sorted)}
+          className="flex items-center gap-1.5 rounded border border-stellar-border px-3 py-1.5 text-xs text-stellar-text-secondary hover:text-white transition-colors"
+        >
+          <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+          </svg>
+          Export CSV
+        </button>
+      </div>
+
+      {/* Table */}
+      <div className="overflow-x-auto rounded-lg border border-stellar-border">
+        <table className="w-full text-sm" aria-label="Asset comparison matrix">
+          <thead>
+            <tr className="border-b border-stellar-border bg-stellar-dark">
+              {visibleColumns.map((col) => (
+                <th
+                  key={col.id}
+                  scope="col"
+                  className="px-4 py-3 text-left"
+                >
+                  <button
+                    type="button"
+                    onClick={() => handleSort(col.id)}
+                    className="flex items-center gap-1 text-xs font-semibold uppercase tracking-wide text-stellar-text-secondary hover:text-white transition-colors focus:outline-none"
+                    title={col.hint}
+                    aria-sort={
+                      sortCol === col.id
+                        ? sortDir === "asc"
+                          ? "ascending"
+                          : "descending"
+                        : "none"
+                    }
+                  >
+                    {col.label}
+                    {sortCol === col.id && (
+                      <span className="text-stellar-blue">{sortDir === "asc" ? "↑" : "↓"}</span>
+                    )}
+                  </button>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map((asset) => (
+              <tr
+                key={asset.symbol}
+                className="border-b border-stellar-border/50 hover:bg-stellar-dark/40 transition-colors"
+              >
+                {visibleColumns.map((col) => {
+                  if (col.id === "symbol") {
+                    return (
+                      <td key={col.id} className="px-4 py-3">
+                        <span className="font-mono font-semibold text-white">{asset.symbol}</span>
+                        <br />
+                        <span className="text-xs text-stellar-text-secondary">{asset.name}</span>
+                      </td>
+                    );
+                  }
+                  if (col.id === "trend") {
+                    const trend = asset.health?.trend;
+                    return (
+                      <td key={col.id} className="px-4 py-3">
+                        <span className={`font-medium ${trendColor(trend)}`}>
+                          {trendIcon(trend)} {trend ?? "—"}
+                        </span>
+                      </td>
+                    );
+                  }
+                  const val = getValue(asset, col.id) as number | null;
+                  return (
+                    <td key={col.id} className="px-4 py-3">
+                      <span className={`font-semibold ${scoreColor(val)}`}>
+                        {val !== null ? val : "—"}
+                      </span>
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+
+            {sorted.length === 0 && (
+              <tr>
+                <td
+                  colSpan={visibleColumns.length}
+                  className="px-4 py-8 text-center text-stellar-text-secondary"
+                >
+                  No assets match your filter.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <p className="text-xs text-stellar-text-muted text-right">
+        {sorted.length} asset{sorted.length !== 1 ? "s" : ""} · scores 0–100
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/AssetComparison/AssetSelector.tsx
+++ b/frontend/src/components/AssetComparison/AssetSelector.tsx
@@ -1,0 +1,53 @@
+import type { AssetWithHealth } from "../../types";
+
+interface Props {
+  assets: AssetWithHealth[];
+  selected: string[];
+  max: number;
+  onToggle: (symbol: string) => void;
+  isLoading: boolean;
+}
+
+export default function AssetSelector({ assets, selected, max, onToggle, isLoading }: Props) {
+  if (isLoading) {
+    return (
+      <div className="flex flex-wrap gap-2">
+        {[...Array(6)].map((_, i) => (
+          <div key={i} className="h-8 w-16 bg-stellar-border/30 rounded animate-pulse" />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <p className="text-xs text-stellar-text-secondary mb-2">
+        Select up to {max} assets to compare. {selected.length}/{max} selected.
+      </p>
+      <div className="flex flex-wrap gap-2" role="group" aria-label="Asset selection">
+        {assets.map((a) => {
+          const isSelected = selected.includes(a.symbol);
+          const isDisabled = !isSelected && selected.length >= max;
+          return (
+            <button
+              key={a.symbol}
+              type="button"
+              onClick={() => onToggle(a.symbol)}
+              disabled={isDisabled}
+              aria-pressed={isSelected}
+              className={`rounded-full px-3 py-1 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-stellar-blue ${
+                isSelected
+                  ? "bg-stellar-blue text-white"
+                  : isDisabled
+                    ? "border border-stellar-border text-stellar-text-muted opacity-50 cursor-not-allowed"
+                    : "border border-stellar-border text-stellar-text-secondary hover:text-white hover:border-stellar-blue/50"
+              }`}
+            >
+              {a.symbol}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/AssetComparison/index.ts
+++ b/frontend/src/components/AssetComparison/index.ts
@@ -1,0 +1,2 @@
+export { default as AssetSelector } from "./AssetSelector";
+export { default as AssetComparisonMatrix } from "./AssetComparisonMatrix";

--- a/frontend/src/components/BridgeHealthTimeline/AnnotationList.tsx
+++ b/frontend/src/components/BridgeHealthTimeline/AnnotationList.tsx
@@ -1,0 +1,51 @@
+import type { BridgeHealthPoint } from "../../services/api";
+
+interface Props {
+  points: BridgeHealthPoint[];
+}
+
+function formatTime(iso: string) {
+  return new Date(iso).toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function scoreColor(score: number) {
+  if (score >= 80) return "text-green-400";
+  if (score >= 50) return "text-yellow-400";
+  return "text-red-400";
+}
+
+export default function AnnotationList({ points }: Props) {
+  const annotated = points.filter((p) => p.annotation);
+
+  if (annotated.length === 0) {
+    return (
+      <p className="text-stellar-text-secondary text-sm py-2">
+        No significant health changes detected in this period.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="space-y-2" aria-label="Health change annotations">
+      {annotated.map((p, i) => (
+        <li
+          key={i}
+          className="flex items-start gap-3 text-sm border-l-2 border-yellow-500/60 pl-3"
+        >
+          <div className="flex-1 min-w-0">
+            <p className="text-white">{p.annotation}</p>
+            <p className="text-stellar-text-secondary text-xs">{formatTime(p.timestamp)}</p>
+          </div>
+          <span className={`font-semibold shrink-0 ${scoreColor(p.score)}`}>
+            {p.score}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/frontend/src/components/BridgeHealthTimeline/HealthTimelineChart.tsx
+++ b/frontend/src/components/BridgeHealthTimeline/HealthTimelineChart.tsx
@@ -1,0 +1,153 @@
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ReferenceLine,
+  ReferenceDot,
+  ResponsiveContainer,
+} from "recharts";
+import type { BridgeHealthPoint } from "../../services/api";
+import type { HealthPeriod } from "../../hooks/useBridgeHealthTimeline";
+
+interface Props {
+  points: BridgeHealthPoint[];
+  period: HealthPeriod;
+  bridgeName: string;
+  isMockData: boolean;
+}
+
+function formatXAxis(timestamp: string, period: HealthPeriod): string {
+  const d = new Date(timestamp);
+  if (period === "24h") {
+    return d.toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", hour12: false });
+  }
+  if (period === "7d") {
+    return d.toLocaleDateString("en-US", { weekday: "short" }) + " " +
+      d.toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", hour12: false });
+  }
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+function scoreColor(score: number): string {
+  if (score >= 80) return "#22c55e";
+  if (score >= 50) return "#eab308";
+  return "#ef4444";
+}
+
+const CustomTooltip = ({
+  active,
+  payload,
+  label,
+  period,
+}: {
+  active?: boolean;
+  payload?: Array<{ value: number; payload: BridgeHealthPoint }>;
+  label?: string;
+  period: HealthPeriod;
+}) => {
+  if (!active || !payload?.length) return null;
+  const point = payload[0]?.payload;
+  const score = payload[0]?.value ?? 0;
+  return (
+    <div className="bg-stellar-card border border-stellar-border rounded-lg p-3 text-xs shadow-xl min-w-[160px]">
+      <p className="text-stellar-text-secondary mb-1">
+        {label ? formatXAxis(label, period) : ""}
+      </p>
+      <p className="text-white font-semibold text-base" style={{ color: scoreColor(score) }}>
+        {score}
+        <span className="text-stellar-text-secondary font-normal ml-1">/ 100</span>
+      </p>
+      {point?.annotation && (
+        <p className="mt-1 text-yellow-400 flex items-center gap-1">
+          <span>&#9679;</span> {point.annotation}
+        </p>
+      )}
+      <p className="mt-1 text-stellar-text-secondary">
+        {score >= 80 ? "Healthy" : score >= 50 ? "Warning" : "Critical"}
+      </p>
+    </div>
+  );
+};
+
+export default function HealthTimelineChart({ points, period, bridgeName, isMockData }: Props) {
+  if (points.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-64 text-stellar-text-secondary text-sm">
+        No health history available for {bridgeName}
+      </div>
+    );
+  }
+
+  const annotations = points.filter((p) => p.annotation);
+
+  const tickInterval = Math.max(1, Math.floor(points.length / 6));
+
+  return (
+    <div className="relative">
+      {isMockData && (
+        <div className="absolute top-0 right-0 z-10 text-xs text-stellar-text-muted bg-stellar-dark/80 rounded px-2 py-1">
+          Demo data
+        </div>
+      )}
+      <ResponsiveContainer width="100%" height={300}>
+        <AreaChart data={points} margin={{ top: 10, right: 16, left: 0, bottom: 0 }}>
+          <defs>
+            <linearGradient id="healthGradient" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="5%" stopColor="#0057FF" stopOpacity={0.3} />
+              <stop offset="95%" stopColor="#0057FF" stopOpacity={0.02} />
+            </linearGradient>
+          </defs>
+
+          <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.06)" vertical={false} />
+
+          <XAxis
+            dataKey="timestamp"
+            tickFormatter={(v) => formatXAxis(v, period)}
+            interval={tickInterval}
+            tick={{ fill: "#8A8FA8", fontSize: 11 }}
+            axisLine={false}
+            tickLine={false}
+          />
+          <YAxis
+            domain={[0, 100]}
+            ticks={[0, 25, 50, 75, 100]}
+            tick={{ fill: "#8A8FA8", fontSize: 11 }}
+            axisLine={false}
+            tickLine={false}
+            width={32}
+          />
+
+          <Tooltip content={<CustomTooltip period={period} />} />
+
+          <ReferenceLine y={80} stroke="#22c55e" strokeDasharray="4 4" strokeOpacity={0.5} label={{ value: "Healthy", fill: "#22c55e", fontSize: 10, position: "insideTopRight" }} />
+          <ReferenceLine y={50} stroke="#eab308" strokeDasharray="4 4" strokeOpacity={0.5} label={{ value: "Warning", fill: "#eab308", fontSize: 10, position: "insideTopRight" }} />
+
+          <Area
+            type="monotone"
+            dataKey="score"
+            stroke="#0057FF"
+            strokeWidth={2}
+            fill="url(#healthGradient)"
+            dot={false}
+            activeDot={{ r: 4, fill: "#0057FF", stroke: "#fff", strokeWidth: 1.5 }}
+          />
+
+          {annotations.map((point, i) => (
+            <ReferenceDot
+              key={i}
+              x={point.timestamp}
+              y={point.score}
+              r={5}
+              fill="#f59e0b"
+              stroke="#0057FF"
+              strokeWidth={1.5}
+            />
+          ))}
+        </AreaChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/frontend/src/components/BridgeHealthTimeline/index.ts
+++ b/frontend/src/components/BridgeHealthTimeline/index.ts
@@ -1,0 +1,2 @@
+export { default as HealthTimelineChart } from "./HealthTimelineChart";
+export { default as AnnotationList } from "./AnnotationList";

--- a/frontend/src/components/ExportScheduler/ScheduleForm.tsx
+++ b/frontend/src/components/ExportScheduler/ScheduleForm.tsx
@@ -1,0 +1,315 @@
+import { useState, type FormEvent } from "react";
+import { useExportSchedulerStore } from "../../stores/exportSchedulerStore";
+import type { CreateScheduledExportRequest } from "../../services/api";
+
+const FREQUENCIES = [
+  { id: "daily" as const, label: "Daily" },
+  { id: "weekly" as const, label: "Weekly" },
+  { id: "monthly" as const, label: "Monthly" },
+];
+
+const DAYS_OF_WEEK = [
+  { value: 1, label: "Monday" },
+  { value: 2, label: "Tuesday" },
+  { value: 3, label: "Wednesday" },
+  { value: 4, label: "Thursday" },
+  { value: 5, label: "Friday" },
+  { value: 6, label: "Saturday" },
+  { value: 0, label: "Sunday" },
+];
+
+const DATA_TYPES = [
+  { id: "analytics" as const, label: "Analytics" },
+  { id: "transactions" as const, label: "Transactions" },
+  { id: "health_metrics" as const, label: "Health Metrics" },
+];
+
+const FORMATS = [
+  { id: "csv" as const, label: "CSV" },
+  { id: "json" as const, label: "JSON" },
+];
+
+const TIMEZONES: string[] = (() => {
+  try {
+    return (Intl as unknown as { supportedValuesOf: (key: string) => string[] }).supportedValuesOf("timeZone");
+  } catch {
+    return ["UTC", "America/New_York", "America/Chicago", "America/Los_Angeles", "Europe/London", "Europe/Paris", "Asia/Tokyo", "Asia/Singapore", "Australia/Sydney"];
+  }
+})();
+
+interface Props {
+  onCreated?: () => void;
+}
+
+const DEFAULT_FORM: CreateScheduledExportRequest = {
+  name: "",
+  format: "csv",
+  dataType: "analytics",
+  frequency: "daily",
+  dayOfWeek: 1,
+  dayOfMonth: 1,
+  timeOfDay: "08:00",
+  timezone: Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC",
+  deliveryMethod: "download",
+  emailAddress: "",
+  filters: {
+    startDate: "",
+    endDate: "",
+    assetCodes: [],
+    bridgeIds: [],
+  },
+};
+
+export default function ScheduleForm({ onCreated }: Props) {
+  const addSchedule = useExportSchedulerStore((s) => s.addSchedule);
+  const [form, setForm] = useState<CreateScheduledExportRequest>(DEFAULT_FORM);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [submitted, setSubmitted] = useState(false);
+
+  function validate(): boolean {
+    const errs: Record<string, string> = {};
+    if (!form.name.trim()) errs.name = "Name is required.";
+    if (form.deliveryMethod === "email" && !form.emailAddress?.trim()) {
+      errs.emailAddress = "Email address is required for email delivery.";
+    }
+    if (
+      form.deliveryMethod === "email" &&
+      form.emailAddress &&
+      !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.emailAddress)
+    ) {
+      errs.emailAddress = "Enter a valid email address.";
+    }
+    setErrors(errs);
+    return Object.keys(errs).length === 0;
+  }
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!validate()) return;
+    addSchedule(form);
+    setForm(DEFAULT_FORM);
+    setErrors({});
+    setSubmitted(true);
+    setTimeout(() => setSubmitted(false), 3000);
+    onCreated?.();
+  }
+
+  function set<K extends keyof CreateScheduledExportRequest>(
+    key: K,
+    value: CreateScheduledExportRequest[K]
+  ) {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  }
+
+  return (
+    <form onSubmit={handleSubmit} noValidate className="space-y-5" aria-label="Create export schedule">
+      {submitted && (
+        <div role="status" className="rounded-lg border border-green-700 bg-green-900/20 px-4 py-3 text-green-400 text-sm">
+          Schedule created successfully.
+        </div>
+      )}
+
+      {/* Name */}
+      <div>
+        <label htmlFor="sched-name" className="block text-sm font-medium text-stellar-text-secondary mb-1">
+          Schedule Name
+        </label>
+        <input
+          id="sched-name"
+          type="text"
+          value={form.name}
+          onChange={(e) => set("name", e.target.value)}
+          placeholder="Weekly analytics export"
+          className="w-full rounded-lg border border-stellar-border bg-stellar-dark px-3 py-2 text-sm text-white placeholder:text-stellar-text-muted focus:outline-none focus:ring-2 focus:ring-stellar-blue"
+          aria-required="true"
+          aria-invalid={!!errors.name}
+          aria-describedby={errors.name ? "sched-name-err" : undefined}
+        />
+        {errors.name && (
+          <p id="sched-name-err" className="mt-1 text-xs text-red-400" role="alert">{errors.name}</p>
+        )}
+      </div>
+
+      {/* Format + Data type row */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div>
+          <label htmlFor="sched-format" className="block text-sm font-medium text-stellar-text-secondary mb-1">
+            Format
+          </label>
+          <select
+            id="sched-format"
+            value={form.format}
+            onChange={(e) => set("format", e.target.value as "csv" | "json")}
+            className="w-full rounded-lg border border-stellar-border bg-stellar-dark px-3 py-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-stellar-blue"
+          >
+            {FORMATS.map((f) => (
+              <option key={f.id} value={f.id}>{f.label}</option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label htmlFor="sched-data-type" className="block text-sm font-medium text-stellar-text-secondary mb-1">
+            Data Type
+          </label>
+          <select
+            id="sched-data-type"
+            value={form.dataType}
+            onChange={(e) => set("dataType", e.target.value as typeof form.dataType)}
+            className="w-full rounded-lg border border-stellar-border bg-stellar-dark px-3 py-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-stellar-blue"
+          >
+            {DATA_TYPES.map((dt) => (
+              <option key={dt.id} value={dt.id}>{dt.label}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {/* Frequency */}
+      <div>
+        <p className="text-sm font-medium text-stellar-text-secondary mb-2">Frequency</p>
+        <div className="flex gap-2 flex-wrap" role="group" aria-label="Frequency">
+          {FREQUENCIES.map((f) => (
+            <button
+              key={f.id}
+              type="button"
+              onClick={() => set("frequency", f.id)}
+              aria-pressed={form.frequency === f.id}
+              className={`rounded px-4 py-2 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-stellar-blue ${
+                form.frequency === f.id
+                  ? "bg-stellar-blue text-white"
+                  : "border border-stellar-border text-stellar-text-secondary hover:text-white"
+              }`}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Conditional day selectors */}
+      {form.frequency === "weekly" && (
+        <div>
+          <label htmlFor="sched-dow" className="block text-sm font-medium text-stellar-text-secondary mb-1">
+            Day of Week
+          </label>
+          <select
+            id="sched-dow"
+            value={form.dayOfWeek}
+            onChange={(e) => set("dayOfWeek", Number(e.target.value))}
+            className="w-full max-w-xs rounded-lg border border-stellar-border bg-stellar-dark px-3 py-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-stellar-blue"
+          >
+            {DAYS_OF_WEEK.map((d) => (
+              <option key={d.value} value={d.value}>{d.label}</option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {form.frequency === "monthly" && (
+        <div>
+          <label htmlFor="sched-dom" className="block text-sm font-medium text-stellar-text-secondary mb-1">
+            Day of Month
+          </label>
+          <input
+            id="sched-dom"
+            type="number"
+            min={1}
+            max={28}
+            value={form.dayOfMonth}
+            onChange={(e) => set("dayOfMonth", Math.min(28, Math.max(1, Number(e.target.value))))}
+            className="w-24 rounded-lg border border-stellar-border bg-stellar-dark px-3 py-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-stellar-blue"
+          />
+          <p className="mt-1 text-xs text-stellar-text-muted">1–28 (safe for all months)</p>
+        </div>
+      )}
+
+      {/* Time + Timezone row */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div>
+          <label htmlFor="sched-time" className="block text-sm font-medium text-stellar-text-secondary mb-1">
+            Time of Day
+          </label>
+          <input
+            id="sched-time"
+            type="time"
+            value={form.timeOfDay}
+            onChange={(e) => set("timeOfDay", e.target.value)}
+            className="w-full rounded-lg border border-stellar-border bg-stellar-dark px-3 py-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-stellar-blue"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="sched-tz" className="block text-sm font-medium text-stellar-text-secondary mb-1">
+            Timezone
+          </label>
+          <select
+            id="sched-tz"
+            value={form.timezone}
+            onChange={(e) => set("timezone", e.target.value)}
+            className="w-full rounded-lg border border-stellar-border bg-stellar-dark px-3 py-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-stellar-blue"
+          >
+            {TIMEZONES.slice(0, 100).map((tz: string) => (
+              <option key={tz} value={tz}>{tz}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {/* Delivery method */}
+      <div>
+        <p className="text-sm font-medium text-stellar-text-secondary mb-2">Delivery</p>
+        <div className="flex gap-2">
+          {(["download", "email"] as const).map((method) => (
+            <button
+              key={method}
+              type="button"
+              onClick={() => set("deliveryMethod", method)}
+              aria-pressed={form.deliveryMethod === method}
+              className={`rounded px-4 py-2 text-sm font-medium capitalize transition-colors focus:outline-none focus:ring-2 focus:ring-stellar-blue ${
+                form.deliveryMethod === method
+                  ? "bg-stellar-blue text-white"
+                  : "border border-stellar-border text-stellar-text-secondary hover:text-white"
+              }`}
+            >
+              {method === "download" ? "In-app Download" : "Email"}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {form.deliveryMethod === "email" && (
+        <div>
+          <label htmlFor="sched-email" className="block text-sm font-medium text-stellar-text-secondary mb-1">
+            Email Address
+          </label>
+          <input
+            id="sched-email"
+            type="email"
+            value={form.emailAddress ?? ""}
+            onChange={(e) => set("emailAddress", e.target.value)}
+            placeholder="analyst@example.com"
+            className="w-full max-w-md rounded-lg border border-stellar-border bg-stellar-dark px-3 py-2 text-sm text-white placeholder:text-stellar-text-muted focus:outline-none focus:ring-2 focus:ring-stellar-blue"
+            aria-required="true"
+            aria-invalid={!!errors.emailAddress}
+            aria-describedby={errors.emailAddress ? "sched-email-err" : undefined}
+          />
+          {errors.emailAddress && (
+            <p id="sched-email-err" className="mt-1 text-xs text-red-400" role="alert">
+              {errors.emailAddress}
+            </p>
+          )}
+        </div>
+      )}
+
+      <div className="pt-2">
+        <button
+          type="submit"
+          className="rounded-lg bg-stellar-blue px-6 py-2.5 text-sm font-semibold text-white hover:bg-stellar-blue/90 transition-colors focus:outline-none focus:ring-2 focus:ring-stellar-blue"
+        >
+          Create Schedule
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/components/ExportScheduler/ScheduleList.tsx
+++ b/frontend/src/components/ExportScheduler/ScheduleList.tsx
@@ -1,0 +1,186 @@
+import { useState } from "react";
+import { useExportSchedulerStore } from "../../stores/exportSchedulerStore";
+import type { ScheduledExport } from "../../services/api";
+
+function formatNextRun(iso: string | null) {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleString("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+}
+
+function frequencyLabel(s: ScheduledExport): string {
+  if (s.frequency === "daily") return `Daily at ${s.timeOfDay}`;
+  if (s.frequency === "weekly") {
+    const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+    return `Weekly on ${days[s.dayOfWeek ?? 1]} at ${s.timeOfDay}`;
+  }
+  return `Monthly on day ${s.dayOfMonth ?? 1} at ${s.timeOfDay}`;
+}
+
+interface RowProps {
+  schedule: ScheduledExport;
+  onToggle: (id: string, active: boolean) => void;
+  onDelete: (id: string) => void;
+  onRunNow: (id: string) => void;
+}
+
+function ScheduleRow({ schedule: s, onToggle, onDelete, onRunNow }: RowProps) {
+  const [confirming, setConfirming] = useState(false);
+
+  return (
+    <div className="flex flex-col sm:flex-row sm:items-center gap-3 rounded-lg border border-stellar-border bg-stellar-dark p-4">
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 flex-wrap">
+          <p className="font-medium text-white truncate">{s.name}</p>
+          <span
+            className={`text-xs rounded-full px-2 py-0.5 font-medium ${
+              s.isActive
+                ? "bg-green-900/40 text-green-400"
+                : "bg-stellar-border text-stellar-text-secondary"
+            }`}
+          >
+            {s.isActive ? "Active" : "Paused"}
+          </span>
+        </div>
+        <p className="text-xs text-stellar-text-secondary mt-0.5">
+          {frequencyLabel(s)} · {s.format.toUpperCase()} · {s.dataType.replace("_", " ")} ·{" "}
+          {s.timezone}
+        </p>
+        <p className="text-xs text-stellar-text-secondary mt-0.5">
+          Delivery: {s.deliveryMethod === "email" ? `Email → ${s.emailAddress}` : "In-app download"}
+        </p>
+        <p className="text-xs text-stellar-text-muted mt-1">
+          Next run: {formatNextRun(s.nextRunAt)}
+          {s.lastRunAt && ` · Last ran: ${formatNextRun(s.lastRunAt)}`}
+        </p>
+      </div>
+
+      <div className="flex items-center gap-2 flex-shrink-0">
+        <button
+          type="button"
+          onClick={() => onRunNow(s.id)}
+          className="rounded border border-stellar-border px-3 py-1.5 text-xs text-stellar-text-secondary hover:text-white transition-colors"
+          title="Run now"
+        >
+          Run now
+        </button>
+
+        <button
+          type="button"
+          onClick={() => onToggle(s.id, !s.isActive)}
+          className={`rounded border px-3 py-1.5 text-xs transition-colors ${
+            s.isActive
+              ? "border-stellar-border text-stellar-text-secondary hover:text-yellow-400"
+              : "border-green-700 text-green-400 hover:text-green-300"
+          }`}
+          aria-label={s.isActive ? "Pause schedule" : "Activate schedule"}
+        >
+          {s.isActive ? "Pause" : "Activate"}
+        </button>
+
+        {confirming ? (
+          <>
+            <button
+              type="button"
+              onClick={() => onDelete(s.id)}
+              className="rounded border border-red-700 px-3 py-1.5 text-xs text-red-400 hover:text-red-300 transition-colors"
+            >
+              Confirm
+            </button>
+            <button
+              type="button"
+              onClick={() => setConfirming(false)}
+              className="rounded border border-stellar-border px-3 py-1.5 text-xs text-stellar-text-secondary hover:text-white transition-colors"
+            >
+              Cancel
+            </button>
+          </>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setConfirming(true)}
+            className="rounded border border-stellar-border px-3 py-1.5 text-xs text-stellar-text-secondary hover:text-red-400 transition-colors"
+            aria-label="Delete schedule"
+          >
+            Delete
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function ScheduleList() {
+  const schedules = useExportSchedulerStore((s) => s.schedules);
+  const updateSchedule = useExportSchedulerStore((s) => s.updateSchedule);
+  const removeSchedule = useExportSchedulerStore((s) => s.removeSchedule);
+  const recordRun = useExportSchedulerStore((s) => s.recordRun);
+
+  const [runFeedback, setRunFeedback] = useState<string | null>(null);
+
+  function handleRunNow(id: string) {
+    recordRun(id);
+    const name = schedules.find((s) => s.id === id)?.name ?? "Export";
+    setRunFeedback(`"${name}" queued for immediate export.`);
+    setTimeout(() => setRunFeedback(null), 4000);
+  }
+
+  if (schedules.length === 0) {
+    return (
+      <div className="rounded-lg border border-stellar-border p-8 text-center">
+        <svg
+          className="w-10 h-10 mx-auto mb-3 text-stellar-text-muted"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={1.5}
+            d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+          />
+        </svg>
+        <p className="text-white font-medium">No schedules yet</p>
+        <p className="text-stellar-text-secondary text-sm mt-1">
+          Create your first scheduled export using the form above.
+        </p>
+      </div>
+    );
+  }
+
+  const active = schedules.filter((s) => s.isActive);
+  const paused = schedules.filter((s) => !s.isActive);
+
+  return (
+    <div className="space-y-4">
+      {runFeedback && (
+        <div role="status" className="rounded-lg border border-green-700 bg-green-900/20 px-4 py-3 text-green-400 text-sm">
+          {runFeedback}
+        </div>
+      )}
+
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-stellar-text-secondary">
+          {schedules.length} schedule{schedules.length !== 1 ? "s" : ""} ·{" "}
+          <span className="text-green-400">{active.length} active</span>
+          {paused.length > 0 && ` · ${paused.length} paused`}
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        {schedules.map((s) => (
+          <ScheduleRow
+            key={s.id}
+            schedule={s}
+            onToggle={(id, isActive) => updateSchedule(id, { isActive })}
+            onDelete={removeSchedule}
+            onRunNow={handleRunNow}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ExportScheduler/index.ts
+++ b/frontend/src/components/ExportScheduler/index.ts
@@ -1,0 +1,2 @@
+export { default as ScheduleForm } from "./ScheduleForm";
+export { default as ScheduleList } from "./ScheduleList";

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -7,6 +7,8 @@ import ShortcutHelp from "./ShortcutHelp";
 import CommandPalette from "./CommandPalette";
 import MaintenanceBanner from "./MaintenanceBanner";
 import { useKeyboardShortcuts } from "../hooks/useKeyboardShortcuts";
+import { MetricsSidebar } from "./MetricsSidebar";
+import { useMetricsSidebarStore } from "../stores/metricsSidebarStore";
 
 export default function Layout() {
   const { pathname } = useLocation();
@@ -29,6 +31,11 @@ export default function Layout() {
 
   useKeyboardShortcuts({ onOpenHelp: openHelp, onOpenSearch: openSearch });
 
+  const sidebarPinnedCount = useMetricsSidebarStore((s) => s.pinned.length);
+  const isSidebarOpen = useMetricsSidebarStore((s) => s.isOpen);
+  const isSidebarCollapsed = useMetricsSidebarStore((s) => s.isCollapsed);
+  const sidebarWidth = sidebarPinnedCount > 0 && isSidebarOpen && !isSidebarCollapsed ? "pr-64" : sidebarPinnedCount > 0 && isSidebarOpen ? "pr-10" : "";
+
   return (
     <div className="min-h-screen bg-stellar-dark">
       <Navbar />
@@ -36,7 +43,7 @@ export default function Layout() {
       <main
         id="main-content"
         tabIndex={-1}
-        className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 focus:outline-none"
+        className={`max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 focus:outline-none transition-all duration-300 ${sidebarWidth}`}
       >
         {/* Command Palette */}
         <CommandPalette />
@@ -45,6 +52,8 @@ export default function Layout() {
           <Outlet />
         </ComponentErrorBoundary>
       </main>
+
+      {isSidebarOpen && sidebarPinnedCount > 0 && <MetricsSidebar />}
 
       <ShortcutHelp isOpen={shortcutHelpOpen} onClose={closeHelp} />
     </div>

--- a/frontend/src/components/MetricsSidebar/MetricsLibrary.tsx
+++ b/frontend/src/components/MetricsSidebar/MetricsLibrary.tsx
@@ -1,0 +1,86 @@
+import { AVAILABLE_METRICS } from "../../stores/metricsSidebarStore";
+import type { PinnedMetric } from "../../stores/metricsSidebarStore";
+
+type Category = "all" | "network" | "bridge" | "asset";
+
+interface Props {
+  pinned: PinnedMetric[];
+  onPin: (metric: Omit<PinnedMetric, "order">) => void;
+  onUnpin: (id: string) => void;
+  category: Category;
+  onCategoryChange: (c: Category) => void;
+}
+
+const CATEGORY_LABELS: { id: Category; label: string }[] = [
+  { id: "all", label: "All" },
+  { id: "network", label: "Network" },
+  { id: "bridge", label: "Bridge" },
+  { id: "asset", label: "Asset" },
+];
+
+export default function MetricsLibrary({
+  pinned,
+  onPin,
+  onUnpin,
+  category,
+  onCategoryChange,
+}: Props) {
+  const pinnedIds = new Set(pinned.map((p) => p.id));
+
+  const filtered = category === "all"
+    ? AVAILABLE_METRICS
+    : AVAILABLE_METRICS.filter((m) => m.category === category);
+
+  return (
+    <div className="space-y-3">
+      {/* Category tabs */}
+      <div className="flex gap-1 flex-wrap" role="group" aria-label="Filter by category">
+        {CATEGORY_LABELS.map((c) => (
+          <button
+            key={c.id}
+            type="button"
+            onClick={() => onCategoryChange(c.id)}
+            aria-pressed={category === c.id}
+            className={`rounded-full px-3 py-1 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-stellar-blue ${
+              category === c.id
+                ? "bg-stellar-blue text-white"
+                : "border border-stellar-border text-stellar-text-secondary hover:text-white"
+            }`}
+          >
+            {c.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Metrics grid */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+        {filtered.map((m) => {
+          const isPinned = pinnedIds.has(m.id);
+          return (
+            <div
+              key={m.id}
+              className="flex items-center justify-between rounded-lg border border-stellar-border bg-stellar-dark px-3 py-2.5"
+            >
+              <div className="min-w-0">
+                <p className="text-sm text-white truncate">{m.label}</p>
+                <p className="text-xs text-stellar-text-muted capitalize">{m.category}</p>
+              </div>
+              <button
+                type="button"
+                onClick={() => (isPinned ? onUnpin(m.id) : onPin(m))}
+                className={`ml-2 flex-shrink-0 rounded px-2.5 py-1 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-stellar-blue ${
+                  isPinned
+                    ? "border border-stellar-border text-stellar-text-secondary hover:text-red-400"
+                    : "bg-stellar-blue/20 border border-stellar-blue/40 text-stellar-blue hover:bg-stellar-blue/30"
+                }`}
+                aria-label={isPinned ? `Unpin ${m.label}` : `Pin ${m.label}`}
+              >
+                {isPinned ? "Unpin" : "Pin"}
+              </button>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/MetricsSidebar/MetricsSidebar.tsx
+++ b/frontend/src/components/MetricsSidebar/MetricsSidebar.tsx
@@ -1,0 +1,168 @@
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+  arrayMove,
+} from "@dnd-kit/sortable";
+import { useMetricsSidebarStore } from "../../stores/metricsSidebarStore";
+import PinnedMetricCard from "./PinnedMetricCard";
+import { useBridges } from "../../hooks/useBridges";
+import { useAssetsWithHealth } from "../../hooks/useAssets";
+
+function useLiveMetricValues() {
+  const { data: bridgesData } = useBridges({ refetchInterval: 30_000 });
+  const { data: assetsData } = useAssetsWithHealth({ refetchInterval: 30_000 });
+
+  const bridges = bridgesData?.bridges ?? [];
+  const assets = assetsData ?? [];
+
+  const healthyBridges = bridges.filter((b) => b.status === "healthy").length;
+  const avgHealthScore =
+    assets.length > 0
+      ? Math.round(
+          assets.reduce((sum, a) => sum + (a.health?.overallScore ?? 0), 0) / assets.length
+        )
+      : null;
+
+  const totalTvl = bridges.reduce((sum, b) => sum + b.totalValueLocked, 0);
+  const avgMismatch =
+    bridges.length > 0
+      ? (bridges.reduce((sum, b) => sum + b.mismatchPercentage, 0) / bridges.length).toFixed(2)
+      : null;
+
+  return {
+    "net-health-avg": {
+      value: avgHealthScore,
+      unit: "",
+      trend:
+        avgHealthScore !== null
+          ? avgHealthScore >= 75
+            ? ("up" as const)
+            : ("down" as const)
+          : undefined,
+    },
+    "net-bridges-total": { value: bridges.length, unit: "" },
+    "net-tvl-total": {
+      value: totalTvl > 0 ? `$${(totalTvl / 1_000_000).toFixed(1)}M` : "—",
+      unit: "",
+    },
+    "net-healthy-bridges": { value: healthyBridges, unit: "" },
+    "net-alerts-active": { value: null, unit: "" },
+    "net-assets-tracked": { value: assets.length, unit: "" },
+    "bridge-mismatch": { value: avgMismatch, unit: "%" },
+    "bridge-uptime": { value: null, unit: "%" },
+    "bridge-vol-24h": { value: null, unit: "" },
+    "asset-health-score": { value: avgHealthScore, unit: "" },
+    "asset-price-dev": { value: null, unit: "" },
+    "asset-liquidity": { value: null, unit: "" },
+  } as Record<string, { value: string | number | null; unit?: string; trend?: "up" | "down" | "flat" }>;
+}
+
+export default function MetricsSidebar() {
+  const { pinned, isCollapsed, unpinMetric, reorderMetrics, toggleCollapse } =
+    useMetricsSidebarStore();
+
+  const liveValues = useLiveMetricValues();
+
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = pinned.findIndex((p) => p.id === active.id);
+    const newIndex = pinned.findIndex((p) => p.id === over.id);
+    const reordered = arrayMove(pinned, oldIndex, newIndex);
+    reorderMetrics(reordered.map((p) => p.id));
+  }
+
+  if (pinned.length === 0) return null;
+
+  const sortedPinned = [...pinned].sort((a, b) => a.order - b.order);
+
+  return (
+    <aside
+      className={`fixed right-0 top-16 bottom-0 z-30 flex flex-col border-l border-stellar-border bg-stellar-card transition-all duration-300 shadow-2xl ${
+        isCollapsed ? "w-10" : "w-64"
+      }`}
+      aria-label="Pinned metrics sidebar"
+    >
+      {/* Toggle collapse */}
+      <button
+        type="button"
+        onClick={toggleCollapse}
+        className="flex items-center justify-center h-10 border-b border-stellar-border text-stellar-text-secondary hover:text-white transition-colors focus:outline-none"
+        aria-label={isCollapsed ? "Expand metrics sidebar" : "Collapse metrics sidebar"}
+        title={isCollapsed ? "Expand" : "Collapse"}
+      >
+        <svg
+          className={`w-4 h-4 transition-transform duration-300 ${isCollapsed ? "rotate-180" : ""}`}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+        </svg>
+      </button>
+
+      {!isCollapsed && (
+        <div className="flex-1 overflow-y-auto p-3 space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-widest text-stellar-text-secondary px-1 pb-1">
+            Pinned Metrics
+          </p>
+
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleDragEnd}
+          >
+            <SortableContext
+              items={sortedPinned.map((p) => p.id)}
+              strategy={verticalListSortingStrategy}
+            >
+              {sortedPinned.map((metric) => (
+                <PinnedMetricCard
+                  key={metric.id}
+                  metric={metric}
+                  liveValue={liveValues[metric.id]}
+                  onUnpin={unpinMetric}
+                />
+              ))}
+            </SortableContext>
+          </DndContext>
+
+          <p className="text-xs text-stellar-text-muted text-center pt-2">
+            Drag to reorder · Visit{" "}
+            <a href="/metrics-sidebar" className="text-stellar-blue hover:underline">
+              Metrics
+            </a>{" "}
+            to manage
+          </p>
+        </div>
+      )}
+
+      {isCollapsed && (
+        <div className="flex-1 flex flex-col items-center gap-3 pt-3">
+          {sortedPinned.slice(0, 5).map((_, i) => (
+            <div key={i} className="w-2 h-2 rounded-full bg-stellar-blue/60" />
+          ))}
+          {sortedPinned.length > 5 && (
+            <p className="text-xs text-stellar-text-muted">+{sortedPinned.length - 5}</p>
+          )}
+        </div>
+      )}
+    </aside>
+  );
+}

--- a/frontend/src/components/MetricsSidebar/PinnedMetricCard.tsx
+++ b/frontend/src/components/MetricsSidebar/PinnedMetricCard.tsx
@@ -1,0 +1,97 @@
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import type { PinnedMetric } from "../../stores/metricsSidebarStore";
+
+interface MetricValue {
+  value: string | number | null;
+  trend?: "up" | "down" | "flat";
+  unit?: string;
+}
+
+interface Props {
+  metric: PinnedMetric;
+  liveValue?: MetricValue;
+  onUnpin: (id: string) => void;
+}
+
+function trendArrow(trend?: "up" | "down" | "flat") {
+  if (trend === "up") return <span className="text-green-400 text-xs">↑</span>;
+  if (trend === "down") return <span className="text-red-400 text-xs">↓</span>;
+  return null;
+}
+
+export default function PinnedMetricCard({ metric, liveValue, onUnpin }: Props) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: metric.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  const val = liveValue?.value;
+  const displayVal = val !== null && val !== undefined ? String(val) : "—";
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`flex items-start gap-2 rounded-lg border border-stellar-border bg-stellar-dark p-3 group select-none ${
+        isDragging ? "shadow-xl ring-1 ring-stellar-blue/50" : ""
+      }`}
+    >
+      {/* Drag handle */}
+      <button
+        type="button"
+        className="flex-shrink-0 mt-0.5 cursor-grab active:cursor-grabbing text-stellar-text-muted hover:text-stellar-text-secondary p-0.5 rounded transition-colors focus:outline-none"
+        {...attributes}
+        {...listeners}
+        aria-label={`Drag to reorder ${metric.label}`}
+      >
+        <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20">
+          <circle cx="7" cy="6" r="1.5" />
+          <circle cx="13" cy="6" r="1.5" />
+          <circle cx="7" cy="10" r="1.5" />
+          <circle cx="13" cy="10" r="1.5" />
+          <circle cx="7" cy="14" r="1.5" />
+          <circle cx="13" cy="14" r="1.5" />
+        </svg>
+      </button>
+
+      {/* Content */}
+      <div className="flex-1 min-w-0">
+        <p className="text-xs text-stellar-text-secondary truncate">{metric.label}</p>
+        <div className="flex items-baseline gap-1 mt-0.5">
+          <p className="text-base font-semibold text-white truncate">
+            {displayVal}
+          </p>
+          {liveValue?.unit && (
+            <span className="text-xs text-stellar-text-muted">{liveValue.unit}</span>
+          )}
+          {trendArrow(liveValue?.trend)}
+        </div>
+        <p className="text-xs text-stellar-text-muted capitalize mt-0.5">{metric.category}</p>
+      </div>
+
+      {/* Unpin */}
+      <button
+        type="button"
+        onClick={() => onUnpin(metric.id)}
+        className="flex-shrink-0 opacity-0 group-hover:opacity-100 focus:opacity-100 text-stellar-text-muted hover:text-red-400 transition-all rounded p-0.5 focus:outline-none"
+        aria-label={`Unpin ${metric.label}`}
+        title="Unpin"
+      >
+        <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/MetricsSidebar/index.ts
+++ b/frontend/src/components/MetricsSidebar/index.ts
@@ -1,0 +1,3 @@
+export { default as MetricsSidebar } from "./MetricsSidebar";
+export { default as PinnedMetricCard } from "./PinnedMetricCard";
+export { default as MetricsLibrary } from "./MetricsLibrary";

--- a/frontend/src/components/MobileNav/navigation.ts
+++ b/frontend/src/components/MobileNav/navigation.ts
@@ -23,6 +23,8 @@ export const navGroups: NavGroup[] = [
       { to: "/data-provenance", label: "Provenance", description: "Trace metric lineage from source to destination" },
       { to: "/watchlist", label: "Watchlist", description: "Tracked assets and alerts" },
       { to: "/reports", label: "Reports", description: "Operational reporting views" },
+      { to: "/bridge-health-timeline", label: "Health Timeline", description: "Bridge health score progression over time" },
+      { to: "/asset-comparison", label: "Asset Matrix", description: "Compare multiple assets across key metrics" },
     ],
   },
   {
@@ -48,6 +50,8 @@ export const navGroups: NavGroup[] = [
         description: "Review operator roles, permissions, and access history",
       },
       { to: "/settings", label: "Settings", description: "Notification and dashboard preferences" },
+      { to: "/export-scheduler", label: "Export Scheduler", description: "Schedule recurring report exports" },
+      { to: "/metrics-sidebar", label: "Pinned Metrics", description: "Pin and manage frequently viewed metrics" },
     ],
   },
 ];

--- a/frontend/src/hooks/useBridgeHealthTimeline.ts
+++ b/frontend/src/hooks/useBridgeHealthTimeline.ts
@@ -1,0 +1,85 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useBridges } from "./useBridges";
+import { getBridgeHealthHistory } from "../services/api";
+import type { BridgeHealthPoint } from "../services/api";
+
+export type HealthPeriod = "24h" | "7d" | "30d";
+
+function seedRandom(seed: number) {
+  let s = seed;
+  return () => {
+    s = (s * 9301 + 49297) % 233280;
+    return s / 233280;
+  };
+}
+
+function generateMockHistory(
+  bridgeName: string,
+  period: HealthPeriod
+): BridgeHealthPoint[] {
+  const hash = bridgeName
+    .split("")
+    .reduce((acc, c) => acc + c.charCodeAt(0), 0);
+  const rand = seedRandom(hash);
+
+  const baseScore = 55 + Math.floor(rand() * 40);
+  const now = Date.now();
+
+  const configs: Record<HealthPeriod, { steps: number; stepMs: number }> = {
+    "24h": { steps: 24, stepMs: 60 * 60 * 1000 },
+    "7d": { steps: 42, stepMs: 4 * 60 * 60 * 1000 },
+    "30d": { steps: 30, stepMs: 24 * 60 * 60 * 1000 },
+  };
+
+  const { steps, stepMs } = configs[period];
+  const points: BridgeHealthPoint[] = [];
+  let score = baseScore;
+
+  for (let i = steps; i >= 0; i--) {
+    const delta = (rand() - 0.48) * 8;
+    score = Math.max(0, Math.min(100, score + delta));
+    const timestamp = new Date(now - i * stepMs).toISOString();
+
+    let annotation: string | undefined;
+    if (i > 0 && i < steps) {
+      const prev = points[points.length - 1]?.score ?? score;
+      if (Math.abs(score - prev) >= 10) {
+        annotation =
+          score > prev
+            ? "Health improved"
+            : "Health degraded";
+      }
+    }
+
+    points.push({ timestamp, score: Math.round(score), annotation });
+  }
+
+  return points;
+}
+
+export function useBridgeHealthTimeline(
+  bridgeName: string,
+  period: HealthPeriod = "7d"
+) {
+  const query = useQuery({
+    queryKey: ["bridge-health-history", bridgeName, period],
+    queryFn: () => getBridgeHealthHistory(bridgeName, period),
+    enabled: !!bridgeName,
+    retry: false,
+  });
+
+  const points = useMemo<BridgeHealthPoint[]>(() => {
+    if (query.data?.points?.length) return query.data.points;
+    if (bridgeName) return generateMockHistory(bridgeName, period);
+    return [];
+  }, [query.data, bridgeName, period]);
+
+  return {
+    ...query,
+    points,
+    isMockData: !query.data?.points?.length && bridgeName.length > 0,
+  };
+}
+
+export { useBridges };

--- a/frontend/src/pages/AssetComparison.tsx
+++ b/frontend/src/pages/AssetComparison.tsx
@@ -1,0 +1,148 @@
+import { useState, useMemo } from "react";
+import { useAssetsWithHealth } from "../hooks/useAssets";
+import { useLocalStorageState } from "../hooks/useLocalStorageState";
+import { AssetSelector, AssetComparisonMatrix } from "../components/AssetComparison";
+
+const MAX_COMPARE = 8;
+const STORAGE_KEY = "bridge-watch:asset-comparison:v1";
+
+export default function AssetComparison() {
+  const { data: allAssets = [], isLoading, error } = useAssetsWithHealth();
+  const [selected, setSelected] = useLocalStorageState<string[]>(STORAGE_KEY, []);
+  const [filter, setFilter] = useState("");
+
+  const selectedAssets = useMemo(
+    () => allAssets.filter((a) => selected.includes(a.symbol)),
+    [allAssets, selected]
+  );
+
+  function toggleAsset(symbol: string) {
+    setSelected((prev) => {
+      if (prev.includes(symbol)) return prev.filter((s) => s !== symbol);
+      if (prev.length >= MAX_COMPARE) return prev;
+      return [...prev, symbol];
+    });
+  }
+
+  function clearAll() {
+    setSelected([]);
+    setFilter("");
+  }
+
+  const avgHealth =
+    selectedAssets.length > 0
+      ? Math.round(
+          selectedAssets.reduce((sum, a) => sum + (a.health?.overallScore ?? 0), 0) /
+            selectedAssets.length
+        )
+      : null;
+
+  const best =
+    selectedAssets.length > 0
+      ? selectedAssets.reduce(
+          (prev, curr) =>
+            (curr.health?.overallScore ?? 0) > (prev.health?.overallScore ?? 0) ? curr : prev,
+          selectedAssets[0]
+        )
+      : null;
+
+  const worst =
+    selectedAssets.length > 0
+      ? selectedAssets.reduce(
+          (prev, curr) =>
+            (curr.health?.overallScore ?? 101) < (prev.health?.overallScore ?? 101) ? curr : prev,
+          selectedAssets[0]
+        )
+      : null;
+
+  return (
+    <div className="space-y-8">
+      <header>
+        <h1 className="text-3xl font-bold text-white">Asset Comparison Matrix</h1>
+        <p className="mt-2 text-stellar-text-secondary">
+          Select multiple assets and compare them side-by-side across all health metrics.
+        </p>
+      </header>
+
+      {/* Asset selection */}
+      <section className="bg-stellar-card border border-stellar-border rounded-lg p-6">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-semibold text-white">Select Assets</h2>
+          {selected.length > 0 && (
+            <button
+              type="button"
+              onClick={clearAll}
+              className="text-xs text-stellar-text-secondary hover:text-red-400 transition-colors"
+            >
+              Clear all
+            </button>
+          )}
+        </div>
+        {error ? (
+          <p className="text-red-400 text-sm">Failed to load assets. Please try again.</p>
+        ) : (
+          <AssetSelector
+            assets={allAssets}
+            selected={selected}
+            max={MAX_COMPARE}
+            onToggle={toggleAsset}
+            isLoading={isLoading}
+          />
+        )}
+      </section>
+
+      {/* Summary stats for selected assets */}
+      {selectedAssets.length > 0 && (
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <div className="bg-stellar-card border border-stellar-border rounded-lg p-4">
+            <p className="text-xs text-stellar-text-secondary uppercase tracking-wide">Assets Selected</p>
+            <p className="mt-1 text-2xl font-bold text-white">{selectedAssets.length}</p>
+          </div>
+          <div className="bg-stellar-card border border-stellar-border rounded-lg p-4">
+            <p className="text-xs text-stellar-text-secondary uppercase tracking-wide">Average Health</p>
+            <p
+              className={`mt-1 text-2xl font-bold ${
+                avgHealth !== null
+                  ? avgHealth >= 80
+                    ? "text-green-400"
+                    : avgHealth >= 50
+                      ? "text-yellow-400"
+                      : "text-red-400"
+                  : "text-white"
+              }`}
+            >
+              {avgHealth ?? "—"}
+            </p>
+          </div>
+          <div className="bg-stellar-card border border-stellar-border rounded-lg p-4">
+            <p className="text-xs text-stellar-text-secondary uppercase tracking-wide">Best / Worst</p>
+            <p className="mt-1 text-sm font-semibold text-white">
+              <span className="text-green-400">{best?.symbol ?? "—"}</span>
+              {" · "}
+              <span className="text-red-400">{worst?.symbol !== best?.symbol ? (worst?.symbol ?? "—") : "—"}</span>
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Filter + matrix */}
+      <section className="bg-stellar-card border border-stellar-border rounded-lg p-6">
+        <div className="flex flex-wrap items-center justify-between gap-3 mb-5">
+          <h2 className="text-lg font-semibold text-white">Comparison Matrix</h2>
+          {selectedAssets.length > 0 && (
+            <input
+              type="search"
+              value={filter}
+              onChange={(e) => setFilter(e.target.value)}
+              placeholder="Filter assets…"
+              className="rounded-lg border border-stellar-border bg-stellar-dark px-3 py-2 text-sm text-white placeholder:text-stellar-text-muted focus:outline-none focus:ring-2 focus:ring-stellar-blue w-full sm:w-56"
+              aria-label="Filter assets in matrix"
+            />
+          )}
+        </div>
+
+        <AssetComparisonMatrix assets={selectedAssets} filter={filter} />
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/BridgeHealthTimeline.tsx
+++ b/frontend/src/pages/BridgeHealthTimeline.tsx
@@ -1,0 +1,212 @@
+import { useState } from "react";
+import { useBridgeHealthTimeline, useBridges } from "../hooks/useBridgeHealthTimeline";
+import type { HealthPeriod } from "../hooks/useBridgeHealthTimeline";
+import { HealthTimelineChart, AnnotationList } from "../components/BridgeHealthTimeline";
+
+const PERIODS: { id: HealthPeriod; label: string }[] = [
+  { id: "24h", label: "24 Hours" },
+  { id: "7d", label: "7 Days" },
+  { id: "30d", label: "30 Days" },
+];
+
+function scoreColor(score: number) {
+  if (score >= 80) return "text-green-400";
+  if (score >= 50) return "text-yellow-400";
+  return "text-red-400";
+}
+
+function scoreLabel(score: number) {
+  if (score >= 80) return "Healthy";
+  if (score >= 50) return "Warning";
+  return "Critical";
+}
+
+export default function BridgeHealthTimeline() {
+  const { data: bridgesData, isLoading: bridgesLoading } = useBridges();
+  const bridges = bridgesData?.bridges ?? [];
+
+  const [selectedBridge, setSelectedBridge] = useState<string>("");
+  const [period, setPeriod] = useState<HealthPeriod>("7d");
+
+  const effectiveBridge = selectedBridge || bridges[0]?.name || "";
+
+  const { points, isLoading, isMockData } = useBridgeHealthTimeline(
+    effectiveBridge,
+    period
+  );
+
+  const latest = points[points.length - 1];
+  const earliest = points[0];
+  const avg = points.length
+    ? Math.round(points.reduce((sum, p) => sum + p.score, 0) / points.length)
+    : null;
+  const minScore = points.length ? Math.min(...points.map((p) => p.score)) : null;
+  const maxScore = points.length ? Math.max(...points.map((p) => p.score)) : null;
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <h1 className="text-3xl font-bold text-white">Bridge Health Timeline</h1>
+        <p className="mt-2 text-stellar-text-secondary">
+          Track health score progression for any bridge over a selected time period.
+        </p>
+      </header>
+
+      {/* Controls */}
+      <div className="flex flex-wrap gap-4 items-end">
+        <div className="flex-1 min-w-[200px] max-w-xs">
+          <label
+            htmlFor="bridge-select"
+            className="block text-sm font-medium text-stellar-text-secondary mb-1"
+          >
+            Bridge
+          </label>
+          <select
+            id="bridge-select"
+            value={selectedBridge || effectiveBridge}
+            onChange={(e) => setSelectedBridge(e.target.value)}
+            disabled={bridgesLoading}
+            className="w-full rounded-lg border border-stellar-border bg-stellar-card px-3 py-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-stellar-blue disabled:opacity-50"
+          >
+            {bridgesLoading && (
+              <option value="">Loading bridges…</option>
+            )}
+            {bridges.map((b) => (
+              <option key={b.name} value={b.name}>
+                {b.name}
+              </option>
+            ))}
+            {!bridgesLoading && bridges.length === 0 && (
+              <option value="demo-bridge">Demo Bridge</option>
+            )}
+          </select>
+        </div>
+
+        <div>
+          <p className="text-sm font-medium text-stellar-text-secondary mb-1">Time Period</p>
+          <div className="flex gap-1" role="group" aria-label="Time period">
+            {PERIODS.map((p) => (
+              <button
+                key={p.id}
+                type="button"
+                onClick={() => setPeriod(p.id)}
+                aria-pressed={period === p.id}
+                className={`rounded px-3 py-2 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-stellar-blue ${
+                  period === p.id
+                    ? "bg-stellar-blue text-white"
+                    : "border border-stellar-border text-stellar-text-secondary hover:text-white"
+                }`}
+              >
+                {p.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Summary stats */}
+      {points.length > 0 && (
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          {[
+            {
+              label: "Current Score",
+              value: latest?.score ?? "—",
+              colorFn: (v: number) => scoreColor(v),
+              sub: latest ? scoreLabel(latest.score) : "",
+            },
+            { label: "Average Score", value: avg ?? "—", colorFn: scoreColor, sub: "over period" },
+            { label: "Lowest", value: minScore ?? "—", colorFn: scoreColor, sub: "minimum" },
+            { label: "Highest", value: maxScore ?? "—", colorFn: scoreColor, sub: "maximum" },
+          ].map((stat) => (
+            <div
+              key={stat.label}
+              className="bg-stellar-card border border-stellar-border rounded-lg p-4"
+            >
+              <p className="text-xs text-stellar-text-secondary uppercase tracking-wide">{stat.label}</p>
+              <p
+                className={`mt-1 text-2xl font-bold ${
+                  typeof stat.value === "number" ? stat.colorFn(stat.value) : "text-white"
+                }`}
+              >
+                {stat.value}
+              </p>
+              {stat.sub && (
+                <p className="text-xs text-stellar-text-secondary mt-0.5">{stat.sub}</p>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Chart */}
+      <div className="bg-stellar-card border border-stellar-border rounded-lg p-6">
+        <div className="flex items-center justify-between mb-4">
+          <div>
+            <h2 className="text-lg font-semibold text-white">
+              {effectiveBridge || "Select a bridge"}
+            </h2>
+            <p className="text-xs text-stellar-text-secondary mt-0.5">
+              Health score · {period} period
+              {earliest && latest
+                ? ` · ${new Date(earliest.timestamp).toLocaleDateString()} – ${new Date(
+                    latest.timestamp
+                  ).toLocaleDateString()}`
+                : ""}
+            </p>
+          </div>
+
+          {isMockData && (
+            <span className="text-xs text-stellar-text-muted border border-stellar-border rounded px-2 py-1">
+              Demo data
+            </span>
+          )}
+        </div>
+
+        {isLoading ? (
+          <div className="h-[300px] bg-stellar-border/20 rounded animate-pulse" />
+        ) : (
+          <HealthTimelineChart
+            points={points}
+            period={period}
+            bridgeName={effectiveBridge}
+            isMockData={isMockData}
+          />
+        )}
+
+        {/* Legend */}
+        <div className="flex flex-wrap items-center gap-4 mt-4 pt-4 border-t border-stellar-border text-xs text-stellar-text-secondary">
+          <span className="flex items-center gap-1.5">
+            <span className="w-3 h-0.5 bg-green-400 block rounded" />
+            Healthy ≥ 80
+          </span>
+          <span className="flex items-center gap-1.5">
+            <span className="w-3 h-0.5 bg-yellow-400 block rounded" />
+            Warning 50–79
+          </span>
+          <span className="flex items-center gap-1.5">
+            <span className="w-3 h-0.5 bg-red-400 block rounded" />
+            Critical &lt; 50
+          </span>
+          <span className="flex items-center gap-1.5">
+            <span className="w-2 h-2 rounded-full bg-yellow-500 block" />
+            Annotation marker
+          </span>
+        </div>
+      </div>
+
+      {/* Annotations panel */}
+      <div className="bg-stellar-card border border-stellar-border rounded-lg p-6">
+        <h2 className="text-lg font-semibold text-white mb-3">Health Change Events</h2>
+        {isLoading ? (
+          <div className="space-y-2">
+            {[...Array(3)].map((_, i) => (
+              <div key={i} className="h-10 bg-stellar-border/20 rounded animate-pulse" />
+            ))}
+          </div>
+        ) : (
+          <AnnotationList points={points} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/ExportScheduler.tsx
+++ b/frontend/src/pages/ExportScheduler.tsx
@@ -1,0 +1,88 @@
+import { useState } from "react";
+import { ScheduleForm, ScheduleList } from "../components/ExportScheduler";
+
+export default function ExportScheduler() {
+  const [showForm, setShowForm] = useState(false);
+
+  return (
+    <div className="space-y-8">
+      <header className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold text-white">Export Scheduler</h1>
+          <p className="mt-2 text-stellar-text-secondary">
+            Schedule recurring report exports for delivery to email or in-app download.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setShowForm((v) => !v)}
+          className="rounded-lg bg-stellar-blue px-5 py-2.5 text-sm font-semibold text-white hover:bg-stellar-blue/90 transition-colors focus:outline-none focus:ring-2 focus:ring-stellar-blue"
+          aria-expanded={showForm}
+        >
+          {showForm ? "Cancel" : "+ New Schedule"}
+        </button>
+      </header>
+
+      {showForm && (
+        <section
+          className="bg-stellar-card border border-stellar-border rounded-lg p-6"
+          aria-label="New schedule form"
+        >
+          <h2 className="text-lg font-semibold text-white mb-5">Create Schedule</h2>
+          <ScheduleForm onCreated={() => setShowForm(false)} />
+        </section>
+      )}
+
+      <section aria-label="Scheduled exports">
+        <div className="flex items-center gap-3 mb-4">
+          <h2 className="text-lg font-semibold text-white">Scheduled Exports</h2>
+        </div>
+        <ScheduleList />
+      </section>
+
+      {/* Info panel */}
+      <section className="bg-stellar-card border border-stellar-border rounded-lg p-6">
+        <h2 className="text-lg font-semibold text-white mb-3">How it works</h2>
+        <div className="grid sm:grid-cols-3 gap-4 text-sm text-stellar-text-secondary">
+          {[
+            {
+              icon: (
+                <svg className="w-5 h-5 text-stellar-blue" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                </svg>
+              ),
+              title: "Set frequency",
+              body: "Choose daily, weekly, or monthly runs. Specify the exact time and timezone.",
+            },
+            {
+              icon: (
+                <svg className="w-5 h-5 text-stellar-blue" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                </svg>
+              ),
+              title: "Choose delivery",
+              body: "Send to an email address or keep it available as an in-app download.",
+            },
+            {
+              icon: (
+                <svg className="w-5 h-5 text-stellar-blue" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+                </svg>
+              ),
+              title: "Manage jobs",
+              body: "Pause, activate, run on demand, or delete any scheduled job at any time.",
+            },
+          ].map((item) => (
+            <div key={item.title} className="flex gap-3">
+              <div className="flex-shrink-0 mt-0.5">{item.icon}</div>
+              <div>
+                <p className="text-white font-medium">{item.title}</p>
+                <p className="mt-0.5">{item.body}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/MetricsSidebar.tsx
+++ b/frontend/src/pages/MetricsSidebar.tsx
@@ -1,0 +1,228 @@
+import { useState } from "react";
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+  arrayMove,
+} from "@dnd-kit/sortable";
+import {
+  useMetricsSidebarStore,
+  AVAILABLE_METRICS,
+} from "../stores/metricsSidebarStore";
+import PinnedMetricCard from "../components/MetricsSidebar/PinnedMetricCard";
+import MetricsLibrary from "../components/MetricsSidebar/MetricsLibrary";
+
+type Category = "all" | "network" | "bridge" | "asset";
+
+export default function MetricsSidebarPage() {
+  const {
+    pinned,
+    isOpen,
+    pinMetric,
+    unpinMetric,
+    reorderMetrics,
+    setOpen,
+  } = useMetricsSidebarStore();
+
+  const [libraryCategory, setLibraryCategory] = useState<Category>("all");
+
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const sortedPinned = [...pinned].sort((a, b) => a.order - b.order);
+    const oldIndex = sortedPinned.findIndex((p) => p.id === active.id);
+    const newIndex = sortedPinned.findIndex((p) => p.id === over.id);
+    const reordered = arrayMove(sortedPinned, oldIndex, newIndex);
+    reorderMetrics(reordered.map((p) => p.id));
+  }
+
+  const sortedPinned = [...pinned].sort((a, b) => a.order - b.order);
+
+  return (
+    <div className="space-y-8">
+      <header className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold text-white">Metrics Sidebar</h1>
+          <p className="mt-2 text-stellar-text-secondary">
+            Pin metrics to a persistent sidebar so they stay visible while you browse the dashboard.
+            Drag to reorder pinned metrics.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setOpen(!isOpen)}
+          className={`rounded-lg px-5 py-2.5 text-sm font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-stellar-blue ${
+            isOpen
+              ? "border border-stellar-border text-stellar-text-secondary hover:text-white"
+              : "bg-stellar-blue text-white hover:bg-stellar-blue/90"
+          }`}
+          aria-pressed={isOpen}
+        >
+          {isOpen ? "Hide Sidebar" : "Show Sidebar"}
+        </button>
+      </header>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* Pinned metrics */}
+        <section className="bg-stellar-card border border-stellar-border rounded-lg p-6">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-lg font-semibold text-white">
+              Pinned Metrics
+              {pinned.length > 0 && (
+                <span className="ml-2 text-sm font-normal text-stellar-text-secondary">
+                  ({pinned.length})
+                </span>
+              )}
+            </h2>
+            {pinned.length > 0 && (
+              <button
+                type="button"
+                onClick={() => pinned.forEach((p) => unpinMetric(p.id))}
+                className="text-xs text-stellar-text-secondary hover:text-red-400 transition-colors"
+              >
+                Unpin all
+              </button>
+            )}
+          </div>
+
+          {sortedPinned.length === 0 ? (
+            <div className="rounded-lg border border-stellar-border border-dashed p-8 text-center">
+              <svg
+                className="w-10 h-10 mx-auto mb-3 text-stellar-text-muted"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={1.5}
+                  d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"
+                />
+              </svg>
+              <p className="text-white font-medium">No metrics pinned</p>
+              <p className="text-stellar-text-secondary text-sm mt-1">
+                Choose metrics from the library on the right.
+              </p>
+            </div>
+          ) : (
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handleDragEnd}
+            >
+              <SortableContext
+                items={sortedPinned.map((p) => p.id)}
+                strategy={verticalListSortingStrategy}
+              >
+                <div className="space-y-2">
+                  {sortedPinned.map((metric) => (
+                    <PinnedMetricCard
+                      key={metric.id}
+                      metric={metric}
+                      onUnpin={unpinMetric}
+                    />
+                  ))}
+                </div>
+              </SortableContext>
+            </DndContext>
+          )}
+
+          {sortedPinned.length > 0 && (
+            <p className="mt-3 text-xs text-stellar-text-muted text-center">
+              Drag cards to reorder · hover to unpin
+            </p>
+          )}
+        </section>
+
+        {/* Metrics library */}
+        <section className="bg-stellar-card border border-stellar-border rounded-lg p-6">
+          <h2 className="text-lg font-semibold text-white mb-4">Metrics Library</h2>
+          <MetricsLibrary
+            pinned={pinned}
+            onPin={pinMetric}
+            onUnpin={unpinMetric}
+            category={libraryCategory}
+            onCategoryChange={setLibraryCategory}
+          />
+        </section>
+      </div>
+
+      {/* Sidebar behaviour info */}
+      <section className="bg-stellar-card border border-stellar-border rounded-lg p-6">
+        <h2 className="text-lg font-semibold text-white mb-4">Sidebar Behaviour</h2>
+        <div className="grid sm:grid-cols-3 gap-4 text-sm text-stellar-text-secondary">
+          {[
+            {
+              title: "Persistent",
+              body: "Pinned metrics stay visible in the sidebar as you navigate between pages.",
+            },
+            {
+              title: "Collapsible",
+              body: "Use the collapse button on the sidebar to hide it when you need more screen space.",
+            },
+            {
+              title: "Mobile",
+              body: "On small screens the sidebar is hidden by default. Toggle via the Show Sidebar button.",
+            },
+          ].map((item) => (
+            <div key={item.title} className="flex gap-3">
+              <div className="flex-shrink-0 mt-0.5">
+                <span className="w-5 h-5 rounded-full bg-stellar-blue/20 text-stellar-blue flex items-center justify-center text-xs font-bold">
+                  ✓
+                </span>
+              </div>
+              <div>
+                <p className="text-white font-medium">{item.title}</p>
+                <p className="mt-0.5">{item.body}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Quick-pin from available list */}
+      <section className="bg-stellar-card border border-stellar-border rounded-lg p-6">
+        <h2 className="text-lg font-semibold text-white mb-1">All Available Metrics</h2>
+        <p className="text-sm text-stellar-text-secondary mb-4">
+          {AVAILABLE_METRICS.length} metrics available across network, bridge, and asset categories.
+        </p>
+        <div className="flex flex-wrap gap-2">
+          {AVAILABLE_METRICS.map((m) => {
+            const isPinned = pinned.some((p) => p.id === m.id);
+            return (
+              <button
+                key={m.id}
+                type="button"
+                onClick={() => (isPinned ? unpinMetric(m.id) : pinMetric(m))}
+                aria-pressed={isPinned}
+                className={`rounded-full px-3 py-1 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-stellar-blue ${
+                  isPinned
+                    ? "bg-stellar-blue text-white"
+                    : "border border-stellar-border text-stellar-text-secondary hover:text-white hover:border-stellar-blue/50"
+                }`}
+              >
+                {m.label}
+              </button>
+            );
+          })}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -708,3 +708,90 @@ export function getProvenanceLineage(
   if (bridge) params.set("bridge", bridge);
   return fetchApi<ProvenanceGraph>(`/provenance/lineage?${params.toString()}`);
 }
+
+export interface BridgeHealthPoint {
+  timestamp: string;
+  score: number;
+  annotation?: string;
+}
+
+export interface BridgeHealthHistoryResponse {
+  bridge: string;
+  period: "24h" | "7d" | "30d";
+  points: BridgeHealthPoint[];
+}
+
+export function getBridgeHealthHistory(
+  bridgeName: string,
+  period: "24h" | "7d" | "30d" = "7d"
+) {
+  return fetchApi<BridgeHealthHistoryResponse | null>(
+    `/bridges/${encodeURIComponent(bridgeName)}/health/history?period=${period}`
+  );
+}
+
+export interface ScheduledExport {
+  id: string;
+  name: string;
+  format: ExportFormat;
+  dataType: ExportDataType;
+  frequency: "daily" | "weekly" | "monthly";
+  dayOfWeek?: number;
+  dayOfMonth?: number;
+  timeOfDay: string;
+  timezone: string;
+  deliveryMethod: "email" | "download";
+  emailAddress?: string;
+  filters: ExportFilters;
+  isActive: boolean;
+  lastRunAt: string | null;
+  nextRunAt: string | null;
+  createdAt: string;
+}
+
+export interface CreateScheduledExportRequest {
+  name: string;
+  format: ExportFormat;
+  dataType: ExportDataType;
+  frequency: "daily" | "weekly" | "monthly";
+  dayOfWeek?: number;
+  dayOfMonth?: number;
+  timeOfDay: string;
+  timezone: string;
+  deliveryMethod: "email" | "download";
+  emailAddress?: string;
+  filters: ExportFilters;
+}
+
+export function listScheduledExports() {
+  return fetchApi<{ schedules: ScheduledExport[] }>("/exports/schedules");
+}
+
+export function createScheduledExport(payload: CreateScheduledExportRequest) {
+  return fetchApi<{ schedule: ScheduledExport }>("/exports/schedules", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+export function updateScheduledExport(
+  id: string,
+  payload: Partial<CreateScheduledExportRequest> & { isActive?: boolean }
+) {
+  return fetchApi<{ schedule: ScheduledExport }>(`/exports/schedules/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify(payload),
+  });
+}
+
+export function deleteScheduledExport(id: string) {
+  return fetchApi<Record<string, never>>(`/exports/schedules/${id}`, {
+    method: "DELETE",
+  });
+}
+
+export function runScheduledExportNow(id: string) {
+  return fetchApi<{ export: ExportRecord }>(`/exports/schedules/${id}/run`, {
+    method: "POST",
+  });
+}

--- a/frontend/src/stores/exportSchedulerStore.ts
+++ b/frontend/src/stores/exportSchedulerStore.ts
@@ -1,0 +1,131 @@
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+import type { ScheduledExport, CreateScheduledExportRequest } from "../services/api";
+
+function generateId() {
+  return `sched-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function computeNextRun(
+  frequency: "daily" | "weekly" | "monthly",
+  timeOfDay: string,
+  timezone: string,
+  dayOfWeek?: number,
+  dayOfMonth?: number
+): string {
+  try {
+    const [hours, minutes] = timeOfDay.split(":").map(Number);
+    const now = new Date();
+    const next = new Date(now);
+    next.setHours(hours, minutes, 0, 0);
+
+    if (frequency === "daily") {
+      if (next <= now) next.setDate(next.getDate() + 1);
+    } else if (frequency === "weekly") {
+      const targetDay = dayOfWeek ?? 1;
+      const diff = (targetDay - now.getDay() + 7) % 7 || 7;
+      next.setDate(now.getDate() + diff);
+    } else {
+      const targetDay = dayOfMonth ?? 1;
+      next.setDate(targetDay);
+      if (next <= now) next.setMonth(next.getMonth() + 1, targetDay);
+    }
+
+    void timezone;
+    return next.toISOString();
+  } catch {
+    return new Date(Date.now() + 86400000).toISOString();
+  }
+}
+
+interface ExportSchedulerState {
+  schedules: ScheduledExport[];
+  addSchedule: (req: CreateScheduledExportRequest) => ScheduledExport;
+  updateSchedule: (
+    id: string,
+    updates: Partial<CreateScheduledExportRequest> & { isActive?: boolean }
+  ) => void;
+  removeSchedule: (id: string) => void;
+  recordRun: (id: string) => void;
+}
+
+export const useExportSchedulerStore = create<ExportSchedulerState>()(
+  persist(
+    (set) => ({
+      schedules: [],
+
+      addSchedule(req) {
+        const now = new Date().toISOString();
+        const schedule: ScheduledExport = {
+          ...req,
+          id: generateId(),
+          isActive: true,
+          lastRunAt: null,
+          nextRunAt: computeNextRun(
+            req.frequency,
+            req.timeOfDay,
+            req.timezone,
+            req.dayOfWeek,
+            req.dayOfMonth
+          ),
+          createdAt: now,
+        };
+        set((s) => ({ schedules: [schedule, ...s.schedules] }));
+        return schedule;
+      },
+
+      updateSchedule(id, updates) {
+        set((s) => ({
+          schedules: s.schedules.map((sched) => {
+            if (sched.id !== id) return sched;
+            const merged = { ...sched, ...updates };
+            return {
+              ...merged,
+              nextRunAt: computeNextRun(
+                merged.frequency,
+                merged.timeOfDay,
+                merged.timezone,
+                merged.dayOfWeek,
+                merged.dayOfMonth
+              ),
+            };
+          }),
+        }));
+      },
+
+      removeSchedule(id) {
+        set((s) => ({
+          schedules: s.schedules.filter((sched) => sched.id !== id),
+        }));
+      },
+
+      recordRun(id) {
+        const now = new Date().toISOString();
+        set((s) => ({
+          schedules: s.schedules.map((sched) => {
+            if (sched.id !== id) return sched;
+            return {
+              ...sched,
+              lastRunAt: now,
+              nextRunAt: computeNextRun(
+                sched.frequency,
+                sched.timeOfDay,
+                sched.timezone,
+                sched.dayOfWeek,
+                sched.dayOfMonth
+              ),
+            };
+          }),
+        }));
+      },
+    }),
+    {
+      name: "bridge-watch:export-schedules",
+      storage: createJSONStorage(() => localStorage),
+    }
+  )
+);
+
+export function selectSchedules(s: ExportSchedulerState) {
+  return s.schedules;
+}

--- a/frontend/src/stores/metricsSidebarStore.ts
+++ b/frontend/src/stores/metricsSidebarStore.ts
@@ -1,0 +1,94 @@
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+
+export interface PinnedMetric {
+  id: string;
+  label: string;
+  category: "bridge" | "asset" | "network";
+  metricKey: string;
+  entityId?: string;
+  order: number;
+}
+
+interface MetricsSidebarState {
+  pinned: PinnedMetric[];
+  isOpen: boolean;
+  isCollapsed: boolean;
+  pinMetric: (metric: Omit<PinnedMetric, "order">) => void;
+  unpinMetric: (id: string) => void;
+  reorderMetrics: (orderedIds: string[]) => void;
+  toggleOpen: () => void;
+  toggleCollapse: () => void;
+  setOpen: (open: boolean) => void;
+}
+
+export const useMetricsSidebarStore = create<MetricsSidebarState>()(
+  persist(
+    (set) => ({
+      pinned: [],
+      isOpen: false,
+      isCollapsed: false,
+
+      pinMetric(metric) {
+        set((s) => {
+          if (s.pinned.find((p) => p.id === metric.id)) return s;
+          return {
+            pinned: [...s.pinned, { ...metric, order: s.pinned.length }],
+          };
+        });
+      },
+
+      unpinMetric(id) {
+        set((s) => ({
+          pinned: s.pinned
+            .filter((p) => p.id !== id)
+            .map((p, i) => ({ ...p, order: i })),
+        }));
+      },
+
+      reorderMetrics(orderedIds) {
+        set((s) => {
+          const map = new Map(s.pinned.map((p) => [p.id, p]));
+          const reordered = orderedIds
+            .map((id, i) => {
+              const m = map.get(id);
+              return m ? { ...m, order: i } : null;
+            })
+            .filter((m): m is PinnedMetric => m !== null);
+          return { pinned: reordered };
+        });
+      },
+
+      toggleOpen() {
+        set((s) => ({ isOpen: !s.isOpen }));
+      },
+
+      toggleCollapse() {
+        set((s) => ({ isCollapsed: !s.isCollapsed }));
+      },
+
+      setOpen(open) {
+        set({ isOpen: open });
+      },
+    }),
+    {
+      name: "bridge-watch:metrics-sidebar",
+      storage: createJSONStorage(() => localStorage),
+    }
+  )
+);
+
+export const AVAILABLE_METRICS: Omit<PinnedMetric, "order">[] = [
+  { id: "net-health-avg", label: "Avg Network Health", category: "network", metricKey: "avgHealthScore" },
+  { id: "net-bridges-total", label: "Total Bridges", category: "network", metricKey: "bridgeCount" },
+  { id: "net-tvl-total", label: "Total TVL", category: "network", metricKey: "totalTvl" },
+  { id: "net-healthy-bridges", label: "Healthy Bridges", category: "network", metricKey: "healthyBridges" },
+  { id: "net-alerts-active", label: "Active Alerts", category: "network", metricKey: "activeAlerts" },
+  { id: "net-assets-tracked", label: "Assets Tracked", category: "network", metricKey: "assetCount" },
+  { id: "bridge-uptime", label: "Bridge Uptime %", category: "bridge", metricKey: "uptime30d" },
+  { id: "bridge-mismatch", label: "Bridge Mismatch %", category: "bridge", metricKey: "mismatchPct" },
+  { id: "bridge-vol-24h", label: "Bridge Vol 24h", category: "bridge", metricKey: "volume24h" },
+  { id: "asset-health-score", label: "Asset Health Score", category: "asset", metricKey: "healthScore" },
+  { id: "asset-price-dev", label: "Price Deviation", category: "asset", metricKey: "priceDeviation" },
+  { id: "asset-liquidity", label: "Liquidity Depth", category: "asset", metricKey: "liquidityDepth" },
+];


### PR DESCRIPTION

Implements four new frontend features:

- Bridge Health Timeline (#627): interactive area chart showing health score progression over time for any bridge, with period selector (24h/7d/30d), annotation markers for significant health changes, hover tooltips, and summary statistics.

- Export Scheduler UI (#625): full scheduling interface for recurring report exports with frequency options (daily/weekly/monthly), timezone support via Intl API, email/download delivery, and a persistent Zustand-backed job list with pause/activate/run-now controls.

- Asset Comparison Matrix (#626): sortable, filterable side-by-side matrix for comparing up to 8 assets across health score, liquidity, price stability, uptime, reserve backing, and volume metrics, with CSV export and column visibility toggles.

- Metrics Sidebar Pinning (#624): draggable (dnd-kit) pinned metrics sidebar integrated into the main layout, with pin/unpin from a categorised metrics library, drag-to-reorder, collapse support, and state persisted in localStorage via Zustand.

Closes #624 
Closes #625  
Closes #626
Closes #627

