### PR TITLE
[629] Implement Custom Metric Builder

### DIFF
--- a/backend/src/api/routes/index.ts
+++ b/backend/src/api/routes/index.ts
@@ -72,6 +72,7 @@ import { ownershipMatrixRoutes } from "./ownershipMatrix.js";
 import { operatorNotesRoutes } from "./notes.js";
 import { incidentsRoutes } from "./incidents.js";
 import { tagsRoutes } from "./tags.js";
+import { savedMetricsRoutes } from "./savedMetrics.routes.js";
 
 export async function registerRoutes(server: FastifyInstance) {
   server.register(assetsRoutes, { prefix: "/api/v1/assets" });
@@ -90,6 +91,7 @@ export async function registerRoutes(server: FastifyInstance) {
   server.register(aggregationRoutes, { prefix: "/api/v1/aggregation" });
   server.register(metadataRoutes, { prefix: "/api/v1/metadata" });
   server.register(analyticsRoutes, { prefix: "/api/v1/analytics" });
+  server.register(savedMetricsRoutes, { prefix: "/api/v1/analytics/saved-metrics" });
   server.register(watchlistsRoutes, { prefix: "/api/v1/watchlists" });
   server.register(cacheRoutes, { prefix: "/api/v1/cache" });
   server.register(healthRoutes, { prefix: "/api/v1/health" });

--- a/backend/src/api/routes/savedMetrics.routes.ts
+++ b/backend/src/api/routes/savedMetrics.routes.ts
@@ -1,0 +1,161 @@
+import type { FastifyInstance, FastifyRequest } from "fastify";
+import { savedMetricService } from "../../services/savedMetric.service.js";
+import { logger } from "../../utils/logger.js";
+
+function getRequestUserId(request: FastifyRequest): string {
+  return request.apiKeyAuth?.id ?? "00000000-0000-0000-0000-000000000000";
+}
+
+export async function savedMetricsRoutes(server: FastifyInstance) {
+  server.get(
+    "/",
+    {
+      schema: {
+        tags: ["Analytics"],
+        summary: "List saved custom metrics",
+      },
+    },
+    async (request, reply) => {
+      try {
+        const metrics = await savedMetricService.listMetrics(getRequestUserId(request));
+        return reply.send({ success: true, data: metrics });
+      } catch (error) {
+        logger.error({ error }, "Failed to list saved metrics");
+        return reply.status(500).send({ success: false, error: "Failed to list saved metrics" });
+      }
+    },
+  );
+
+  server.post<{ Body: { name: string; description?: string; formula: string; isShared?: boolean; cacheTtl?: number } }>(
+    "/",
+    {
+      schema: {
+        tags: ["Analytics"],
+        summary: "Create a saved custom metric",
+        body: {
+          type: "object",
+          required: ["name", "formula"],
+          properties: {
+            name: { type: "string" },
+            description: { type: "string" },
+            formula: { type: "string" },
+            isShared: { type: "boolean" },
+            cacheTtl: { type: "integer" },
+          },
+        },
+      },
+    },
+    async (request, reply) => {
+      try {
+        const metric = await savedMetricService.createMetric({
+          ...request.body,
+          createdBy: getRequestUserId(request),
+        });
+        return reply.status(201).send({ success: true, data: metric });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Failed to create metric";
+        return reply.status(400).send({ success: false, error: message });
+      }
+    },
+  );
+
+  server.post<{ Body: { formula: string } }>(
+    "/validate",
+    {
+      schema: {
+        tags: ["Analytics"],
+        summary: "Validate and preview a metric formula",
+        body: {
+          type: "object",
+          required: ["formula"],
+          properties: { formula: { type: "string" } },
+        },
+      },
+    },
+    async (request, reply) => {
+      try {
+        const result = await savedMetricService.previewFormula(request.body.formula);
+        return reply.send({ success: result.valid, data: result });
+      } catch (error) {
+        logger.error({ error }, "Metric validation failed");
+        return reply.status(500).send({ success: false, error: "Validation failed" });
+      }
+    },
+  );
+
+  server.get<{ Params: { id: string }; Querystring: { forceRefresh?: string } }>(
+    "/:id/execute",
+    {
+      schema: {
+        tags: ["Analytics"],
+        summary: "Execute a saved custom metric",
+        params: {
+          type: "object",
+          required: ["id"],
+          properties: { id: { type: "string" } },
+        },
+      },
+    },
+    async (request, reply) => {
+      const result = await savedMetricService.executeSavedMetric(
+        request.params.id,
+        getRequestUserId(request),
+        request.query.forceRefresh === "true",
+      );
+      if (!result) return reply.status(404).send({ success: false, error: "Metric not found" });
+      return reply.send({ success: true, data: result });
+    },
+  );
+
+  server.patch<{ Params: { id: string }; Body: Record<string, unknown> }>(
+    "/:id",
+    {
+      schema: {
+        tags: ["Analytics"],
+        summary: "Update a saved custom metric",
+        params: {
+          type: "object",
+          required: ["id"],
+          properties: { id: { type: "string" } },
+        },
+      },
+    },
+    async (request, reply) => {
+      try {
+        const updated = await savedMetricService.updateMetric(
+          request.params.id,
+          getRequestUserId(request),
+          request.body as Parameters<typeof savedMetricService.updateMetric>[2],
+        );
+        if (!updated) return reply.status(404).send({ success: false, error: "Metric not found" });
+        return reply.send({ success: true, data: updated });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Failed to update metric";
+        return reply.status(400).send({ success: false, error: message });
+      }
+    },
+  );
+
+  server.delete<{ Params: { id: string } }>(
+    "/:id",
+    {
+      schema: {
+        tags: ["Analytics"],
+        summary: "Delete a saved custom metric",
+        params: {
+          type: "object",
+          required: ["id"],
+          properties: { id: { type: "string" } },
+        },
+      },
+    },
+    async (request, reply) => {
+      const deleted = await savedMetricService.deleteMetric(
+        request.params.id,
+        getRequestUserId(request),
+      );
+      if (!deleted) return reply.status(404).send({ success: false, error: "Metric not found" });
+      return reply.send({ success: true });
+    },
+  );
+}

--- a/backend/src/database/migrations/036_user_saved_metrics.ts
+++ b/backend/src/database/migrations/036_user_saved_metrics.ts
@@ -1,0 +1,24 @@
+import type { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable("user_saved_metrics", (table) => {
+    table.uuid("id").primary().defaultTo(knex.raw("gen_random_uuid()"));
+    table.string("name").notNullable();
+    table.text("description");
+    table.text("formula").notNullable();
+    table.boolean("is_shared").notNullable().defaultTo(false);
+    table.uuid("created_by").notNullable();
+    table.integer("cache_ttl").notNullable().defaultTo(600);
+    table.jsonb("metadata").notNullable().defaultTo("{}");
+    table.timestamp("created_at").notNullable().defaultTo(knex.fn.now());
+    table.timestamp("updated_at").notNullable().defaultTo(knex.fn.now());
+
+    table.index(["created_by"]);
+    table.index(["is_shared"]);
+    table.unique(["created_by", "name"]);
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists("user_saved_metrics");
+}

--- a/backend/src/services/savedMetric.service.ts
+++ b/backend/src/services/savedMetric.service.ts
@@ -1,0 +1,232 @@
+import { getDatabase } from "../database/connection.js";
+import { logger } from "../utils/logger.js";
+import type { CustomMetric } from "./analytics.service.js";
+import { AnalyticsService } from "./analytics.service.js";
+
+const BLOCKED_SQL_PATTERN =
+  /\b(insert|update|delete|drop|alter|truncate|grant|revoke|create|attach|detach|pragma)\b/i;
+
+export interface SavedMetric {
+  id: string;
+  name: string;
+  description: string | null;
+  formula: string;
+  isShared: boolean;
+  createdBy: string;
+  cacheTtl: number;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateSavedMetricInput {
+  name: string;
+  description?: string;
+  formula: string;
+  isShared?: boolean;
+  createdBy: string;
+  cacheTtl?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface UpdateSavedMetricInput {
+  name?: string;
+  description?: string;
+  formula?: string;
+  isShared?: boolean;
+  cacheTtl?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface MetricValidationResult {
+  valid: boolean;
+  errors: string[];
+  preview?: {
+    rowCount: number;
+    columns: string[];
+    sampleRows: Record<string, unknown>[];
+  };
+}
+
+export class SavedMetricService {
+  private db = getDatabase();
+  private analytics = new AnalyticsService();
+
+  validateFormula(formula: string): { valid: boolean; errors: string[] } {
+    const errors: string[] = [];
+    const trimmed = formula.trim();
+
+    if (!trimmed) {
+      errors.push("Formula cannot be empty");
+      return { valid: false, errors };
+    }
+
+    if (!/^\s*select\b/i.test(trimmed)) {
+      errors.push("Formula must be a SELECT query");
+    }
+
+    if (trimmed.includes(";")) {
+      errors.push("Multiple statements are not allowed");
+    }
+
+    if (BLOCKED_SQL_PATTERN.test(trimmed)) {
+      errors.push("Only read-only SELECT queries are permitted");
+    }
+
+    return { valid: errors.length === 0, errors };
+  }
+
+  async previewFormula(formula: string): Promise<MetricValidationResult> {
+    const validation = this.validateFormula(formula);
+    if (!validation.valid) {
+      return { valid: false, errors: validation.errors };
+    }
+
+    try {
+      const limitedQuery = `SELECT * FROM (${formula.replace(/;\s*$/, "")}) AS preview_query LIMIT 5`;
+      const result = await this.db.raw(limitedQuery);
+      const rows = (result.rows ?? result) as Record<string, unknown>[];
+      const columns = rows[0] ? Object.keys(rows[0]) : [];
+
+      return {
+        valid: true,
+        errors: [],
+        preview: {
+          rowCount: rows.length,
+          columns,
+          sampleRows: rows,
+        },
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Query execution failed";
+      return { valid: false, errors: [message] };
+    }
+  }
+
+  async listMetrics(userId: string): Promise<SavedMetric[]> {
+    const rows = await this.db("user_saved_metrics")
+      .where("created_by", userId)
+      .orWhere("is_shared", true)
+      .orderBy("updated_at", "desc");
+
+    return rows.map(this.mapRow);
+  }
+
+  async getMetric(id: string, userId: string): Promise<SavedMetric | null> {
+    const row = await this.db("user_saved_metrics")
+      .where("id", id)
+      .andWhere((qb) => {
+        qb.where("created_by", userId).orWhere("is_shared", true);
+      })
+      .first();
+
+    return row ? this.mapRow(row) : null;
+  }
+
+  async createMetric(input: CreateSavedMetricInput): Promise<SavedMetric> {
+    const validation = this.validateFormula(input.formula);
+    if (!validation.valid) {
+      throw new Error(validation.errors.join("; "));
+    }
+
+    const [row] = await this.db("user_saved_metrics")
+      .insert({
+        name: input.name.trim(),
+        description: input.description?.trim() ?? null,
+        formula: input.formula.trim(),
+        is_shared: input.isShared ?? false,
+        created_by: input.createdBy,
+        cache_ttl: input.cacheTtl ?? 600,
+        metadata: JSON.stringify(input.metadata ?? {}),
+      })
+      .returning("*");
+
+    logger.info({ metricId: row.id, name: input.name }, "Saved custom metric created");
+    return this.mapRow(row);
+  }
+
+  async updateMetric(
+    id: string,
+    userId: string,
+    input: UpdateSavedMetricInput,
+  ): Promise<SavedMetric | null> {
+    const existing = await this.db("user_saved_metrics")
+      .where({ id, created_by: userId })
+      .first();
+
+    if (!existing) return null;
+
+    if (input.formula) {
+      const validation = this.validateFormula(input.formula);
+      if (!validation.valid) {
+        throw new Error(validation.errors.join("; "));
+      }
+    }
+
+    const [row] = await this.db("user_saved_metrics")
+      .where({ id, created_by: userId })
+      .update({
+        ...(input.name !== undefined ? { name: input.name.trim() } : {}),
+        ...(input.description !== undefined ? { description: input.description.trim() } : {}),
+        ...(input.formula !== undefined ? { formula: input.formula.trim() } : {}),
+        ...(input.isShared !== undefined ? { is_shared: input.isShared } : {}),
+        ...(input.cacheTtl !== undefined ? { cache_ttl: input.cacheTtl } : {}),
+        ...(input.metadata !== undefined ? { metadata: JSON.stringify(input.metadata) } : {}),
+        updated_at: new Date(),
+      })
+      .returning("*");
+
+    return row ? this.mapRow(row) : null;
+  }
+
+  async deleteMetric(id: string, userId: string): Promise<boolean> {
+    const count = await this.db("user_saved_metrics")
+      .where({ id, created_by: userId })
+      .delete();
+    return count > 0;
+  }
+
+  async executeSavedMetric(id: string, userId: string, forceRefresh = false) {
+    const saved = await this.getMetric(id, userId);
+    if (!saved) return null;
+
+    const metric: CustomMetric = {
+      id: saved.id,
+      name: saved.name,
+      description: saved.description ?? "",
+      query: saved.formula,
+      parameters: {},
+      cacheKey: `saved-${saved.id}`,
+      cacheTTL: saved.cacheTtl,
+    };
+
+    const result = await this.analytics.executeCustomMetric(metric, forceRefresh);
+    return { metric: saved, result };
+  }
+
+  private mapRow(row: Record<string, unknown>): SavedMetric {
+    return {
+      id: row.id as string,
+      name: row.name as string,
+      description: (row.description as string | null) ?? null,
+      formula: row.formula as string,
+      isShared: Boolean(row.is_shared),
+      createdBy: row.created_by as string,
+      cacheTtl: Number(row.cache_ttl ?? 600),
+      metadata:
+        typeof row.metadata === "object" && row.metadata !== null
+          ? (row.metadata as Record<string, unknown>)
+          : JSON.parse((row.metadata as string) || "{}"),
+      createdAt:
+        row.created_at instanceof Date
+          ? row.created_at.toISOString()
+          : String(row.created_at),
+      updatedAt:
+        row.updated_at instanceof Date
+          ? row.updated_at.toISOString()
+          : String(row.updated_at),
+    };
+  }
+}
+
+export const savedMetricService = new SavedMetricService();

--- a/backend/tests/services/savedMetric.service.test.ts
+++ b/backend/tests/services/savedMetric.service.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { SavedMetricService } from "../../src/services/savedMetric.service.js";
+
+describe("SavedMetricService", () => {
+  const service = new SavedMetricService();
+
+  it("rejects non-SELECT formulas", () => {
+    const result = service.validateFormula("DELETE FROM bridges");
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  it("accepts read-only SELECT formulas", () => {
+    const result = service.validateFormula(
+      "SELECT bridge_id, COUNT(*) AS total FROM bridge_operators GROUP BY bridge_id",
+    );
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("rejects multi-statement formulas", () => {
+    const result = service.validateFormula("SELECT 1; DROP TABLE bridges");
+    expect(result.valid).toBe(false);
+  });
+});

--- a/docs/custom-metric-syntax.md
+++ b/docs/custom-metric-syntax.md
@@ -1,0 +1,33 @@
+# Custom Metric Query Language
+
+Saved metrics use **read-only SQL SELECT** statements against Bridge Watch analytics tables.
+
+## Rules
+
+- Must start with `SELECT`
+- Single statement only (no semicolons)
+- No `INSERT`, `UPDATE`, `DELETE`, `DROP`, or DDL keywords
+- Results are cached per metric `cacheTtl` (default 600 seconds)
+
+## Common tables
+
+| Table | Use |
+|-------|-----|
+| `bridge_operators` | Bridge provider metadata |
+| `verification_results` | Bridge verification outcomes |
+| `liquidity_snapshots` | DEX liquidity by symbol |
+| `alert_events` | Alert delivery history |
+| `bridge_volume_stats` | Cross-chain flow volumes |
+| `prices` | Asset price time series |
+
+## Example
+
+```sql
+SELECT bridge_id, COUNT(*) AS verifications
+FROM verification_results
+WHERE verified_at >= NOW() - INTERVAL '7 days'
+GROUP BY bridge_id
+ORDER BY verifications DESC
+```
+
+Use the metric builder at `/analytics/metric-builder` to validate, preview, save, and share formulas.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ const Bridges = lazy(() => import("./pages/Bridges"));
 const Incidents = lazy(() => import("./pages/Incidents"));
 const IncidentReplay = lazy(() => import("./pages/IncidentReplay"));
 const Analytics = lazy(() => import("./pages/Analytics"));
+const CustomMetricBuilder = lazy(() => import("./pages/CustomMetricBuilder"));
 const Reports = lazy(() => import("./pages/Reports"));
 const Landing = lazy(() => import("./pages/Landing"));
 const Settings = lazy(() => import("./pages/Settings"));
@@ -66,6 +67,7 @@ function App() {
               <Route path="/alerts" element={<Alerts />} />
               <Route path="/transactions" element={<Transactions />} />
               <Route path="/analytics" element={<Analytics />} />
+              <Route path="/analytics/metric-builder" element={<CustomMetricBuilder />} />
               <Route path="/reports" element={<Reports />} />
               <Route path="/watchlist" element={<WatchlistPage />} />
               <Route path="/watchlists" element={<WatchlistsPage />} />

--- a/frontend/src/components/MobileNav/navigation.ts
+++ b/frontend/src/components/MobileNav/navigation.ts
@@ -21,6 +21,7 @@ export const navGroups: NavGroup[] = [
       { to: "/transactions", label: "Transactions", description: "Recent bridge transfer activity" },
       { to: "/reconciliation", label: "Reconciliation", description: "Supply drift and reserve backing triage" },
       { to: "/analytics", label: "Analytics", description: "Trend analysis and health scoring" },
+      { to: "/analytics/metric-builder", label: "Metric Builder", description: "Create and save custom SQL metrics" },
       { to: "/data-provenance", label: "Provenance", description: "Trace metric lineage from source to destination" },
       { to: "/watchlist", label: "Watchlist", description: "Tracked assets and alerts" },
       { to: "/reports", label: "Reports", description: "Operational reporting views" },

--- a/frontend/src/hooks/useSavedMetrics.ts
+++ b/frontend/src/hooks/useSavedMetrics.ts
@@ -1,0 +1,44 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  createSavedMetric,
+  deleteSavedMetric,
+  listSavedMetrics,
+  validateMetricFormula,
+  type SavedMetric,
+} from "../services/api";
+
+export function useSavedMetrics() {
+  return useQuery({
+    queryKey: ["savedMetrics"],
+    queryFn: listSavedMetrics,
+    staleTime: 30_000,
+  });
+}
+
+export function useValidateMetricFormula() {
+  return useMutation({
+    mutationFn: (formula: string) => validateMetricFormula(formula),
+  });
+}
+
+export function useCreateSavedMetric() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: createSavedMetric,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["savedMetrics"] });
+    },
+  });
+}
+
+export function useDeleteSavedMetric() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: deleteSavedMetric,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["savedMetrics"] });
+    },
+  });
+}
+
+export type { SavedMetric };

--- a/frontend/src/pages/CustomMetricBuilder.test.tsx
+++ b/frontend/src/pages/CustomMetricBuilder.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import CustomMetricBuilder from "./CustomMetricBuilder";
+
+vi.mock("../hooks/useSavedMetrics", () => ({
+  useSavedMetrics: () => ({
+    data: [
+      {
+        id: "m1",
+        name: "Bridge uptime",
+        description: "Weekly verification counts",
+        formula: "SELECT 1",
+        isShared: true,
+        createdBy: "user-1",
+        cacheTtl: 600,
+        metadata: {},
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+    ],
+    isLoading: false,
+  }),
+  useValidateMetricFormula: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+    data: null,
+  }),
+  useCreateSavedMetric: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+  useDeleteSavedMetric: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+  }),
+}));
+
+describe("CustomMetricBuilder", () => {
+  it("renders formula editor and saved metrics list", () => {
+    const queryClient = new QueryClient();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <CustomMetricBuilder />
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByRole("heading", { name: "Custom Metric Builder" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Formula (SQL SELECT)")).toBeInTheDocument();
+    expect(screen.getByText("Bridge uptime")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Validate & preview" })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/CustomMetricBuilder.tsx
+++ b/frontend/src/pages/CustomMetricBuilder.tsx
@@ -1,0 +1,190 @@
+import { useMemo, useState } from "react";
+import {
+  useCreateSavedMetric,
+  useDeleteSavedMetric,
+  useSavedMetrics,
+  useValidateMetricFormula,
+} from "../hooks/useSavedMetrics";
+
+const EXAMPLE_FORMULA = `SELECT bridge_id, COUNT(*) AS verifications
+FROM verification_results
+WHERE verified_at >= NOW() - INTERVAL '7 days'
+GROUP BY bridge_id
+ORDER BY verifications DESC`;
+
+export default function CustomMetricBuilder() {
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [formula, setFormula] = useState(EXAMPLE_FORMULA);
+  const [isShared, setIsShared] = useState(false);
+  const [validationMessage, setValidationMessage] = useState<string | null>(null);
+
+  const { data: metrics = [], isLoading } = useSavedMetrics();
+  const validateMutation = useValidateMetricFormula();
+  const createMutation = useCreateSavedMetric();
+  const deleteMutation = useDeleteSavedMetric();
+
+  const preview = validateMutation.data?.data?.preview;
+
+  const canSave = useMemo(
+    () => name.trim().length > 0 && formula.trim().length > 0 && !createMutation.isPending,
+    [name, formula, createMutation.isPending],
+  );
+
+  const handleValidate = async () => {
+    const result = await validateMutation.mutateAsync(formula);
+    if (result.data?.valid) {
+      setValidationMessage("Formula is valid");
+    } else {
+      setValidationMessage(result.data?.errors.join(", ") ?? "Validation failed");
+    }
+  };
+
+  const handleSave = async () => {
+    await createMutation.mutateAsync({
+      name,
+      description,
+      formula,
+      isShared,
+    });
+    setName("");
+    setDescription("");
+    setValidationMessage("Metric saved");
+  };
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-3xl font-bold text-stellar-text-primary">Custom Metric Builder</h1>
+        <p className="mt-2 text-stellar-text-secondary">
+          Compose read-only SQL metrics, validate against live data, and save for your team.
+        </p>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-[1fr_360px]">
+        <section className="space-y-4 rounded-xl border border-stellar-border bg-stellar-card p-6">
+          <div>
+            <label htmlFor="metric-name" className="text-sm text-stellar-text-secondary">
+              Metric name
+            </label>
+            <input
+              id="metric-name"
+              className="mt-1 w-full rounded-md border border-stellar-border bg-stellar-dark px-3 py-2 text-white"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Bridge verification rate"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="metric-description" className="text-sm text-stellar-text-secondary">
+              Description
+            </label>
+            <input
+              id="metric-description"
+              className="mt-1 w-full rounded-md border border-stellar-border bg-stellar-dark px-3 py-2 text-white"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Weekly verification counts by bridge"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="metric-formula" className="text-sm text-stellar-text-secondary">
+              Formula (SQL SELECT)
+            </label>
+            <textarea
+              id="metric-formula"
+              className="mt-1 h-48 w-full rounded-md border border-stellar-border bg-stellar-dark px-3 py-2 font-mono text-sm text-white"
+              value={formula}
+              onChange={(e) => setFormula(e.target.value)}
+              spellCheck={false}
+            />
+          </div>
+
+          <label className="flex items-center gap-2 text-sm text-stellar-text-secondary">
+            <input
+              type="checkbox"
+              checked={isShared}
+              onChange={(e) => setIsShared(e.target.checked)}
+            />
+            Share with team
+          </label>
+
+          <div className="flex flex-wrap gap-3">
+            <button
+              type="button"
+              className="rounded-md border border-stellar-border px-4 py-2 text-sm text-white hover:bg-stellar-dark"
+              onClick={handleValidate}
+              disabled={validateMutation.isPending}
+            >
+              Validate &amp; preview
+            </button>
+            <button
+              type="button"
+              className="rounded-md bg-stellar-blue px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
+              onClick={handleSave}
+              disabled={!canSave}
+            >
+              Save metric
+            </button>
+          </div>
+
+          {validationMessage && (
+            <p className="text-sm text-stellar-text-secondary">{validationMessage}</p>
+          )}
+
+          {preview && (
+            <div className="rounded-md border border-stellar-border bg-stellar-dark p-4">
+              <p className="text-sm font-medium text-white">Preview ({preview.rowCount} rows)</p>
+              <pre className="mt-2 overflow-auto text-xs text-stellar-text-secondary">
+                {JSON.stringify(preview.sampleRows, null, 2)}
+              </pre>
+            </div>
+          )}
+        </section>
+
+        <aside className="rounded-xl border border-stellar-border bg-stellar-card p-6">
+          <h2 className="text-lg font-semibold text-white">Saved metrics</h2>
+          <p className="mt-1 text-sm text-stellar-text-secondary">
+            See `docs/custom-metric-syntax.md` for query language reference.
+          </p>
+
+          {isLoading ? (
+            <p className="mt-4 text-sm text-stellar-text-secondary">Loading...</p>
+          ) : metrics.length === 0 ? (
+            <p className="mt-4 text-sm text-stellar-text-secondary">No saved metrics yet.</p>
+          ) : (
+            <ul className="mt-4 space-y-3">
+              {metrics.map((metric) => (
+                <li
+                  key={metric.id}
+                  className="rounded-md border border-stellar-border bg-stellar-dark p-3"
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <div>
+                      <p className="font-medium text-white">{metric.name}</p>
+                      {metric.description && (
+                        <p className="text-xs text-stellar-text-secondary">{metric.description}</p>
+                      )}
+                      {metric.isShared && (
+                        <span className="mt-1 inline-block text-xs text-stellar-blue">Shared</span>
+                      )}
+                    </div>
+                    <button
+                      type="button"
+                      className="text-xs text-red-400 hover:text-red-300"
+                      onClick={() => deleteMutation.mutate(metric.id)}
+                    >
+                      Delete
+                    </button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -870,3 +870,61 @@ export interface IncidentReplayTimeline {
 export function getIncidentReplayTimeline(incidentId: string) {
   return fetchApi<IncidentReplayTimeline>(`/incidents/${encodeURIComponent(incidentId)}/replay`);
 }
+
+export interface SavedMetric {
+  id: string;
+  name: string;
+  description: string | null;
+  formula: string;
+  isShared: boolean;
+  createdBy: string;
+  cacheTtl: number;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface MetricValidationResponse {
+  valid: boolean;
+  errors: string[];
+  preview?: {
+    rowCount: number;
+    columns: string[];
+    sampleRows: Record<string, unknown>[];
+  };
+}
+
+export function listSavedMetrics() {
+  return fetchApi<{ success: boolean; data: SavedMetric[] }>("/analytics/saved-metrics").then(
+    (r) => r.data,
+  );
+}
+
+export function createSavedMetric(payload: {
+  name: string;
+  description?: string;
+  formula: string;
+  isShared?: boolean;
+  cacheTtl?: number;
+}) {
+  return fetchApi<{ success: boolean; data: SavedMetric }>("/analytics/saved-metrics", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+export function validateMetricFormula(formula: string) {
+  return fetchApi<{ success: boolean; data: MetricValidationResponse }>(
+    "/analytics/saved-metrics/validate",
+    {
+      method: "POST",
+      body: JSON.stringify({ formula }),
+    },
+  );
+}
+
+export function deleteSavedMetric(id: string) {
+  return fetchApi<{ success: boolean }>(`/analytics/saved-metrics/${id}`, {
+    method: "DELETE",
+  });
+}


### PR DESCRIPTION
## Summary
- Adds `user_saved_metrics` table and `/api/v1/analytics/saved-metrics` CRUD with validation and preview
- Introduces `/analytics/metric-builder` UI for formula editing, preview, save, share, and delete
- Documents the read-only SQL query language in `docs/custom-metric-syntax.md`

## Test plan
- [x] Backend build passes
- [x] Frontend build passes
- [x] `savedMetric.service.test.ts` passes
- [x] `CustomMetricBuilder.test.tsx` passes

Closes #629