### PR TITLE
feat: contract annotations, schema contract tests, docker layer tuning, request context propagation

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -10,9 +10,12 @@
 FROM node:20-alpine AS base
 WORKDIR /app
 
-# Install dependencies first (layer cache friendly)
+# Install dependencies first (layer cache friendly). This layer is only
+# invalidated when package.json changes, not on every source edit. The
+# BuildKit cache mount keeps npm's package cache across builds so even an
+# invalidated install re-downloads as little as possible.
 COPY package.json ./
-RUN npm install
+RUN --mount=type=cache,target=/root/.npm npm install
 
 # -----------------------------------------------------------------------------
 # Development — live reload via tsx watch
@@ -40,7 +43,7 @@ WORKDIR /app
 ENV NODE_ENV=production
 
 COPY package.json ./
-RUN npm install --omit=dev && npm cache clean --force
+RUN --mount=type=cache,target=/root/.npm npm install --omit=dev && npm cache clean --force
 
 COPY --from=builder /app/dist ./dist
 

--- a/backend/docs/SCHEMA_CONTRACT_TESTING.md
+++ b/backend/docs/SCHEMA_CONTRACT_TESTING.md
@@ -1,0 +1,48 @@
+# Schema Contract Testing
+
+## Overview
+Schema contract tests verify that API responses keep matching the shape that
+consumers depend on, over time. They live in [`tests/contracts/`](../tests/contracts/)
+and run as part of the normal backend unit test suite (`npm run test:unit`,
+and the root `npm test`), so they execute in CI on every push and pull request
+alongside the rest of the backend tests — no separate workflow is needed.
+
+This is distinct from [Schema Drift Handling](SCHEMA_DRIFT_HANDLING.md), which
+detects drift in upstream provider payloads (Circle, CoinGecko, etc). Schema
+contract tests are about **our own** API responses staying stable for the
+clients that consume Bridge Watch.
+
+## How it works
+1. **Contract schemas** — [`tests/contracts/schemas.ts`](../tests/contracts/schemas.ts)
+   defines a [Zod](https://zod.dev) schema per endpoint response. These schemas
+   describe the public contract, independent of the Fastify route's internal
+   JSON-schema validation.
+2. **Breaking change detection** — [`tests/contracts/assertSchema.ts`](../tests/contracts/assertSchema.ts)
+   parses the live response against the contract schema and throws a readable,
+   per-field error (not a raw `ZodError` dump) if anything no longer matches —
+   a field was removed, renamed, or changed type.
+3. **Snapshots** — each test also calls `toMatchSnapshot()` on a representative
+   payload. Snapshots live in `tests/contracts/__snapshots__/` and show up as a
+   plain diff in the PR when a response shape changes, even for changes the
+   Zod schema itself wouldn't catch (e.g. a new optional field).
+4. **Coverage** — the suite covers representative endpoints: `GET /health`,
+   `GET /api/v1/assets`, and the contract annotation endpoints introduced
+   alongside this test suite. Extend coverage by adding a schema in
+   `schemas.ts` and a test in `api.contract.test.ts` for each new key endpoint.
+
+## Updating a contract
+When a response shape changes on purpose:
+1. Update the corresponding Zod schema in `tests/contracts/schemas.ts`.
+2. Run `npx vitest run --config vitest.unit.config.ts -u` to refresh snapshots.
+3. Call out the change explicitly in the PR description (and add a
+   `BREAKING CHANGE:` footer per [CONTRIBUTING.md](../../CONTRIBUTING.md) if it
+   breaks existing consumers).
+
+If a contract test fails and the response change was **not** intentional, that
+is the signal to fix the route/service instead of updating the schema.
+
+## Running locally
+```bash
+cd backend
+npm run test:unit -- tests/contracts
+```

--- a/backend/docs/contract-annotations.md
+++ b/backend/docs/contract-annotations.md
@@ -1,0 +1,55 @@
+# Contract Data Annotations
+
+## Overview
+Annotations let operators and auditors attach short, timestamped notes to contract
+data — for example recording why a reserve threshold was adjusted, or flagging a
+known anomaly during an incident. Annotations are read-only context: they never
+change the underlying contract data, they only add a human-readable trail next to it.
+
+Annotations are backed by the existing `service_annotations` table (see
+[`028_service_annotations.ts`](../src/database/migrations/028_service_annotations.ts))
+and exposed for contracts through a dedicated, contract-scoped route. Every
+annotation is also written to `service_annotation_audit`, so the full history
+of who created, updated, or deleted an annotation is preserved.
+
+## Semantics
+- **Storage**: each annotation is stored with `entityType="contract"` and
+  `entityId=<contractAddress>`, scoping it to a single contract.
+- **Timestamps**: `createdAt` / `updatedAt` are set automatically. The optional
+  `startTime` / `endTime` fields describe the window the annotation applies to
+  (e.g. an incident window), independent of when the annotation itself was written.
+- **Author info**: every annotation requires an `author` (the operator or
+  auditor who wrote it). Updates and deletes are attributed to an `actor` and
+  recorded in the audit log.
+- **Read access**: annotations for a contract are publicly readable via `GET`
+  so any operator or auditor reviewing the contract can see prior context.
+  Writes (`POST`) require an `author`; there is no implicit anonymous write.
+
+## API
+
+### Create an annotation
+```
+POST /api/v1/contracts/:contractAddress/annotations
+{
+  "content": "Reserve threshold lowered ahead of the v2 migration window",
+  "author": "ops@bridgewatch",
+  "startTime": "2026-06-20T00:00:00Z",
+  "endTime": "2026-06-27T00:00:00Z"
+}
+```
+Returns `201` with the created annotation, or `400` if `content`/`author` are missing.
+
+### Read annotations for a contract
+```
+GET /api/v1/contracts/:contractAddress/annotations
+GET /api/v1/contracts/:contractAddress/annotations?active=true&author=ops@bridgewatch
+```
+Returns `200` with an array of annotations for that contract, newest first.
+Optional query params filter by `active` status and `author`.
+
+## Relationship to the generic annotation API
+The contract routes are a thin convenience layer over the generic
+`/api/v1/service-annotations` endpoints (update, delete, and audit-log lookup
+by annotation `id` are still available there). Use the contract-scoped routes
+when you only care about one contract; use the generic routes when you need
+to update/delete a specific annotation or inspect its audit trail.

--- a/backend/docs/request-context-propagation.md
+++ b/backend/docs/request-context-propagation.md
@@ -1,0 +1,67 @@
+# Request Context Propagation
+
+## Overview
+Every inbound request gets a request ID, correlation ID, trace ID, and span ID
+so that traces and logs from internal services can be tied back to the
+request that triggered them. This builds on the existing tracing/correlation
+middleware in [`src/api/middleware/tracing.ts`](../src/api/middleware/tracing.ts)
+and [`src/api/middleware/correlation.middleware.ts`](../src/api/middleware/correlation.middleware.ts).
+
+## How context is captured
+`registerTracing` (in `tracing.ts`) runs on every request's `onRequest` hook:
+
+1. It resolves IDs from inbound headers if present, generating new ones otherwise:
+   - `x-request-id`
+   - `x-correlation-id` / `x-trace-id`
+   - `x-parent-span-id`
+   - `x-user-id` (or the authenticated user, once auth middleware has run)
+2. It attaches the resulting `TraceContext` to `request.traceContext` for
+   route handlers and other middleware that have direct access to the
+   Fastify request.
+3. It also enters the context into an `AsyncLocalStorage`
+   (see [`src/utils/requestContext.ts`](../src/utils/requestContext.ts)) for
+   the remainder of the request's lifecycle, so code several layers deep in a
+   service call — which does not have the Fastify `request` object — can
+   still read the current request's context.
+4. Response headers `X-Request-ID`, `X-Correlation-ID`, `X-Trace-ID`, and
+   `X-Span-ID` are set so the context round-trips back to the caller.
+
+## Using context propagation in services
+```ts
+import { getRequestContext, getPropagationHeaders } from "../utils/requestContext.js";
+
+// Structured logging with the current request's IDs
+const ctx = getRequestContext();
+logger.info({ requestId: ctx?.requestId, correlationId: ctx?.correlationId }, "Fetching reserve data");
+
+// Outbound call to another internal service or external API —
+// forward the headers so the downstream service can correlate its logs.
+const response = await fetch(url, { headers: getPropagationHeaders() });
+```
+
+`getPropagationHeaders()` returns:
+```
+x-request-id
+x-correlation-id
+x-trace-id
+x-parent-span-id
+```
+
+If there is no active request context (e.g. a background job not triggered by
+an HTTP request), both helpers return safely (`undefined` / `{}`) rather than
+throwing, so they're safe to call unconditionally from shared service code.
+
+## Header support
+| Header | Set by caller (optional) | Set in response | Notes |
+|---|---|---|---|
+| `X-Request-ID` | — | ✅ | Unique per request |
+| `X-Correlation-ID` | ✅ | ✅ | Reused across a logical operation that spans multiple requests |
+| `X-Trace-ID` | ✅ | ✅ | W3C/Jaeger/Datadog trace identifiers are also derived from this |
+| `X-Parent-Span-ID` | ✅ | — | Set by an upstream caller to link spans |
+| `X-User-ID` | ✅ | — | Falls back to the authenticated user when omitted |
+
+## Structured logs
+`TracedLogger` (in `tracing.ts`) attaches `requestId`, `correlationId`,
+`traceId`, `spanId`, and `userId` to every structured log line it writes, so
+logs from a single request can be correlated in your log aggregator by
+filtering on any of those fields.

--- a/backend/src/api/middleware/tracing.ts
+++ b/backend/src/api/middleware/tracing.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
 import { randomUUID } from "crypto";
 import { logger } from "../../utils/logger.js";
 import { config } from "../../config/index.js";
+import { runWithRequestContext } from "../../utils/requestContext.js";
 
 // ---------------------------------------------------------------------------
 // Types and Interfaces
@@ -410,10 +411,13 @@ export async function registerTracing(server: FastifyInstance): Promise<void> {
   const traceManager = TraceManager.getInstance();
   const tracedLogger = new TracedLogger(traceManager);
 
-  // Add trace context to request object
-  server.addHook("onRequest", async (request: FastifyRequest, reply: FastifyReply) => {
+  // Add trace context to request object, and propagate it via
+  // AsyncLocalStorage so every async call chain originating from this
+  // request (service calls, outbound HTTP, logging) can read it without
+  // needing the Fastify request object threaded through.
+  server.addHook("onRequest", (request: FastifyRequest, reply: FastifyReply, done: () => void) => {
     const traceContext = traceManager.createTraceContext(request);
-    
+
     // Add trace context to request for use in other middleware/routes
     (request as any).traceContext = traceContext;
     (request as any).tracedLogger = tracedLogger;
@@ -431,6 +435,17 @@ export async function registerTracing(server: FastifyInstance): Promise<void> {
       userAgent: request.headers['user-agent'],
       ip: traceContext.ip,
     });
+
+    runWithRequestContext(
+      {
+        requestId: traceContext.requestId,
+        correlationId: traceContext.correlationId,
+        traceId: traceContext.traceId,
+        spanId: traceContext.spanId,
+        userId: traceContext.userId,
+      },
+      done
+    );
   });
 
   // Add timing and response logging

--- a/backend/src/api/routes/contractAnnotations.routes.ts
+++ b/backend/src/api/routes/contractAnnotations.routes.ts
@@ -1,0 +1,67 @@
+import type { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
+import { serviceAnnotationService } from "../../services/serviceAnnotation.service.js";
+
+const ENTITY_TYPE = "contract";
+
+interface CreateBody {
+  content: string;
+  author: string;
+  startTime?: string;
+  endTime?: string;
+}
+
+interface ContractParams {
+  contractAddress: string;
+}
+
+interface ListQuery {
+  active?: string;
+  author?: string;
+}
+
+/**
+ * Contract-scoped wrapper around the service annotation system.
+ * Annotations are stored with entityType="contract" and entityId=<contractAddress>,
+ * giving auditors and operators read access to context attached to a specific contract.
+ */
+export async function contractAnnotationRoutes(server: FastifyInstance) {
+  server.post<{ Params: ContractParams; Body: CreateBody }>(
+    "/:contractAddress/annotations",
+    async (
+      request: FastifyRequest<{ Params: ContractParams; Body: CreateBody }>,
+      reply: FastifyReply
+    ) => {
+      try {
+        const { contractAddress } = request.params;
+        const { content, author, startTime, endTime } = request.body;
+        const annotation = await serviceAnnotationService.create({
+          serviceName: "contract",
+          entityType: ENTITY_TYPE,
+          entityId: contractAddress,
+          content,
+          author,
+          startTime: startTime ? new Date(startTime) : undefined,
+          endTime: endTime ? new Date(endTime) : undefined,
+        });
+        return reply.code(201).send(annotation);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Failed to create annotation";
+        return reply.code(400).send({ error: message });
+      }
+    }
+  );
+
+  server.get<{ Params: ContractParams; Querystring: ListQuery }>(
+    "/:contractAddress/annotations",
+    async (request: FastifyRequest<{ Params: ContractParams; Querystring: ListQuery }>) => {
+      const { contractAddress } = request.params;
+      const { active, author } = request.query;
+      return serviceAnnotationService.list({
+        entityType: ENTITY_TYPE,
+        entityId: contractAddress,
+        active: active !== undefined ? active === "true" : undefined,
+        author,
+      });
+    }
+  );
+}

--- a/backend/src/api/routes/index.ts
+++ b/backend/src/api/routes/index.ts
@@ -57,6 +57,7 @@ import { circuitHealthRoutes } from "./circuitHealth.js";
 import { ruleEvaluatorRoutes } from "./ruleEvaluator.routes.js";
 import { automationRulesRoutes } from "./automationRules.routes.js";
 import { serviceAnnotationRoutes } from "./serviceAnnotation.routes.js";
+import { contractAnnotationRoutes } from "./contractAnnotations.routes.js";
 import { assetMergeRoutes } from "./assetMerge.routes.js";
 import { alertWindowingRoutes } from "./alertWindowing.routes.js";
 import { queryPresetsRoutes } from "./queryPresets.js";
@@ -163,6 +164,7 @@ export async function registerRoutes(server: FastifyInstance) {
   server.register(serviceAnnotationRoutes, {
     prefix: "/api/v1/service-annotations",
   });
+  server.register(contractAnnotationRoutes, { prefix: "/api/v1/contracts" });
   server.register(assetMergeRoutes, { prefix: "/api/v1/asset-merge" });
   server.register(alertWindowingRoutes, { prefix: "/api/v1/alert-windowing" });
   server.register(queryPresetsRoutes, { prefix: "/api/v1/query-presets" });

--- a/backend/src/utils/requestContext.ts
+++ b/backend/src/utils/requestContext.ts
@@ -1,0 +1,42 @@
+import { AsyncLocalStorage } from "async_hooks";
+
+/**
+ * Request-scoped context propagated across internal service calls within a
+ * single request's lifetime, so logs and outbound HTTP calls can be
+ * correlated back to the originating request without threading IDs through
+ * every function signature.
+ */
+export interface RequestContext {
+  requestId: string;
+  correlationId: string;
+  traceId: string;
+  spanId: string;
+  userId?: string;
+}
+
+const storage = new AsyncLocalStorage<RequestContext>();
+
+export function runWithRequestContext<T>(context: RequestContext, fn: () => T): T {
+  return storage.run(context, fn);
+}
+
+export function getRequestContext(): RequestContext | undefined {
+  return storage.getStore();
+}
+
+/**
+ * Builds the headers an outbound call (to another internal service, or to an
+ * external API on this request's behalf) should carry so the downstream
+ * service can correlate its own logs/traces back to this request.
+ */
+export function getPropagationHeaders(): Record<string, string> {
+  const context = getRequestContext();
+  if (!context) return {};
+
+  return {
+    "x-request-id": context.requestId,
+    "x-correlation-id": context.correlationId,
+    "x-trace-id": context.traceId,
+    "x-parent-span-id": context.spanId,
+  };
+}

--- a/backend/tests/api/contractAnnotations.test.ts
+++ b/backend/tests/api/contractAnnotations.test.ts
@@ -1,0 +1,143 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { FastifyInstance } from "fastify";
+
+vi.hoisted(() => {
+  process.env.NODE_ENV = "test";
+  process.env.API_KEY_BOOTSTRAP_TOKEN = "bootstrap-secret";
+});
+
+import { buildServer } from "../../src/index.js";
+
+const serviceAnnotationMocks = vi.hoisted(() => ({
+  create: vi.fn(),
+  list: vi.fn(),
+}));
+
+vi.mock("../../src/services/serviceAnnotation.service.js", () => ({
+  serviceAnnotationService: {
+    create: serviceAnnotationMocks.create,
+    list: serviceAnnotationMocks.list,
+  },
+}));
+
+describe("Contract Annotations API", () => {
+  let server: FastifyInstance;
+
+  beforeAll(async () => {
+    server = await buildServer();
+  });
+
+  afterAll(async () => {
+    await server.close();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("POST /api/v1/contracts/:contractAddress/annotations", () => {
+    it("creates an annotation scoped to the contract", async () => {
+      const annotation = {
+        id: "ann-1",
+        serviceName: "contract",
+        entityType: "contract",
+        entityId: "CCONTRACT123",
+        content: "Reserve threshold lowered for migration window",
+        author: "ops@bridgewatch",
+        startTime: null,
+        endTime: null,
+        active: true,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+      serviceAnnotationMocks.create.mockResolvedValueOnce(annotation);
+
+      const response = await server.inject({
+        method: "POST",
+        url: "/api/v1/contracts/CCONTRACT123/annotations",
+        payload: {
+          content: "Reserve threshold lowered for migration window",
+          author: "ops@bridgewatch",
+        },
+      });
+
+      expect(response.statusCode).toBe(201);
+      expect(serviceAnnotationMocks.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          entityType: "contract",
+          entityId: "CCONTRACT123",
+          content: "Reserve threshold lowered for migration window",
+          author: "ops@bridgewatch",
+        })
+      );
+      const body = JSON.parse(response.body);
+      expect(body.entityId).toBe("CCONTRACT123");
+    });
+
+    it("returns 400 when the service rejects the input", async () => {
+      serviceAnnotationMocks.create.mockRejectedValueOnce(new Error("content is required"));
+
+      const response = await server.inject({
+        method: "POST",
+        url: "/api/v1/contracts/CCONTRACT123/annotations",
+        payload: { author: "ops" },
+      });
+
+      expect(response.statusCode).toBe(400);
+      const body = JSON.parse(response.body);
+      expect(body).toHaveProperty("error");
+    });
+  });
+
+  describe("GET /api/v1/contracts/:contractAddress/annotations", () => {
+    it("returns annotations for the given contract", async () => {
+      serviceAnnotationMocks.list.mockResolvedValueOnce([
+        {
+          id: "ann-1",
+          serviceName: "contract",
+          entityType: "contract",
+          entityId: "CCONTRACT123",
+          content: "Audit note",
+          author: "auditor@bridgewatch",
+          startTime: null,
+          endTime: null,
+          active: true,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      ]);
+
+      const response = await server.inject({
+        method: "GET",
+        url: "/api/v1/contracts/CCONTRACT123/annotations",
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(serviceAnnotationMocks.list).toHaveBeenCalledWith(
+        expect.objectContaining({ entityType: "contract", entityId: "CCONTRACT123" })
+      );
+      const body = JSON.parse(response.body);
+      expect(body).toHaveLength(1);
+      expect(body[0].content).toBe("Audit note");
+    });
+
+    it("filters by active and author query params", async () => {
+      serviceAnnotationMocks.list.mockResolvedValueOnce([]);
+
+      const response = await server.inject({
+        method: "GET",
+        url: "/api/v1/contracts/CCONTRACT123/annotations?active=true&author=auditor@bridgewatch",
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(serviceAnnotationMocks.list).toHaveBeenCalledWith(
+        expect.objectContaining({
+          entityType: "contract",
+          entityId: "CCONTRACT123",
+          active: true,
+          author: "auditor@bridgewatch",
+        })
+      );
+    });
+  });
+});

--- a/backend/tests/contracts/api.contract.test.ts
+++ b/backend/tests/contracts/api.contract.test.ts
@@ -1,0 +1,138 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { FastifyInstance } from "fastify";
+
+vi.hoisted(() => {
+  process.env.NODE_ENV = "test";
+  process.env.API_KEY_BOOTSTRAP_TOKEN = "bootstrap-secret";
+});
+
+import { buildServer } from "../../src/index.js";
+import {
+  AssetListResponseSchema,
+  ContractAnnotationListResponseSchema,
+  ErrorResponseSchema,
+  HealthResponseSchema,
+} from "./schemas.js";
+import { assertMatchesSchema } from "./assertSchema.js";
+
+const serviceAnnotationMocks = vi.hoisted(() => ({
+  create: vi.fn(),
+  list: vi.fn(),
+}));
+
+vi.mock("../../src/services/serviceAnnotation.service.js", () => ({
+  serviceAnnotationService: {
+    create: serviceAnnotationMocks.create,
+    list: serviceAnnotationMocks.list,
+  },
+}));
+
+/**
+ * Schema contract tests.
+ *
+ * These tests verify that key API endpoints keep returning responses that
+ * match their documented, snapshotted shape. They are not integration tests
+ * for business logic — they only ask "did the shape of this response change
+ * unexpectedly?" Snapshots capture a representative payload per endpoint so
+ * reviewers can see exactly what changed in a PR diff.
+ *
+ * Update a snapshot deliberately with `vitest run --update` and explain the
+ * change in the PR description if it represents an intentional breaking change.
+ */
+describe("API schema contracts", () => {
+  let server: FastifyInstance;
+
+  beforeAll(async () => {
+    server = await buildServer();
+  });
+
+  afterAll(async () => {
+    await server.close();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("GET /health", () => {
+    it("matches the health response contract", async () => {
+      const response = await server.inject({ method: "GET", url: "/health" });
+
+      expect(response.statusCode).toBe(200);
+      const body = assertMatchesSchema("GET /health", JSON.parse(response.body), HealthResponseSchema);
+
+      expect({
+        status: body.status,
+        version: body.version,
+      }).toMatchSnapshot();
+    });
+  });
+
+  describe("GET /api/v1/assets", () => {
+    it("matches the asset list response contract", async () => {
+      const response = await server.inject({ method: "GET", url: "/api/v1/assets" });
+
+      expect(response.statusCode).toBe(200);
+      const body = assertMatchesSchema(
+        "GET /api/v1/assets",
+        JSON.parse(response.body),
+        AssetListResponseSchema
+      );
+
+      expect(body).toMatchSnapshot();
+    });
+  });
+
+  describe("GET /api/v1/contracts/:contractAddress/annotations", () => {
+    it("matches the contract annotation list response contract", async () => {
+      serviceAnnotationMocks.list.mockResolvedValueOnce([
+        {
+          id: "ann-1",
+          serviceName: "contract",
+          entityType: "contract",
+          entityId: "CCONTRACT123",
+          content: "Audit note for schema contract test",
+          author: "auditor@bridgewatch",
+          startTime: null,
+          endTime: null,
+          active: true,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        },
+      ]);
+
+      const response = await server.inject({
+        method: "GET",
+        url: "/api/v1/contracts/CCONTRACT123/annotations",
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = assertMatchesSchema(
+        "GET /api/v1/contracts/:contractAddress/annotations",
+        JSON.parse(response.body),
+        ContractAnnotationListResponseSchema
+      );
+
+      expect(body).toMatchSnapshot();
+    });
+
+    it("matches the error response contract on invalid create", async () => {
+      serviceAnnotationMocks.create.mockRejectedValueOnce(new Error("content is required"));
+
+      const response = await server.inject({
+        method: "POST",
+        url: "/api/v1/contracts/CCONTRACT123/annotations",
+        payload: { author: "ops" },
+      });
+
+      expect(response.statusCode).toBe(400);
+      const body = assertMatchesSchema(
+        "POST /api/v1/contracts/:contractAddress/annotations (error)",
+        JSON.parse(response.body),
+        ErrorResponseSchema
+      );
+
+      expect(body).toMatchSnapshot();
+    });
+  });
+});

--- a/backend/tests/contracts/assertSchema.ts
+++ b/backend/tests/contracts/assertSchema.ts
@@ -1,0 +1,37 @@
+import type { z } from "zod";
+import { expect } from "vitest";
+
+/**
+ * Asserts that `body` matches `schema`, formatting Zod issues into a
+ * readable, per-field breaking-change report instead of a raw ZodError dump.
+ *
+ * Use this for every schema contract test so failures clearly say which
+ * field broke the contract and why, e.g.:
+ *
+ *   Schema contract violation for "GET /health":
+ *     - uptime: Expected number, received string
+ *     - version: Required
+ */
+export function assertMatchesSchema<T>(
+  endpoint: string,
+  body: unknown,
+  schema: z.ZodType<T>
+): T {
+  const result = schema.safeParse(body);
+
+  if (!result.success) {
+    const issues = result.error.issues
+      .map((issue) => `  - ${issue.path.join(".") || "(root)"}: ${issue.message}`)
+      .join("\n");
+
+    throw new Error(
+      `Schema contract violation for "${endpoint}":\n${issues}\n\n` +
+        `This means the response shape changed in a way that breaks the documented ` +
+        `API contract. If this change is intentional, update the schema in ` +
+        `tests/contracts/schemas.ts and call this out as a breaking change in the PR.`
+    );
+  }
+
+  expect(result.success).toBe(true);
+  return result.data;
+}

--- a/backend/tests/contracts/schemas.ts
+++ b/backend/tests/contracts/schemas.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+
+/**
+ * Zod schemas describing the public contract of key API responses.
+ *
+ * These are intentionally independent of the Fastify route schemas — they
+ * describe what *consumers* are allowed to rely on. A route's internal
+ * JSON-schema can change shape for validation purposes without this file
+ * changing, but if the actual response body stops matching one of these
+ * schemas, that's a breaking change for API consumers and the contract
+ * test must fail.
+ */
+
+export const HealthResponseSchema = z.object({
+  status: z.string(),
+  timestamp: z.string(),
+  uptime: z.number(),
+  version: z.string(),
+});
+
+export const AssetListResponseSchema = z.object({
+  assets: z.array(z.unknown()),
+  total: z.number().int(),
+});
+
+export const AnnotationSchema = z.object({
+  id: z.string(),
+  serviceName: z.string(),
+  entityType: z.string(),
+  entityId: z.string().nullable(),
+  content: z.string(),
+  author: z.string(),
+  startTime: z.string().nullable(),
+  endTime: z.string().nullable(),
+  active: z.boolean(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export const ContractAnnotationListResponseSchema = z.array(AnnotationSchema);
+
+export const ErrorResponseSchema = z.object({
+  error: z.string(),
+});

--- a/backend/tests/services/requestContext.test.ts
+++ b/backend/tests/services/requestContext.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import {
+  getPropagationHeaders,
+  getRequestContext,
+  runWithRequestContext,
+} from "../../src/utils/requestContext.js";
+
+describe("requestContext", () => {
+  it("returns undefined outside of a request context", () => {
+    expect(getRequestContext()).toBeUndefined();
+    expect(getPropagationHeaders()).toEqual({});
+  });
+
+  it("exposes the active context within runWithRequestContext", () => {
+    runWithRequestContext(
+      {
+        requestId: "req-1",
+        correlationId: "corr-1",
+        traceId: "trace-1",
+        spanId: "span-1",
+        userId: "user-1",
+      },
+      () => {
+        expect(getRequestContext()).toEqual({
+          requestId: "req-1",
+          correlationId: "corr-1",
+          traceId: "trace-1",
+          spanId: "span-1",
+          userId: "user-1",
+        });
+      }
+    );
+  });
+
+  it("builds propagation headers from the active context", () => {
+    runWithRequestContext(
+      {
+        requestId: "req-2",
+        correlationId: "corr-2",
+        traceId: "trace-2",
+        spanId: "span-2",
+      },
+      () => {
+        expect(getPropagationHeaders()).toEqual({
+          "x-request-id": "req-2",
+          "x-correlation-id": "corr-2",
+          "x-trace-id": "trace-2",
+          "x-parent-span-id": "span-2",
+        });
+      }
+    );
+  });
+
+  it("propagates context across an async continuation", async () => {
+    await runWithRequestContext(
+      {
+        requestId: "req-3",
+        correlationId: "corr-3",
+        traceId: "trace-3",
+        spanId: "span-3",
+      },
+      async () => {
+        await Promise.resolve();
+        expect(getRequestContext()?.requestId).toBe("req-3");
+      }
+    );
+  });
+
+  it("does not leak context after runWithRequestContext returns", () => {
+    runWithRequestContext(
+      { requestId: "req-4", correlationId: "corr-4", traceId: "trace-4", spanId: "span-4" },
+      () => {}
+    );
+    expect(getRequestContext()).toBeUndefined();
+  });
+});

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
             "tests/workers/**/*.test.ts",
             "tests/jobs/**/*.test.ts",
             "tests/testing/**/*.test.ts",
+            "tests/contracts/**/*.test.ts",
           ],
           setupFiles: ["./tests/setup.ts"],
         },

--- a/backend/vitest.unit.config.ts
+++ b/backend/vitest.unit.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
       "tests/workers/**/*.test.ts",
       "tests/jobs/**/*.test.ts",
       "tests/testing/**/*.test.ts",
+      "tests/contracts/**/*.test.ts",
     ],
     fileParallelism: false,
   },

--- a/docs/deployment/docker-deployment.md
+++ b/docs/deployment/docker-deployment.md
@@ -214,6 +214,42 @@ docker compose logs --tail=50
 - **Password:** Optional, configured via `REDIS_PASSWORD`
 - **Health check:** `redis-cli ping` every 10s
 
+## Docker Layer Tuning
+
+Both the backend and frontend Dockerfiles are ordered so dependency
+installation happens before source code is copied in:
+
+```dockerfile
+WORKDIR /app
+COPY package.json ./
+RUN --mount=type=cache,target=/root/.npm npm install
+# source is copied / mounted afterwards
+```
+
+This matters for two reasons:
+
+- **Small rebuilds during development** — editing application source under
+  `src/` only invalidates the layers *after* `npm install`. The dependency
+  layer is reused from cache as long as `package.json` hasn't changed, so a
+  typical code change rebuild only re-runs the TypeScript build (or, in the
+  `dev` stage, nothing — source is bind-mounted, not copied).
+- **Cache efficiency across environments** — the `RUN --mount=type=cache,target=/root/.npm`
+  cache mount persists npm's package cache across builds, independent of the
+  layer cache. Even when `package.json` *does* change and the install layer is
+  invalidated, npm reuses already-downloaded packages instead of re-fetching
+  them from the registry. This works the same way locally (`docker build`,
+  `docker compose build`) and in CI.
+
+In CI, [`.github/workflows/docker.yml`](../../.github/workflows/docker.yml)
+builds with `cache-from: type=gha` / `cache-to: type=gha,mode=max`, which
+persists both the layer cache and the BuildKit cache-mount contents between
+workflow runs — so a CI rebuild after a small source change is just as cheap
+as a local incremental rebuild.
+
+`.dockerignore` (present in both `backend/` and `frontend/`) keeps
+`node_modules`, `dist`, test files, and docs out of the build context so they
+never trigger spurious cache invalidation or get sent to the Docker daemon.
+
 ## Volume Management
 
 ### Persistent Volumes

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,9 +10,12 @@
 FROM node:20-alpine AS base
 WORKDIR /app
 
-# Install dependencies first (layer cache friendly)
+# Install dependencies first (layer cache friendly). This layer is only
+# invalidated when package.json changes, not on every source edit. The
+# BuildKit cache mount keeps npm's package cache across builds so even an
+# invalidated install re-downloads as little as possible.
 COPY package.json ./
-RUN npm install
+RUN --mount=type=cache,target=/root/.npm npm install
 
 # -----------------------------------------------------------------------------
 # Development — Vite dev server with hot module replacement


### PR DESCRIPTION
## Summary

This PR addresses four assigned issues:

### Closes #530 — Create Data Annotation Function
- Adds contract-scoped read/write access on top of the existing `service_annotations` storage: `POST` and `GET /api/v1/contracts/:contractAddress/annotations`.
- Reuses existing annotation storage (timestamps, author info, and the `service_annotation_audit` trail) — no new tables needed.
- Documents annotation semantics in `backend/docs/contract-annotations.md` (storage, timestamps, author info, read access).
- Adds route tests in `backend/tests/api/contractAnnotations.test.ts`.

### Closes #542 — Create Schema Contract Tests
- Adds Zod-based schema contract tests in `backend/tests/contracts/` covering key endpoints (`GET /health`, `GET /api/v1/assets`, and the new contract annotation endpoints).
- `assertSchema.ts` produces readable, per-field breaking-change messages instead of a raw validator dump.
- Snapshots (`toMatchSnapshot()`) capture representative payloads so reviewers see exactly what changed in a PR diff.
- Wired into the existing unit test projects (`vitest.config.ts`, `vitest.unit.config.ts`), so it runs automatically in CI via the current `npm test` / `npm run test:unit` jobs — no new workflow required.
- Update workflow documented in `backend/docs/SCHEMA_CONTRACT_TESTING.md`.

### Closes #540 — Implement Docker Layer Tuning
- `backend/Dockerfile` and `frontend/Dockerfile`: added `RUN --mount=type=cache,target=/root/.npm` cache mounts on the dependency-install layers, on top of the existing cache-friendly layer order (deps before source).
- `.dockerignore` already existed in both contexts and CI already builds with `cache-from/cache-to: type=gha`; this change adds the missing piece (npm package cache persistence) for small rebuilds and cross-environment cache efficiency.
- Documented in `docs/deployment/docker-deployment.md` under a new "Docker Layer Tuning" section.

### Closes #555 — Create Request Context Propagation
- Adds `backend/src/utils/requestContext.ts`: an `AsyncLocalStorage`-backed request context (request ID, correlation ID, trace ID, span ID, user ID) plus `getPropagationHeaders()` for outbound calls.
- Wired into the existing `registerTracing` middleware (`tracing.ts`) so the context is available to any service code for the lifetime of a request, without needing the Fastify `request` object threaded through every call.
- Builds on the existing correlation/tracing/structured-logging middleware already in place — additive, not a rewrite.
- Documented in `backend/docs/request-context-propagation.md` (request IDs, user context, trace propagation, structured logs, header support).
- Unit tests in `backend/tests/services/requestContext.test.ts`.

## Test plan

- [ ] `npm --workspace=backend run lint`
- [ ] `npm --workspace=backend run build`
- [ ] `npm --workspace=backend run test:unit` — covers `tests/api/contractAnnotations.test.ts`, `tests/contracts/**`, `tests/services/requestContext.test.ts`
- [ ] `npm --workspace=backend run test:integration`
- [ ] Manual: `POST` then `GET /api/v1/contracts/:contractAddress/annotations` against a local dev server
- [ ] Manual: `docker compose -f docker-compose.dev.yml build backend frontend` to confirm the cache-mount syntax builds cleanly with BuildKit