### PR TITLE
[628] Build Incident Replay Player

### DIFF
--- a/backend/src/api/routes/incidents.routes.ts
+++ b/backend/src/api/routes/incidents.routes.ts
@@ -54,6 +54,31 @@ export async function incidentRoutes(server: FastifyInstance) {
     }
   );
 
+  // GET /api/v1/incidents/:id/replay — ordered event timeline for replay player
+  server.get<{ Params: { id: string } }>(
+    "/:id/replay",
+    {
+      schema: {
+        tags: ["Incidents"],
+        summary: "Get incident replay timeline",
+        params: {
+          type: "object",
+          properties: { id: { type: "string" } },
+          required: ["id"],
+        },
+        response: {
+          200: { type: "object", additionalProperties: true },
+          404: { $ref: "Error#" },
+        },
+      },
+    },
+    async (request, reply) => {
+      const timeline = await incidentService.getIncidentReplayTimeline(request.params.id);
+      if (!timeline) return reply.status(404).send({ error: "Incident not found" });
+      return timeline;
+    }
+  );
+
   // GET /api/v1/incidents/:id — get single incident
   server.get<{ Params: { id: string } }>(
     "/:id",

--- a/backend/src/api/routes/index.ts
+++ b/backend/src/api/routes/index.ts
@@ -1,4 +1,7 @@
 import type { FastifyInstance } from "fastify";
+import { assetsRoutes } from "./assets.js";
+import { bridgesRoutes } from "./bridges.js";
+import { websocketRoutes } from "./websocket.js";
 import { alertsRoutes } from "./alerts.routes.js";
 import { alertHistoryRoutes } from "./alertHistory.routes.js";
 import { exportsRoutes } from "./exports.js";

--- a/backend/src/services/incident.service.ts
+++ b/backend/src/services/incident.service.ts
@@ -80,6 +80,30 @@ export interface HeatmapData {
   assets: string[];
 }
 
+export type IncidentReplayEventType =
+  | "incident_created"
+  | "ingestion"
+  | "status_change"
+  | "enrichment"
+  | "resolution";
+
+export interface IncidentReplayEvent {
+  id: string;
+  timestamp: string;
+  eventType: IncidentReplayEventType;
+  title: string;
+  description: string;
+  severity?: IncidentSeverity;
+  metadata: Record<string, unknown>;
+}
+
+export interface IncidentReplayTimeline {
+  incidentId: string;
+  incident: BridgeIncident;
+  events: IncidentReplayEvent[];
+  durationMs: number;
+}
+
 export class IncidentService {
   private db = getDatabase();
 
@@ -267,6 +291,109 @@ export class IncidentService {
       totalIncidents: filtered.length,
       dateRange: { start: startDate, end: endDate },
       assets: Array.from(assets).sort(),
+    };
+  }
+
+  async getIncidentReplayTimeline(id: string): Promise<IncidentReplayTimeline | null> {
+    const incident = await this.getIncident(id);
+    if (!incident) return null;
+
+    const ingestionRows = await this.db("bridge_incident_ingestion_history")
+      .where("incident_id", id)
+      .orderBy("created_at", "asc")
+      .select("*");
+
+    const events: IncidentReplayEvent[] = [];
+
+    events.push({
+      id: `${id}-created`,
+      timestamp: incident.occurredAt,
+      eventType: "incident_created",
+      title: "Incident detected",
+      description: incident.title,
+      severity: incident.severity,
+      metadata: {
+        bridgeId: incident.bridgeId,
+        assetCode: incident.assetCode,
+        sourceType: incident.sourceType,
+      },
+    });
+
+    for (const row of ingestionRows) {
+      const payload =
+        typeof row.payload === "object" && row.payload !== null
+          ? (row.payload as Record<string, unknown>)
+          : JSON.parse((row.payload as string) || "{}");
+
+      events.push({
+        id: row.id as string,
+        timestamp:
+          row.created_at instanceof Date
+            ? row.created_at.toISOString()
+            : String(row.created_at),
+        eventType: "ingestion",
+        title: `Ingestion: ${row.event_type}`,
+        description: (row.error_message as string | null) ?? `Source ${row.source_type} event processed`,
+        metadata: {
+          sourceType: row.source_type,
+          sourceExternalId: row.source_external_id,
+          status: row.status,
+          attemptNumber: row.attempt_number,
+          payload,
+        },
+      });
+    }
+
+    if (incident.enrichmentTags.length > 0 || Object.keys(incident.enrichmentMetadata).length > 0) {
+      events.push({
+        id: `${id}-enrichment`,
+        timestamp: incident.updatedAt,
+        eventType: "enrichment",
+        title: "Enrichment applied",
+        description: `Tags: ${incident.enrichmentTags.join(", ") || "none"}`,
+        metadata: {
+          enrichmentMetadata: incident.enrichmentMetadata,
+          enrichmentTags: incident.enrichmentTags,
+          derivedFields: incident.derivedFields,
+        },
+      });
+    }
+
+    if (incident.status !== "open") {
+      events.push({
+        id: `${id}-status`,
+        timestamp: incident.updatedAt,
+        eventType: "status_change",
+        title: `Status changed to ${incident.status}`,
+        description: `Incident moved to ${incident.status} state`,
+        severity: incident.severity,
+        metadata: { status: incident.status },
+      });
+    }
+
+    if (incident.resolvedAt) {
+      events.push({
+        id: `${id}-resolved`,
+        timestamp: incident.resolvedAt,
+        eventType: "resolution",
+        title: "Incident resolved",
+        description: "Incident marked as resolved",
+        metadata: { resolvedAt: incident.resolvedAt },
+      });
+    }
+
+    events.sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
+
+    const startMs = new Date(events[0]?.timestamp ?? incident.occurredAt).getTime();
+    const endMs = new Date(
+      events[events.length - 1]?.timestamp ?? incident.updatedAt,
+    ).getTime();
+
+    return {
+      incidentId: id,
+      incident,
+      events,
+      durationMs: Math.max(0, endMs - startMs),
     };
   }
 

--- a/backend/src/services/tagSync.service.ts
+++ b/backend/src/services/tagSync.service.ts
@@ -81,7 +81,7 @@ export class TagSyncService {
       "Removing tag"
     );
 
-    return this.model.removeTag(entityType, entityId, validatedTag, source);
+    return this.model.removeEntityTag(entityType, entityId, validatedTag, source);
   }
 
   async syncEntityTags(
@@ -133,7 +133,7 @@ export class TagSyncService {
   }
 
   async getAllTags(): Promise<Array<{ tag: string; count: number }>> {
-    return this.model.getAllTags();
+    return this.model.getAllEntityTags();
   }
 
   async propagateTag(

--- a/backend/tests/api/incidents.test.ts
+++ b/backend/tests/api/incidents.test.ts
@@ -36,4 +36,16 @@ describe("Incidents API", () => {
       expect(typeof response.statusCode).toBe("number");
     });
   });
