### PR TITLE
test: create database state fixtures

### DIFF
--- a/backend/tests/fixtures/fixture-manager.ts
+++ b/backend/tests/fixtures/fixture-manager.ts
@@ -1,0 +1,44 @@
+import type { Knex } from "knex";
+import { Fixture } from "./fixture-registry.js";
+import { truncateTables } from "../helpers/db.js";
+import { fixtures } from "./states/index.js";
+
+const FIXTURE_TABLES = [
+  "reserve_commitments",
+  "bridge_operators",
+  "bridge_transactions",
+  "bridges",
+  "assets",
+];
+
+let _loadedFixture: Fixture | null = null;
+
+/**
+ * Load a named fixture into the database.
+ * Automatically truncates relevant tables before inserting to ensure a clean slate.
+ */
+export async function loadFixture(db: Knex, fixture: Fixture): Promise<void> {
+  await truncateTables(db, FIXTURE_TABLES);
+
+  const loader = fixtures[fixture];
+  if (!loader) {
+    throw new Error(`Unknown fixture: "${fixture}". Register it in tests/fixtures/states/index.ts`);
+  }
+
+  await loader(db);
+  _loadedFixture = fixture;
+}
+
+/**
+ * Reset fixture state — truncates all fixture-managed tables.
+ * Call in afterEach to guarantee a clean slate for the next test.
+ */
+export async function resetFixture(db: Knex): Promise<void> {
+  await truncateTables(db, FIXTURE_TABLES);
+  _loadedFixture = null;
+}
+
+/** Returns the name of the currently loaded fixture, or null if none. */
+export function listLoadedFixtures(): Fixture | null {
+  return _loadedFixture;
+}

--- a/backend/tests/fixtures/fixture-registry.ts
+++ b/backend/tests/fixtures/fixture-registry.ts
@@ -1,0 +1,23 @@
+/** Named test states available for fixture loading. */
+export enum Fixture {
+  /** One healthy bridge (Circle/USDC) with matching Stellar + Ethereum supplies. */
+  HealthyBridge = "healthy-bridge",
+
+  /** One degraded bridge with a 15% supply mismatch. */
+  DegradedBridge = "degraded-bridge",
+
+  /** Two bridges — one healthy, one down — for multi-bridge tests. */
+  MixedBridgeHealth = "mixed-bridge-health",
+
+  /** Healthy bridge with a pending reserve commitment (sequence 1). */
+  PendingReserveCommitment = "pending-reserve-commitment",
+
+  /** Healthy bridge with a verified reserve commitment. */
+  VerifiedReserveCommitment = "verified-reserve-commitment",
+
+  /** Multiple assets including native XLM, USDC (bridged), and EURC (bridged). */
+  MultiAsset = "multi-asset",
+
+  /** Minimal state — a single active asset, no bridges or commitments. */
+  MinimalAsset = "minimal-asset",
+}

--- a/backend/tests/fixtures/index.ts
+++ b/backend/tests/fixtures/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Database state fixtures for integration testing.
+ *
+ * Each fixture represents a reproducible, named database state that can be
+ * loaded before a test and reset afterwards.  Fixtures are deterministic —
+ * the same fixture always produces the same rows.
+ *
+ * Usage:
+ *   import { loadFixture, resetFixture, Fixture } from "../fixtures";
+ *
+ *   beforeEach(() => loadFixture(db, Fixture.HealthyBridge));
+ *   afterEach(() => resetFixture(db));
+ */
+
+export { Fixture } from "./fixture-registry.js";
+export { loadFixture, resetFixture, listLoadedFixtures } from "./fixture-manager.js";

--- a/backend/tests/fixtures/states/degraded-bridge.ts
+++ b/backend/tests/fixtures/states/degraded-bridge.ts
@@ -1,0 +1,27 @@
+import type { Knex } from "knex";
+
+export async function degradedBridge(db: Knex): Promise<void> {
+  await db("assets").insert({
+    symbol: "USDC",
+    name: "USD Coin",
+    issuer: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+    asset_type: "credit_alphanum4",
+    bridge_provider: "Circle",
+    source_chain: "Ethereum",
+    is_active: true,
+  });
+
+  // 15% mismatch: supply_on_stellar is higher than source by 15%
+  const sourceSupply = 500_000;
+  const stellarSupply = Math.round(sourceSupply * 1.15);
+
+  await db("bridges").insert({
+    name: "Circle",
+    source_chain: "Ethereum",
+    status: "degraded",
+    total_value_locked: sourceSupply + stellarSupply,
+    supply_on_stellar: stellarSupply,
+    supply_on_source: sourceSupply,
+    is_active: true,
+  });
+}

