### PR TITLE
[631] Build Alert Playbook Viewer

### DIFF
--- a/backend/src/api/routes/index.ts
+++ b/backend/src/api/routes/index.ts
@@ -73,6 +73,7 @@ import { operatorNotesRoutes } from "./notes.js";
 import { incidentsRoutes } from "./incidents.js";
 import { tagsRoutes } from "./tags.js";
 import { savedMetricsRoutes } from "./savedMetrics.routes.js";
+import { playbooksRoutes } from "./playbooks.routes.js";
 
 export async function registerRoutes(server: FastifyInstance) {
   server.register(assetsRoutes, { prefix: "/api/v1/assets" });
@@ -179,4 +180,5 @@ export async function registerRoutes(server: FastifyInstance) {
   server.register(operatorNotesRoutes, { prefix: "/api/v1/notes" });
   server.register(incidentsRoutes, { prefix: "/api/v1/incidents-heatmap" });
   server.register(tagsRoutes, { prefix: "/api/v1/tags" });
+  server.register(playbooksRoutes, { prefix: "/api/v1/playbooks" });
 }

--- a/backend/src/api/routes/playbooks.routes.ts
+++ b/backend/src/api/routes/playbooks.routes.ts
@@ -1,0 +1,49 @@
+import type { FastifyInstance } from "fastify";
+import { playbookService } from "../../services/playbook.service.js";
+
+export async function playbooksRoutes(server: FastifyInstance) {
+  server.get<{ Querystring: { q?: string; alertType?: string; severity?: string } }>(
+    "/",
+    {
+      schema: {
+        tags: ["Playbooks"],
+        summary: "Search alert playbooks",
+        querystring: {
+          type: "object",
+          properties: {
+            q: { type: "string" },
+            alertType: { type: "string" },
+            severity: { type: "string" },
+          },
+        },
+      },
+    },
+    async (request) => {
+      return playbookService.searchPlaybooks(
+        request.query.q,
+        request.query.alertType,
+        request.query.severity,
+      );
+    },
+  );
+
+  server.get<{ Params: { id: string } }>(
+    "/:id",
+    {
+      schema: {
+        tags: ["Playbooks"],
+        summary: "Get alert playbook by id or alert type",
+        params: {
+          type: "object",
+          required: ["id"],
+          properties: { id: { type: "string" } },
+        },
+      },
+    },
+    async (request, reply) => {
+      const playbook = await playbookService.getPlaybook(request.params.id);
+      if (!playbook) return reply.status(404).send({ error: "Playbook not found" });
+      return playbook;
+    },
+  );
+}

--- a/backend/src/services/playbook.service.ts
+++ b/backend/src/services/playbook.service.ts
@@ -1,0 +1,172 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { logger } from "../utils/logger.js";
+
+export interface PlaybookStep {
+  order: number;
+  title: string;
+  body: string;
+}
+
+export interface AlertPlaybook {
+  id: string;
+  alertType: string;
+  title: string;
+  severity: string[];
+  summary: string;
+  steps: PlaybookStep[];
+  tags: string[];
+}
+
+export interface PlaybookSearchResult {
+  playbooks: AlertPlaybook[];
+  total: number;
+  query?: string;
+}
+
+const RUNBOOK_PATH = path.resolve(process.cwd(), "docs/ALERTING_RUNBOOK.md");
+
+let cachedPlaybooks: AlertPlaybook[] | null = null;
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+}
+
+function extractAlertType(section: string): string {
+  const match = section.match(/\*\*Alert Type\*\*:\s*`([^`]+)`/i);
+  return match?.[1] ?? slugify(section.split("\n")[0] ?? "playbook");
+}
+
+function extractSeverity(section: string): string[] {
+  const match = section.match(/\*\*Typical Severity\*\*:\s*([^\n]+)/i);
+  if (!match) return [];
+  return match[1]
+    .split("/")
+    .map((part) => part.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function extractSteps(section: string): PlaybookStep[] {
+  const lines = section.split("\n");
+  const steps: PlaybookStep[] = [];
+  let current: PlaybookStep | null = null;
+
+  for (const line of lines) {
+    const numbered = line.match(/^\d+\.\s+\*\*(.+?)\*\*/);
+    const numberedPlain = line.match(/^\d+\.\s+(.+)/);
+
+    if (numbered) {
+      if (current) steps.push(current);
+      current = { order: steps.length + 1, title: numbered[1], body: "" };
+      continue;
+    }
+
+    if (numberedPlain && !line.includes("```")) {
+      if (current) steps.push(current);
+      current = { order: steps.length + 1, title: numberedPlain[1], body: "" };
+      continue;
+    }
+
+    if (current && line.trim() && !line.startsWith("#")) {
+      current.body += `${line.trim()}\n`;
+    }
+  }
+
+  if (current) steps.push(current);
+  return steps;
+}
+
+export function parsePlaybooksFromMarkdown(markdown: string): AlertPlaybook[] {
+  const sectionChunks = markdown.split(/\n###\s+/).slice(1);
+  const playbooks: AlertPlaybook[] = [];
+
+  for (const chunk of sectionChunks) {
+    const section = `### ${chunk}`;
+    const titleLine = chunk.split("\n")[0]?.trim() ?? "Alert playbook";
+    const title = titleLine.replace(/^\d+\.\s*/, "");
+    const alertType = extractAlertType(section);
+    const steps = extractSteps(section);
+
+    if (steps.length === 0) continue;
+
+    const summary = chunk
+      .split("\n")
+      .find((line) => line.startsWith("**Description**:"))
+      ?.replace("**Description**:", "")
+      .trim() ?? `Remediation steps for ${title}`;
+
+    playbooks.push({
+      id: slugify(alertType || title),
+      alertType,
+      title,
+      severity: extractSeverity(section),
+      summary,
+      steps,
+      tags: [alertType, ...extractSeverity(section)],
+    });
+  }
+
+  return playbooks;
+}
+
+export class PlaybookService {
+  async loadPlaybooks(): Promise<AlertPlaybook[]> {
+    if (cachedPlaybooks) return cachedPlaybooks;
+
+    try {
+      const markdown = await readFile(RUNBOOK_PATH, "utf8");
+      cachedPlaybooks = parsePlaybooksFromMarkdown(markdown);
+      return cachedPlaybooks;
+    } catch (error) {
+      logger.error({ error }, "Failed to load alerting runbook");
+      cachedPlaybooks = [];
+      return cachedPlaybooks;
+    }
+  }
+
+  async listPlaybooks(): Promise<AlertPlaybook[]> {
+    return this.loadPlaybooks();
+  }
+
+  async getPlaybook(idOrType: string): Promise<AlertPlaybook | null> {
+    const playbooks = await this.loadPlaybooks();
+    return (
+      playbooks.find(
+        (playbook) =>
+          playbook.id === idOrType ||
+          playbook.alertType === idOrType ||
+          playbook.title.toLowerCase() === idOrType.toLowerCase(),
+      ) ?? null
+    );
+  }
+
+  async searchPlaybooks(query?: string, alertType?: string, severity?: string): Promise<PlaybookSearchResult> {
+    const playbooks = await this.loadPlaybooks();
+    const q = query?.trim().toLowerCase();
+
+    const filtered = playbooks.filter((playbook) => {
+      if (alertType && playbook.alertType !== alertType) return false;
+      if (severity && !playbook.severity.includes(severity.toLowerCase())) return false;
+      if (!q) return true;
+
+      const haystack = [
+        playbook.title,
+        playbook.summary,
+        playbook.alertType,
+        ...playbook.tags,
+        ...playbook.steps.map((step) => `${step.title} ${step.body}`),
+      ]
+        .join(" ")
+        .toLowerCase();
+
+      return haystack.includes(q);
+    });
+
+    return { playbooks: filtered, total: filtered.length, query };
+  }
+}
+
+export const playbookService = new PlaybookService();

--- a/backend/tests/services/playbook.service.test.ts
+++ b/backend/tests/services/playbook.service.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { parsePlaybooksFromMarkdown } from "../../src/services/playbook.service.js";
+
+const SAMPLE = `
+### 1. Supply Mismatch
+
+**Alert Type**: \`supply_mismatch\`
+**Typical Severity**: Critical / High
+**Description**: Detected mismatch between Stellar supply and source chain reserves
+
+#### Immediate Actions
+
+1. **Verify the Alert**
+   Check current supply data.
+
+2. **Assess Severity**
+   Compare mismatch percentage.
+`;
+
+describe("playbook parsing", () => {
+  it("extracts alert playbooks from markdown", () => {
+    const playbooks = parsePlaybooksFromMarkdown(SAMPLE);
+    expect(playbooks).toHaveLength(1);
+    expect(playbooks[0].alertType).toBe("supply_mismatch");
+    expect(playbooks[0].steps.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/docs/alert-playbook-format.md
+++ b/docs/alert-playbook-format.md
@@ -1,0 +1,27 @@
+# Alert Playbook Format
+
+Playbooks are parsed from `backend/docs/ALERTING_RUNBOOK.md` and exposed via `/api/v1/playbooks`.
+
+## Structure
+
+```json
+{
+  "id": "supply-mismatch",
+  "alertType": "supply_mismatch",
+  "title": "Supply Mismatch",
+  "severity": ["critical", "high"],
+  "summary": "Detected mismatch between Stellar supply and source chain reserves",
+  "steps": [
+    { "order": 1, "title": "Verify the Alert", "body": "..." }
+  ],
+  "tags": ["supply_mismatch", "critical", "high"]
+}
+```
+
+## Lookup
+
+- `GET /api/v1/playbooks?q=supply` — full-text search
+- `GET /api/v1/playbooks?alertType=supply_mismatch` — context-aware lookup for triggered alerts
+- `GET /api/v1/playbooks/:id` — fetch a single playbook
+
+The alert playbook viewer at `/alert-playbooks` supports search, step-by-step display, and print-friendly layout.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -29,6 +29,7 @@ const NotificationPreferencesPage = lazy(() => import("./pages/NotificationPrefe
 const RelationshipExplorer = lazy(() => import("./pages/RelationshipExplorer"));
 const SearchResultsPage = lazy(() => import("./pages/SearchResultsPage"));
 const Alerts = lazy(() => import("./pages/Alerts"));
+const AlertPlaybookViewer = lazy(() => import("./pages/AlertPlaybookViewer"));
 const DataProvenanceGraph = lazy(() => import("./pages/DataProvenanceGraph"));
 const AlertSimulationSandbox = lazy(() => import("./pages/AlertSimulationSandbox"));
 const LiquidityFragmentation = lazy(() => import("./pages/LiquidityFragmentation"));
@@ -65,6 +66,7 @@ function App() {
               <Route path="/incidents" element={<Incidents />} />
               <Route path="/incidents/replay/:id" element={<IncidentReplay />} />
               <Route path="/alerts" element={<Alerts />} />
+              <Route path="/alert-playbooks" element={<AlertPlaybookViewer />} />
               <Route path="/transactions" element={<Transactions />} />
               <Route path="/analytics" element={<Analytics />} />
               <Route path="/analytics/metric-builder" element={<CustomMetricBuilder />} />

--- a/frontend/src/components/MobileNav/navigation.ts
+++ b/frontend/src/components/MobileNav/navigation.ts
@@ -42,9 +42,9 @@ export const navGroups: NavGroup[] = [
         description: "Manage alert dispatch routing and audit",
       },
       {
-        to: "/alert-sandbox",
-        label: "Alert Sandbox",
-        description: "Dry-run alert rules against synthetic data before enabling in production",
+        to: "/alert-playbooks",
+        label: "Alert Playbooks",
+        description: "Runbooks and remediation steps for triggered alerts",
       },
       {
         to: "/admin/access-audit",

--- a/frontend/src/hooks/useAlertPlaybooks.ts
+++ b/frontend/src/hooks/useAlertPlaybooks.ts
@@ -1,0 +1,19 @@
+import { useQuery } from "@tanstack/react-query";
+import { getAlertPlaybook, searchAlertPlaybooks } from "../services/api";
+
+export function useAlertPlaybooks(query?: string, alertType?: string) {
+  return useQuery({
+    queryKey: ["alertPlaybooks", query, alertType],
+    queryFn: () => searchAlertPlaybooks({ q: query, alertType }),
+    staleTime: 60_000,
+  });
+}
+
+export function useAlertPlaybook(id?: string) {
+  return useQuery({
+    queryKey: ["alertPlaybook", id],
+    queryFn: () => getAlertPlaybook(id!),
+    enabled: Boolean(id),
+    staleTime: 60_000,
+  });
+}

--- a/frontend/src/pages/AlertPlaybookViewer.test.tsx
+++ b/frontend/src/pages/AlertPlaybookViewer.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+import AlertPlaybookViewer from "./AlertPlaybookViewer";
+
+vi.mock("../hooks/useAlertPlaybooks", () => ({
+  useAlertPlaybooks: () => ({
+    data: {
+      playbooks: [
+        {
+          id: "supply-mismatch",
+          alertType: "supply_mismatch",
+          title: "Supply Mismatch",
+          severity: ["critical", "high"],
+          summary: "Reserve drift detected",
+          steps: [
+            { order: 1, title: "Verify the Alert", body: "Check supply endpoints." },
+          ],
+          tags: ["supply_mismatch"],
+        },
+      ],
+      total: 1,
+    },
+    isLoading: false,
+  }),
+  useAlertPlaybook: () => ({
+    data: {
+      id: "supply-mismatch",
+      alertType: "supply_mismatch",
+      title: "Supply Mismatch",
+      severity: ["critical", "high"],
+      summary: "Reserve drift detected",
+      steps: [{ order: 1, title: "Verify the Alert", body: "Check supply endpoints." }],
+      tags: ["supply_mismatch"],
+    },
+    isLoading: false,
+  }),
+}));
+
+describe("AlertPlaybookViewer", () => {
+  it("renders search controls and playbook steps", () => {
+    const queryClient = new QueryClient();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AlertPlaybookViewer />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByRole("heading", { name: "Alert Playbooks" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Search playbooks")).toBeInTheDocument();
+    expect(screen.getByText("Step 1: Verify the Alert")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Print playbook" })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/AlertPlaybookViewer.tsx
+++ b/frontend/src/pages/AlertPlaybookViewer.tsx
@@ -1,0 +1,134 @@
+import { useMemo, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import { useAlertPlaybook, useAlertPlaybooks } from "../hooks/useAlertPlaybooks";
+
+export default function AlertPlaybookViewer() {
+  const [searchParams] = useSearchParams();
+  const initialAlertType = searchParams.get("alertType") ?? "";
+  const [query, setQuery] = useState("");
+  const [alertType, setAlertType] = useState(initialAlertType);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const { data: searchResults, isLoading } = useAlertPlaybooks(query, alertType || undefined);
+  const playbooks = searchResults?.playbooks ?? [];
+
+  const activeId = selectedId ?? playbooks[0]?.id ?? null;
+  const { data: selectedPlaybook } = useAlertPlaybook(activeId ?? undefined);
+
+  const contextLabel = useMemo(() => {
+    if (alertType) return `Context: ${alertType}`;
+    return "All alert types";
+  }, [alertType]);
+
+  const handlePrint = () => {
+    window.print();
+  };
+
+  return (
+    <div className="space-y-6 print:space-y-4">
+      <div className="flex flex-wrap items-end justify-between gap-4 print:hidden">
+        <div>
+          <h1 className="text-3xl font-bold text-stellar-text-primary">Alert Playbooks</h1>
+          <p className="mt-2 text-stellar-text-secondary">
+            Runbooks and remediation steps for triggered alerts.
+          </p>
+        </div>
+        <button
+          type="button"
+          className="rounded-md border border-stellar-border px-4 py-2 text-sm text-white"
+          onClick={handlePrint}
+        >
+          Print playbook
+        </button>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-[320px_1fr] print:block">
+        <aside className="space-y-4 rounded-xl border border-stellar-border bg-stellar-card p-4 print:hidden">
+          <div>
+            <label htmlFor="playbook-search" className="text-sm text-stellar-text-secondary">
+              Search playbooks
+            </label>
+            <input
+              id="playbook-search"
+              className="mt-1 w-full rounded-md border border-stellar-border bg-stellar-dark px-3 py-2 text-white"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="supply mismatch, bridge downtime..."
+            />
+          </div>
+          <div>
+            <label htmlFor="alert-type-filter" className="text-sm text-stellar-text-secondary">
+              Alert type
+            </label>
+            <input
+              id="alert-type-filter"
+              className="mt-1 w-full rounded-md border border-stellar-border bg-stellar-dark px-3 py-2 text-white"
+              value={alertType}
+              onChange={(e) => setAlertType(e.target.value)}
+              placeholder="supply_mismatch"
+            />
+          </div>
+          <p className="text-xs text-stellar-text-secondary">{contextLabel}</p>
+
+          {isLoading ? (
+            <p className="text-sm text-stellar-text-secondary">Loading playbooks...</p>
+          ) : (
+            <ul className="space-y-2">
+              {playbooks.map((playbook) => (
+                <li key={playbook.id}>
+                  <button
+                    type="button"
+                    className={`w-full rounded-md border px-3 py-2 text-left text-sm ${
+                      playbook.id === activeId
+                        ? "border-stellar-blue bg-stellar-blue/10 text-white"
+                        : "border-stellar-border text-stellar-text-secondary hover:text-white"
+                    }`}
+                    onClick={() => setSelectedId(playbook.id)}
+                  >
+                    <span className="font-medium">{playbook.title}</span>
+                    <span className="mt-1 block text-xs">{playbook.alertType}</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </aside>
+
+        <section className="rounded-xl border border-stellar-border bg-stellar-card p-6 print:border-none print:p-0">
+          {selectedPlaybook ? (
+            <article>
+              <header className="border-b border-stellar-border pb-4 print:border-black">
+                <p className="text-sm uppercase tracking-wide text-stellar-text-secondary print:text-black">
+                  {selectedPlaybook.alertType}
+                  {selectedPlaybook.severity.length > 0 &&
+                    ` · ${selectedPlaybook.severity.join(" / ")}`}
+                </p>
+                <h2 className="mt-1 text-2xl font-semibold text-white print:text-black">
+                  {selectedPlaybook.title}
+                </h2>
+                <p className="mt-2 text-stellar-text-secondary print:text-black">
+                  {selectedPlaybook.summary}
+                </p>
+              </header>
+
+              <ol className="mt-6 space-y-4">
+                {selectedPlaybook.steps.map((step) => (
+                  <li key={step.order} className="rounded-md border border-stellar-border p-4 print:break-inside-avoid">
+                    <p className="font-medium text-white print:text-black">
+                      Step {step.order}: {step.title}
+                    </p>
+                    <p className="mt-2 whitespace-pre-wrap text-sm text-stellar-text-secondary print:text-black">
+                      {step.body.trim()}
+                    </p>
+                  </li>
+                ))}
+              </ol>
+            </article>
+          ) : (
+            <p className="text-stellar-text-secondary">Select a playbook to view remediation steps.</p>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -928,3 +928,38 @@ export function deleteSavedMetric(id: string) {
     method: "DELETE",
   });
 }
+
+export interface PlaybookStep {
+  order: number;
+  title: string;
+  body: string;
+}
+
+export interface AlertPlaybook {
+  id: string;
+  alertType: string;
+  title: string;
+  severity: string[];
+  summary: string;
+  steps: PlaybookStep[];
+  tags: string[];
+}
+
+export function searchAlertPlaybooks(params?: {
+  q?: string;
+  alertType?: string;
+  severity?: string;
+}) {
+  const searchParams = new URLSearchParams();
+  if (params?.q) searchParams.set("q", params.q);
+  if (params?.alertType) searchParams.set("alertType", params.alertType);
+  if (params?.severity) searchParams.set("severity", params.severity);
+  const qs = searchParams.toString();
+  return fetchApi<{ playbooks: AlertPlaybook[]; total: number; query?: string }>(
+    `/playbooks${qs ? `?${qs}` : ""}`,
+  );
+}
+
+export function getAlertPlaybook(id: string) {
+  return fetchApi<AlertPlaybook>(`/playbooks/${encodeURIComponent(id)}`);
+}


### PR DESCRIPTION
## Summary
- Adds `/api/v1/playbooks` search and lookup API parsed from `ALERTING_RUNBOOK.md`
- Introduces `/alert-playbooks` viewer with search, alert-type context, step display, and print support
- Documents playbook JSON shape in `docs/alert-playbook-format.md`

## Test plan
- [x] Backend build passes
- [x] Frontend build passes
- [x] `playbook.service.test.ts` passes
- [x] `AlertPlaybookViewer.test.tsx` passes

Closes #631