+
+  describe("GET /api/v1/incidents/:id/replay", () => {
+    it("responds for replay timeline requests", async () => {
+      const response = await server.inject({
+        method: "GET",
+        url: "/api/v1/incidents/00000000-0000-0000-0000-000000000000/replay",
+      });
+
+      expect(typeof response.statusCode).toBe("number");
+      expect([404, 500]).toContain(response.statusCode);
+    });
+  });
 });

--- a/backend/tests/services/incident.service.test.ts
+++ b/backend/tests/services/incident.service.test.ts
@@ -49,4 +49,9 @@ describe("IncidentService", () => {
     expect(result.totalIncidents).toBe(0);
     expect(result.assets).toEqual([]);
   });
+
+  it("getIncidentReplayTimeline returns null when incident missing", async () => {
+    const result = await service.getIncidentReplayTimeline("missing-id");
+    expect(result).toBeNull();
+  });
 });

--- a/docs/incident-replay-workflow.md
+++ b/docs/incident-replay-workflow.md
@@ -1,0 +1,34 @@
+# Incident Replay Workflow
+
+Operators can reconstruct the sequence of events that led to a bridge incident using the replay player.
+
+## API
+
+```
+GET /api/v1/incidents/:id/replay
+```
+
+Returns an ordered `events` array with timestamps, event types, and metadata drawn from ingestion history and incident lifecycle fields.
+
+## UI
+
+Navigate to `/incidents/replay/:incidentId` to open the player.
+
+### Controls
+
+- **Play / Pause** — auto-advance through events at the selected speed
+- **Restart** — jump back to the first event
+- **Speed** — 0.5x, 1x, 2x, or 4x
+- **Timeline scrubber** — seek to any event
+- **Event details drawer** — inspect metadata for the selected event
+- **Export JSON** — download the full replay payload for postmortems
+
+## Event types
+
+| Type | Source |
+|------|--------|
+| `incident_created` | Incident record `occurredAt` |
+| `ingestion` | `bridge_incident_ingestion_history` rows |
+| `enrichment` | Enrichment tags and metadata |
+| `status_change` | Status transitions |
+| `resolution` | `resolvedAt` timestamp |

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ const Dashboard = lazy(() => import("./pages/Dashboard"));
 const AssetDetail = lazy(() => import("./pages/AssetDetail"));
 const Bridges = lazy(() => import("./pages/Bridges"));
 const Incidents = lazy(() => import("./pages/Incidents"));