--- a/backend/tests/fixtures/states/healthy-bridge.ts
+++ b/backend/tests/fixtures/states/healthy-bridge.ts
@@ -1,0 +1,23 @@
+import type { Knex } from "knex";
+
+export async function healthyBridge(db: Knex): Promise<void> {
+  await db("assets").insert({
+    symbol: "USDC",
+    name: "USD Coin",
+    issuer: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+    asset_type: "credit_alphanum4",
+    bridge_provider: "Circle",
+    source_chain: "Ethereum",
+    is_active: true,
+  });
+
+  await db("bridges").insert({
+    name: "Circle",
+    source_chain: "Ethereum",
+    status: "healthy",
+    total_value_locked: 1_000_000,
+    supply_on_stellar: 500_000,
+    supply_on_source: 500_000,
+    is_active: true,
+  });
+}

--- a/backend/tests/fixtures/states/index.ts
+++ b/backend/tests/fixtures/states/index.ts
@@ -1,0 +1,19 @@
+import type { Knex } from "knex";
+import { Fixture } from "../fixture-registry.js";
+import { healthyBridge } from "./healthy-bridge.js";
+import { degradedBridge } from "./degraded-bridge.js";
+import { mixedBridgeHealth } from "./mixed-bridge-health.js";
+import { pendingReserveCommitment } from "./pending-reserve-commitment.js";
+import { verifiedReserveCommitment } from "./verified-reserve-commitment.js";
+import { multiAsset } from "./multi-asset.js";
+import { minimalAsset } from "./minimal-asset.js";
+
+export const fixtures: Record<Fixture, (db: Knex) => Promise<void>> = {
+  [Fixture.HealthyBridge]: healthyBridge,
+  [Fixture.DegradedBridge]: degradedBridge,
+  [Fixture.MixedBridgeHealth]: mixedBridgeHealth,
+  [Fixture.PendingReserveCommitment]: pendingReserveCommitment,
+  [Fixture.VerifiedReserveCommitment]: verifiedReserveCommitment,
+  [Fixture.MultiAsset]: multiAsset,
+  [Fixture.MinimalAsset]: minimalAsset,
+};

--- a/backend/tests/fixtures/states/minimal-asset.ts
+++ b/backend/tests/fixtures/states/minimal-asset.ts
@@ -1,0 +1,13 @@
+import type { Knex } from "knex";
+
+export async function minimalAsset(db: Knex): Promise<void> {
+  await db("assets").insert({
+    symbol: "XLM",
+    name: "Stellar Lumens",
+    issuer: null,
+    asset_type: "native",
+    bridge_provider: null,
+    source_chain: null,
+    is_active: true,
+  });
+}

--- a/backend/tests/fixtures/states/mixed-bridge-health.ts
+++ b/backend/tests/fixtures/states/mixed-bridge-health.ts
@@ -1,0 +1,45 @@
+import type { Knex } from "knex";
+
+export async function mixedBridgeHealth(db: Knex): Promise<void> {
+  await db("assets").insert([
+    {
+      symbol: "USDC",
+      name: "USD Coin",
+      issuer: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+      asset_type: "credit_alphanum4",
+      bridge_provider: "Circle",
+      source_chain: "Ethereum",
+      is_active: true,
+    },
+    {
+      symbol: "EURC",
+      name: "Euro Coin",
+      issuer: "GDQOE23CFSUMSVZZ4YRVXGW7PCFNIAHLMRAHDE4Z32DIBQGH4KZZK2KZ",
+      asset_type: "credit_alphanum4",
+      bridge_provider: "Circle",
+      source_chain: "Ethereum",
+      is_active: true,
+    },
+  ]);
+
+  await db("bridges").insert([
+    {
+      name: "Circle",
+      source_chain: "Ethereum",
+      status: "healthy",
+      total_value_locked: 1_000_000,
+      supply_on_stellar: 500_000,
+      supply_on_source: 500_000,
+      is_active: true,
+    },
+    {
+      name: "Wormhole",
+      source_chain: "Ethereum",
+      status: "down",
+      total_value_locked: 0,
+      supply_on_stellar: 0,
+      supply_on_source: 0,
+      is_active: true,
+    },
+  ]);
+}

--- a/backend/tests/fixtures/states/multi-asset.ts
+++ b/backend/tests/fixtures/states/multi-asset.ts
@@ -1,0 +1,33 @@
+import type { Knex } from "knex";
+
+export async function multiAsset(db: Knex): Promise<void> {
+  await db("assets").insert([
+    {
+      symbol: "XLM",
+      name: "Stellar Lumens",
+      issuer: null,
+      asset_type: "native",
+      bridge_provider: null,
+      source_chain: null,
+      is_active: true,
+    },
+    {
+      symbol: "USDC",
+      name: "USD Coin",
+      issuer: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+      asset_type: "credit_alphanum4",
+      bridge_provider: "Circle",
+      source_chain: "Ethereum",
+      is_active: true,
+    },
+    {
+      symbol: "EURC",
+      name: "Euro Coin",
+      issuer: "GDQOE23CFSUMSVZZ4YRVXGW7PCFNIAHLMRAHDE4Z32DIBQGH4KZZK2KZ",
+      asset_type: "credit_alphanum4",
+      bridge_provider: "Circle",
+      source_chain: "Ethereum",
+      is_active: true,
+    },
+  ]);
+}

--- a/backend/tests/fixtures/states/pending-reserve-commitment.ts
+++ b/backend/tests/fixtures/states/pending-reserve-commitment.ts
@@ -1,0 +1,44 @@
+import type { Knex } from "knex";
+
+export async function pendingReserveCommitment(db: Knex): Promise<void> {
+  await db("assets").insert({
+    symbol: "USDC",
+    name: "USD Coin",
+    issuer: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+    asset_type: "credit_alphanum4",
+    bridge_provider: "Circle",
+    source_chain: "Ethereum",
+    is_active: true,
+  });
+
+  await db("bridges").insert({
+    name: "Circle",
+    source_chain: "Ethereum",
+    status: "healthy",
+    total_value_locked: 1_000_000,
+    supply_on_stellar: 500_000,
+    supply_on_source: 500_000,
+    is_active: true,
+  });
+
+  await db("bridge_operators").insert({
+    bridge_id: "circle-usdc-eth",
+    operator_address: "GBTEST000OPERATOR000ADDRESS000000000000000000000000000000",
+    provider_name: "Circle",
+    asset_code: "USDC",
+    source_chain: "Ethereum",
+    stake: 100_000,
+    is_active: true,
+    slash_count: 0,
+  });
+
+  await db("reserve_commitments").insert({
+    bridge_id: "circle-usdc-eth",
+    sequence: 1,
+    merkle_root: "a".repeat(64),
+    total_reserves: 500_000,
+    committed_at: Date.now(),
+    committed_ledger: 1_000_000,
+    status: "pending",
+  });
+}

--- a/backend/tests/fixtures/states/verified-reserve-commitment.ts
+++ b/backend/tests/fixtures/states/verified-reserve-commitment.ts
@@ -1,0 +1,44 @@
+import type { Knex } from "knex";
+
+export async function verifiedReserveCommitment(db: Knex): Promise<void> {
+  await db("assets").insert({
+    symbol: "USDC",
+    name: "USD Coin",
+    issuer: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+    asset_type: "credit_alphanum4",
+    bridge_provider: "Circle",
+    source_chain: "Ethereum",
+    is_active: true,
+  });
+
+  await db("bridges").insert({
+    name: "Circle",
+    source_chain: "Ethereum",
+    status: "healthy",
+    total_value_locked: 1_000_000,
+    supply_on_stellar: 500_000,
+    supply_on_source: 500_000,
+    is_active: true,
+  });
+
+  await db("bridge_operators").insert({
+    bridge_id: "circle-usdc-eth",
+    operator_address: "GBTEST000OPERATOR000ADDRESS000000000000000000000000000000",
+    provider_name: "Circle",
+    asset_code: "USDC",
+    source_chain: "Ethereum",
+    stake: 100_000,
+    is_active: true,
+    slash_count: 0,
+  });
+
+  await db("reserve_commitments").insert({
+    bridge_id: "circle-usdc-eth",
+    sequence: 1,
+    merkle_root: "b".repeat(64),
+    total_reserves: 500_000,
+    committed_at: Date.now() - 3_600_000, // 1 hour ago
+    committed_ledger: 999_000,
+    status: "verified",
+  });
+}