+const IncidentReplay = lazy(() => import("./pages/IncidentReplay"));
 const Analytics = lazy(() => import("./pages/Analytics"));
 const Reports = lazy(() => import("./pages/Reports"));
 const Landing = lazy(() => import("./pages/Landing"));
@@ -61,6 +62,7 @@ function App() {
               <Route path="/assets/:symbol" element={<AssetDetail />} />
               <Route path="/bridges" element={<Bridges />} />
               <Route path="/incidents" element={<Incidents />} />
+              <Route path="/incidents/replay/:id" element={<IncidentReplay />} />
               <Route path="/alerts" element={<Alerts />} />
               <Route path="/transactions" element={<Transactions />} />
               <Route path="/analytics" element={<Analytics />} />

--- a/frontend/src/components/IncidentReplayPlayer/IncidentReplayPlayer.tsx
+++ b/frontend/src/components/IncidentReplayPlayer/IncidentReplayPlayer.tsx
@@ -1,0 +1,289 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { IncidentReplayEvent, IncidentReplayTimeline } from "../../services/api";
+
+const SPEED_OPTIONS = [0.5, 1, 2, 4] as const;
+
+interface IncidentReplayPlayerProps {
+  timeline: IncidentReplayTimeline;
+  isLoading?: boolean;
+  error?: string | null;
+}
+
+function formatTimestamp(iso: string): string {
+  return new Date(iso).toLocaleString();
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  return `${Math.floor(ms / 60_000)}m ${Math.round((ms % 60_000) / 1000)}s`;
+}
+
+export default function IncidentReplayPlayer({
+  timeline,
+  isLoading,
+  error,
+}: IncidentReplayPlayerProps) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [speed, setSpeed] = useState<(typeof SPEED_OPTIONS)[number]>(1);
+  const [selectedEvent, setSelectedEvent] = useState<IncidentReplayEvent | null>(null);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const events = timeline.events;
+  const currentEvent = events[currentIndex] ?? null;
+  const progress = events.length > 1 ? (currentIndex / (events.length - 1)) * 100 : 100;
+
+  const stopPlayback = useCallback(() => {
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+    setIsPlaying(false);
+  }, []);
+
+  const advance = useCallback(() => {
+    setCurrentIndex((prev) => {
+      if (prev >= events.length - 1) {
+        stopPlayback();
+        return prev;
+      }
+      return prev + 1;
+    });
+  }, [events.length, stopPlayback]);
+
+  useEffect(() => {
+    if (!isPlaying) return undefined;
+
+    const intervalMs = Math.max(250, 1500 / speed);
+    timerRef.current = setInterval(advance, intervalMs);
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, [isPlaying, speed, advance]);
+
+  useEffect(() => {
+    if (currentEvent) setSelectedEvent(currentEvent);
+  }, [currentEvent]);
+
+  const exportReplay = useCallback(() => {
+    const payload = {
+      exportedAt: new Date().toISOString(),
+      incidentId: timeline.incidentId,
+      incident: timeline.incident,
+      events: timeline.events,
+      durationMs: timeline.durationMs,
+      playbackPosition: currentIndex,
+    };
+    const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = `incident-replay-${timeline.incidentId}.json`;
+    anchor.click();
+    URL.revokeObjectURL(url);
+  }, [timeline, currentIndex]);
+
+  const severityColor = useMemo(() => {
+    const map: Record<string, string> = {
+      critical: "text-red-400",
+      high: "text-orange-400",
+      medium: "text-yellow-400",
+      low: "text-blue-400",
+    };
+    return map[timeline.incident.severity] ?? "text-stellar-text-secondary";
+  }, [timeline.incident.severity]);
+
+  if (isLoading) {
+    return (
+      <div className="rounded-xl border border-stellar-border bg-stellar-card p-8 text-center text-stellar-text-secondary">
+        Loading replay timeline...
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-xl border border-red-500/30 bg-red-500/10 p-8 text-center text-red-300">
+        {error}
+      </div>
+    );
+  }
+
+  if (events.length === 0) {
+    return (
+      <div className="rounded-xl border border-stellar-border bg-stellar-card p-8 text-center text-stellar-text-secondary">
+        No replay events available for this incident.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <header className="rounded-xl border border-stellar-border bg-stellar-card p-6">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <p className={`text-sm font-medium uppercase tracking-wide ${severityColor}`}>
+              {timeline.incident.severity} · {timeline.incident.status}
+            </p>
+            <h2 className="mt-1 text-xl font-semibold text-stellar-text-primary">
+              {timeline.incident.title}
+            </h2>
+            <p className="mt-2 text-sm text-stellar-text-secondary">
+              {timeline.incident.description}
+            </p>
+          </div>
+          <div className="text-right text-sm text-stellar-text-secondary">
+            <p>Bridge: {timeline.incident.bridgeId}</p>
+            {timeline.incident.assetCode && <p>Asset: {timeline.incident.assetCode}</p>}
+            <p>Duration: {formatDuration(timeline.durationMs)}</p>
+            <p>{events.length} events</p>
+          </div>
+        </div>
+      </header>
+
+      <div className="grid gap-6 lg:grid-cols-[1fr_320px]">
+        <section
+          className="rounded-xl border border-stellar-border bg-stellar-card p-6"
+          aria-label="Incident replay timeline"
+        >
+          <div className="mb-4 flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              className="rounded-md bg-stellar-blue px-4 py-2 text-sm font-medium text-white hover:bg-stellar-blue/90"
+              onClick={() => (isPlaying ? stopPlayback() : setIsPlaying(true))}
+              aria-label={isPlaying ? "Pause replay" : "Play replay"}
+            >
+              {isPlaying ? "Pause" : "Play"}
+            </button>
+            <button
+              type="button"
+              className="rounded-md border border-stellar-border px-3 py-2 text-sm text-stellar-text-secondary hover:text-white"
+              onClick={() => {
+                stopPlayback();
+                setCurrentIndex(0);
+              }}
+            >
+              Restart
+            </button>
+            <label className="flex items-center gap-2 text-sm text-stellar-text-secondary">
+              Speed
+              <select
+                className="rounded-md border border-stellar-border bg-stellar-dark px-2 py-1 text-white"
+                value={speed}
+                onChange={(e) => setSpeed(Number(e.target.value) as (typeof SPEED_OPTIONS)[number])}
+                aria-label="Playback speed"
+              >
+                {SPEED_OPTIONS.map((option) => (
+                  <option key={option} value={option}>
+                    {option}x
+                  </option>
+                ))}
+              </select>
+            </label>
+            <button
+              type="button"
+              className="ml-auto rounded-md border border-stellar-border px-3 py-2 text-sm text-stellar-text-secondary hover:text-white"
+              onClick={exportReplay}
+            >
+              Export JSON
+            </button>
+          </div>
+
+          <div className="mb-6">
+            <input
+              type="range"
+              min={0}
+              max={Math.max(0, events.length - 1)}
+              value={currentIndex}
+              onChange={(e) => {
+                stopPlayback();
+                setCurrentIndex(Number(e.target.value));
+              }}
+              className="w-full accent-stellar-blue"
+              aria-label="Timeline scrubber"
+            />
+            <div className="mt-1 flex justify-between text-xs text-stellar-text-secondary">
+              <span>{currentEvent ? formatTimestamp(currentEvent.timestamp) : "—"}</span>
+              <span>{Math.round(progress)}%</span>
+            </div>
+          </div>
+
+          <ol className="space-y-2">
+            {events.map((event, index) => {
+              const isActive = index === currentIndex;
+              const isPast = index < currentIndex;
+              return (
+                <li key={event.id}>
+                  <button
+                    type="button"
+                    className={`w-full rounded-lg border px-4 py-3 text-left transition ${
+                      isActive
+                        ? "border-stellar-blue bg-stellar-blue/10"
+                        : isPast
+                          ? "border-stellar-border/50 bg-stellar-dark/40 opacity-80"
+                          : "border-stellar-border bg-stellar-dark hover:border-stellar-blue/50"
+                    }`}
+                    onClick={() => {
+                      stopPlayback();
+                      setCurrentIndex(index);
+                      setSelectedEvent(event);
+                    }}
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="text-sm font-medium text-stellar-text-primary">
+                        {event.title}
+                      </span>
+                      <span className="text-xs text-stellar-text-secondary">
+                        {formatTimestamp(event.timestamp)}
+                      </span>
+                    </div>
+                    <p className="mt-1 text-xs text-stellar-text-secondary">{event.eventType}</p>
+                  </button>
+                </li>
+              );
+            })}
+          </ol>
+        </section>
+
+        <aside
+          className="rounded-xl border border-stellar-border bg-stellar-card p-6"
+          aria-label="Event details drawer"
+        >
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-stellar-text-secondary">
+            Event Details
+          </h3>
+          {selectedEvent ? (
+            <div className="mt-4 space-y-3">
+              <p className="text-lg font-medium text-stellar-text-primary">{selectedEvent.title}</p>
+              <p className="text-sm text-stellar-text-secondary">{selectedEvent.description}</p>
+              <dl className="space-y-2 text-sm">
+                <div>
+                  <dt className="text-stellar-text-secondary">Type</dt>
+                  <dd className="text-white">{selectedEvent.eventType}</dd>
+                </div>
+                <div>
+                  <dt className="text-stellar-text-secondary">Timestamp</dt>
+                  <dd className="text-white">{formatTimestamp(selectedEvent.timestamp)}</dd>
+                </div>
+                {selectedEvent.severity && (
+                  <div>
+                    <dt className="text-stellar-text-secondary">Severity</dt>
+                    <dd className="text-white">{selectedEvent.severity}</dd>
+                  </div>
+                )}
+              </dl>
+              <pre className="max-h-64 overflow-auto rounded-md bg-stellar-dark p-3 text-xs text-stellar-text-secondary">
+                {JSON.stringify(selectedEvent.metadata, null, 2)}
+              </pre>
+            </div>
+          ) : (
+            <p className="mt-4 text-sm text-stellar-text-secondary">
+              Select an event to inspect details.
+            </p>
+          )}
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/IncidentReplayPlayer/index.ts
+++ b/frontend/src/components/IncidentReplayPlayer/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./IncidentReplayPlayer";

--- a/frontend/src/components/MobileNav/navigation.ts
+++ b/frontend/src/components/MobileNav/navigation.ts
@@ -16,7 +16,8 @@ export const navGroups: NavGroup[] = [
     label: "Monitoring",
     items: [
       { to: "/dashboard", label: "Dashboard", description: "Real-time asset health overview" },
-      { to: "/bridges", label: "Bridges", description: "Bridge performance and incidents" },
+      { to: "/incidents", label: "Incidents", description: "Incident heatmap and clustering" },
+      { to: "/incidents/replay/demo", label: "Incident Replay", description: "Replay incident event timelines" },
       { to: "/transactions", label: "Transactions", description: "Recent bridge transfer activity" },
       { to: "/reconciliation", label: "Reconciliation", description: "Supply drift and reserve backing triage" },
       { to: "/analytics", label: "Analytics", description: "Trend analysis and health scoring" },

--- a/frontend/src/hooks/useIncidentReplay.ts
+++ b/frontend/src/hooks/useIncidentReplay.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+import { getIncidentReplayTimeline } from "../services/api";
+
+export function useIncidentReplay(incidentId: string | undefined) {
+  return useQuery({
+    queryKey: ["incidentReplay", incidentId],
+    queryFn: () => getIncidentReplayTimeline(incidentId!),
+    enabled: Boolean(incidentId),
+    staleTime: 30_000,
+  });
+}

--- a/frontend/src/pages/IncidentReplay.test.tsx
+++ b/frontend/src/pages/IncidentReplay.test.tsx
@@ -1,0 +1,87 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import IncidentReplayPlayer from "../components/IncidentReplayPlayer";
+import IncidentReplay from "./IncidentReplay";
+import type { IncidentReplayTimeline } from "../services/api";
+
+const mockTimeline: IncidentReplayTimeline = {
+  incidentId: "inc-1",
+  incident: {
+    id: "inc-1",
+    bridgeId: "allbridge",
+    assetCode: "USDC",
+    severity: "high",
+    status: "investigating",
+    title: "Supply mismatch detected",
+    description: "Reserve drift exceeded threshold",
+    occurredAt: "2026-01-01T10:00:00.000Z",
+    resolvedAt: null,
+  },
+  events: [
+    {
+      id: "e1",
+      timestamp: "2026-01-01T10:00:00.000Z",
+      eventType: "incident_created",
+      title: "Incident detected",
+      description: "Supply mismatch detected",
+      severity: "high",
+      metadata: { bridgeId: "allbridge" },
+    },
+    {
+      id: "e2",
+      timestamp: "2026-01-01T10:05:00.000Z",
+      eventType: "ingestion",
+      title: "Ingestion: webhook",
+      description: "Webhook event processed",
+      metadata: { sourceType: "webhook" },
+    },
+  ],
+  durationMs: 300_000,
+};
+
+vi.mock("../hooks/useIncidentReplay", () => ({
+  useIncidentReplay: () => ({
+    data: mockTimeline,
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+describe("IncidentReplayPlayer", () => {
+  it("renders timeline controls and event list", () => {
+    render(<IncidentReplayPlayer timeline={mockTimeline} />);
+
+    expect(screen.getByRole("button", { name: "Play replay" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Timeline scrubber")).toBeInTheDocument();
+    expect(screen.getAllByText("Incident detected").length).toBeGreaterThan(0);
+    expect(screen.getByText("Ingestion: webhook")).toBeInTheDocument();
+  });
+
+  it("shows event details when an event is selected", () => {
+    render(<IncidentReplayPlayer timeline={mockTimeline} />);
+
+    fireEvent.click(screen.getByText("Ingestion: webhook"));
+    expect(screen.getByRole("heading", { name: "Event Details" })).toBeInTheDocument();
+    expect(screen.getByText(/"sourceType": "webhook"/)).toBeInTheDocument();
+  });
+});
+
+describe("IncidentReplay page", () => {
+  it("renders replay player for incident route", () => {
+    const queryClient = new QueryClient();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/incidents/replay/inc-1"]}>
+          <Routes>
+            <Route path="/incidents/replay/:id" element={<IncidentReplay />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    expect(screen.getByRole("heading", { name: "Incident Replay" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Play replay" })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/IncidentReplay.tsx
+++ b/frontend/src/pages/IncidentReplay.tsx
@@ -1,0 +1,88 @@
+import { Link, useParams, useSearchParams } from "react-router-dom";
+import IncidentReplayPlayer from "../components/IncidentReplayPlayer";
+import { useIncidentReplay } from "../hooks/useIncidentReplay";
+
+export default function IncidentReplay() {
+  const { id } = useParams<{ id: string }>();
+  const [searchParams] = useSearchParams();
+  const incidentId = id ?? searchParams.get("incidentId") ?? undefined;
+  const { data, isLoading, error } = useIncidentReplay(incidentId);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold text-stellar-text-primary">Incident Replay</h1>
+          <p className="mt-2 text-stellar-text-secondary">
+            Step through the event sequence that led to this incident.
+          </p>
+        </div>
+        <Link
+          to="/incidents"
+          className="rounded-md border border-stellar-border px-4 py-2 text-sm text-stellar-text-secondary hover:text-white"
+        >
+          Back to incidents
+        </Link>
+      </div>
+
+      {!incidentId && (
+        <div className="rounded-xl border border-stellar-border bg-stellar-card p-8 text-center text-stellar-text-secondary">
+          Provide an incident ID in the URL, e.g.{" "}
+          <code className="text-stellar-blue">/incidents/replay/your-incident-id</code>
+        </div>
+      )}
+
+      {incidentId && data && (
+        <IncidentReplayPlayer
+          timeline={data}
+          isLoading={isLoading}
+          error={error?.message ?? null}
+        />
+      )}
+
+      {incidentId && isLoading && (
+        <IncidentReplayPlayer
+          timeline={{
+            incidentId,
+            incident: {
+              id: incidentId,
+              bridgeId: "",
+              assetCode: null,
+              severity: "medium",
+              status: "open",
+              title: "",
+              description: "",
+              occurredAt: new Date().toISOString(),
+              resolvedAt: null,
+            },
+            events: [],
+            durationMs: 0,
+          }}
+          isLoading
+        />
+      )}
+
+      {incidentId && !isLoading && error && (
+        <IncidentReplayPlayer
+          timeline={{
+            incidentId,
+            incident: {
+              id: incidentId,
+              bridgeId: "",
+              assetCode: null,
+              severity: "medium",
+              status: "open",
+              title: "",
+              description: "",
+              occurredAt: new Date().toISOString(),
+              resolvedAt: null,
+            },
+            events: [],
+            durationMs: 0,
+          }}
+          error={error.message}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -794,6 +794,8 @@ export function runScheduledExportNow(id: string) {
   return fetchApi<{ export: ExportRecord }>(`/exports/schedules/${id}/run`, {
     method: "POST",
   });
+}
+
 // Incidents / Heatmap
 export interface HeatmapBucket {
   date: string;
@@ -829,4 +831,42 @@ export function getIncidentHeatmap(params?: {
     dateRange: { start: string; end: string };
     assets: string[];
   }>(`/incidents/heatmap${qs ? `?${qs}` : ""}`);
+}
+
+export type IncidentReplayEventType =
+  | "incident_created"
+  | "ingestion"
+  | "status_change"
+  | "enrichment"
+  | "resolution";
+
+export interface IncidentReplayEvent {
+  id: string;
+  timestamp: string;
+  eventType: IncidentReplayEventType;
+  title: string;
+  description: string;
+  severity?: string;
+  metadata: Record<string, unknown>;
+}
+
+export interface IncidentReplayTimeline {
+  incidentId: string;
+  incident: {
+    id: string;
+    bridgeId: string;
+    assetCode: string | null;
+    severity: string;
+    status: string;
+    title: string;
+    description: string;
+    occurredAt: string;
+    resolvedAt: string | null;
+  };
+  events: IncidentReplayEvent[];
+  durationMs: number;
+}
+
+export function getIncidentReplayTimeline(incidentId: string) {
+  return fetchApi<IncidentReplayTimeline>(`/incidents/${encodeURIComponent(incidentId)}/replay`);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -181,7 +181,6 @@
       "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
@@ -318,7 +317,6 @@
       "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.6",
@@ -518,7 +516,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -975,7 +972,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -3941,7 +3937,6 @@
       "integrity": "sha512-AhvJsu5zl3uG40itSQVuSy5WByp3UVhS6xAnme4FWRwgSxhvZjATJ3AZkkHWOYjnnk+P2/sbz/XuPli1FVCWoQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@storybook/csf": "^0.1.11",
         "@storybook/global": "^5.0.0",
@@ -3966,7 +3961,6 @@
       "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -4561,7 +4555,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -4654,7 +4647,6 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -5058,7 +5050,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5605,7 +5596,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6194,7 +6184,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -6218,7 +6207,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6828,7 +6816,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -6912,7 +6899,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -7480,7 +7466,6 @@
       "integrity": "sha512-0DS4Nn4rV8qyFlQCpKK8brT61EUtswynrpfFTcgLErcilBIBskSMQ86fO2WVuybr14ywyKdRjv91FiRZwnEuvQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readline-sync": "^1.4.10",
         "sprintf-js": "^1.1.3",
@@ -8152,7 +8137,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.29.2"
       },
@@ -8310,7 +8294,6 @@
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.1.tgz",
       "integrity": "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ioredis/commands": "1.5.1",
         "cluster-key-slot": "^1.1.0",
@@ -8848,7 +8831,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -9533,7 +9515,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^5.0.0",
         "@mswjs/interceptors": "^0.41.2",
@@ -10376,7 +10357,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -10722,7 +10702,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -10780,7 +10759,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -11266,7 +11244,6 @@
       "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -11793,7 +11770,6 @@
       "integrity": "sha512-RP/nMJxiWyFc8EVMH5gp20ID032Wvk+Yr3lmKidoegto5Iy+2dVQnUoElZb2zpbVXNHWakGuAkfI0dY1Hfp/vw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@storybook/core": "8.4.7"
       },
@@ -12614,7 +12590,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12781,7 +12756,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -13291,7 +13265,6 @@
       "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "2.1.9",
         "@vitest/mocker": "2.1.9",


### PR DESCRIPTION
## Summary
- Adds `GET /api/v1/incidents/:id/replay` returning an ordered event timeline from ingestion history and incident lifecycle fields
- Introduces `/incidents/replay/:id` page with play/pause, speed control, scrubber, event details drawer, and JSON export
- Documents the replay workflow in `docs/incident-replay-workflow.md`

## Test plan
- [x] Frontend build passes
- [x] Backend build passes
- [x] `IncidentReplay.test.tsx` passes
- [x] Incidents API replay route smoke test passes

Closes #628