--- a/backend/tests/integration/db/fixtures.integration.test.ts
+++ b/backend/tests/integration/db/fixtures.integration.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Integration tests verifying the fixture system itself — Issue #651
+ *
+ * These tests confirm that:
+ *  - Each fixture loads its expected rows deterministically
+ *  - resetFixture truncates all managed tables cleanly
+ *  - Fixtures can be swapped between tests without leakage
+ */
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { getDatabase, closeDatabase } from "../../../src/database/connection.js";
+import { resetDatabase } from "../../helpers/db.js";
+import { Fixture, loadFixture, resetFixture, listLoadedFixtures } from "../../fixtures/index.js";
+import type { Knex } from "knex";
+
+let db: Knex;
+
+beforeAll(async () => {
+  db = getDatabase();
+  await resetDatabase(db);
+});
+
+afterAll(async () => {
+  await closeDatabase();
+});
+
+afterEach(async () => {
+  await resetFixture(db);
+});
+
+// ─── MinimalAsset ─────────────────────────────────────────────────────────────
+
+describe("Fixture.MinimalAsset", () => {
+  beforeEach(() => loadFixture(db, Fixture.MinimalAsset));
+
+  it("inserts exactly one asset (XLM)", async () => {
+    const rows = await db("assets").select("*");
+    expect(rows).toHaveLength(1);
+    expect(rows[0].symbol).toBe("XLM");
+    expect(rows[0].asset_type).toBe("native");
+  });
+
+  it("inserts no bridges", async () => {
+    const rows = await db("bridges").select("*");
+    expect(rows).toHaveLength(0);
+  });
+});
+
+// ─── HealthyBridge ────────────────────────────────────────────────────────────
+
+describe("Fixture.HealthyBridge", () => {
+  beforeEach(() => loadFixture(db, Fixture.HealthyBridge));
+
+  it("inserts one bridge with status=healthy", async () => {
+    const rows = await db("bridges").select("*");
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe("healthy");
+    expect(rows[0].name).toBe("Circle");
+  });
+
+  it("supply_on_stellar equals supply_on_source (no mismatch)", async () => {
+    const [bridge] = await db("bridges").select("*");
+    expect(Number(bridge.supply_on_stellar)).toBe(Number(bridge.supply_on_source));
+  });
+});
+
+// ─── DegradedBridge ───────────────────────────────────────────────────────────
+
+describe("Fixture.DegradedBridge", () => {
+  beforeEach(() => loadFixture(db, Fixture.DegradedBridge));
+
+  it("inserts one bridge with status=degraded", async () => {
+    const [bridge] = await db("bridges").select("*");
+    expect(bridge.status).toBe("degraded");
+  });
+
+  it("supply_on_stellar is ~15% higher than supply_on_source", async () => {
+    const [bridge] = await db("bridges").select("*");
+    const stellar = Number(bridge.supply_on_stellar);
+    const source = Number(bridge.supply_on_source);
+    const mismatch = (stellar - source) / source;
+    expect(mismatch).toBeCloseTo(0.15, 1);
+  });
+});
+
+// ─── MixedBridgeHealth ────────────────────────────────────────────────────────
+
+describe("Fixture.MixedBridgeHealth", () => {
+  beforeEach(() => loadFixture(db, Fixture.MixedBridgeHealth));
+
+  it("inserts two bridges with different statuses", async () => {
+    const rows = await db("bridges").select("status").orderBy("name");
+    const statuses = rows.map((r: { status: string }) => r.status);
+    expect(statuses).toContain("healthy");
+    expect(statuses).toContain("down");
+  });
+
+  it("inserts two assets", async () => {
+    const rows = await db("assets").select("symbol");
+    expect(rows).toHaveLength(2);
+  });
+});
+
+// ─── MultiAsset ───────────────────────────────────────────────────────────────
+
+describe("Fixture.MultiAsset", () => {
+  beforeEach(() => loadFixture(db, Fixture.MultiAsset));
+
+  it("inserts XLM, USDC, and EURC", async () => {
+    const rows = await db("assets").select("symbol").orderBy("symbol");
+    const symbols = rows.map((r: { symbol: string }) => r.symbol);
+    expect(symbols).toContain("XLM");
+    expect(symbols).toContain("USDC");
+    expect(symbols).toContain("EURC");
+  });
+
+  it("XLM has no bridge_provider (native asset)", async () => {
+    const [xlm] = await db("assets").where("symbol", "XLM").select("bridge_provider");
+    expect(xlm.bridge_provider).toBeNull();
+  });
+});
+
+// ─── PendingReserveCommitment ─────────────────────────────────────────────────
+
+describe("Fixture.PendingReserveCommitment", () => {
+  beforeEach(() => loadFixture(db, Fixture.PendingReserveCommitment));
+
+  it("inserts a reserve commitment with status=pending", async () => {
+    const rows = await db("reserve_commitments").select("*");
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe("pending");
+    expect(rows[0].sequence).toBe(1);
+  });
+
+  it("inserts a bridge operator linked to the commitment", async () => {
+    const rows = await db("bridge_operators").select("*");
+    expect(rows).toHaveLength(1);
+    expect(rows[0].bridge_id).toBe("circle-usdc-eth");
+  });
+});
+
+// ─── VerifiedReserveCommitment ────────────────────────────────────────────────
+
+describe("Fixture.VerifiedReserveCommitment", () => {
+  beforeEach(() => loadFixture(db, Fixture.VerifiedReserveCommitment));
+
+  it("inserts a reserve commitment with status=verified", async () => {
+    const [commitment] = await db("reserve_commitments").select("*");
+    expect(commitment.status).toBe("verified");
+  });
+
+  it("committed_at is in the past", async () => {
+    const [commitment] = await db("reserve_commitments").select("committed_at");
+    expect(Number(commitment.committed_at)).toBeLessThan(Date.now());
+  });
+});
+
+// ─── Fixture isolation ────────────────────────────────────────────────────────
+
+describe("Fixture isolation (no cross-test leakage)", () => {
+  it("tables are empty after resetFixture", async () => {
+    await loadFixture(db, Fixture.HealthyBridge);
+    await resetFixture(db);
+
+    const bridges = await db("bridges").select("*");
+    const assets = await db("assets").select("*");
+    expect(bridges).toHaveLength(0);
+    expect(assets).toHaveLength(0);
+  });
+
+  it("loading a second fixture does not accumulate rows from the first", async () => {
+    await loadFixture(db, Fixture.HealthyBridge);
+    await loadFixture(db, Fixture.MinimalAsset); // implicitly resets before loading
+
+    const bridges = await db("bridges").select("*");
+    const assets = await db("assets").select("*");
+    expect(bridges).toHaveLength(0);
+    expect(assets).toHaveLength(1);
+    expect(assets[0].symbol).toBe("XLM");
+  });
+
+  it("listLoadedFixtures returns the current fixture name", async () => {
+    await loadFixture(db, Fixture.MultiAsset);
+    expect(listLoadedFixtures()).toBe(Fixture.MultiAsset);
+  });
+
+  it("listLoadedFixtures returns null after reset", async () => {
+    await loadFixture(db, Fixture.HealthyBridge);
+    await resetFixture(db);
+    expect(listLoadedFixtures()).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `backend/tests/fixtures/` — a fixture system with 7 named database states: `MinimalAsset`, `HealthyBridge`, `DegradedBridge`, `MixedBridgeHealth`, `MultiAsset`, `PendingReserveCommitment`, `VerifiedReserveCommitment`
- `loadFixture(db, Fixture.X)` truncates managed tables then inserts deterministic rows; `resetFixture(db)` clears all fixture-managed tables
- Adds `backend/tests/integration/db/fixtures.integration.test.ts` with 14 tests verifying row counts, field values, and isolation between tests

## Test plan

- [ ] `cd backend && npx vitest run tests/integration/db` — all 14 fixture tests pass
- [ ] Load `Fixture.DegradedBridge` and confirm ~15% mismatch between `supply_on_stellar` and `supply_on_source`
- [ ] Load `Fixture.HealthyBridge`, then `Fixture.MinimalAsset` — bridges table must be empty (no leakage)

Closes StellaBridge/Bridge-Watch#651