### PR TITLE
feat: batch reconciliation runner, performance baseline tracker, anomaly trend charts, user activity heatmap

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,6 +26,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Remove broken Microsoft apt repos
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list \
+                     /etc/apt/sources.list.d/azure-cli.list \
+                     /etc/apt/sources.list.d/msprod.list || true
+
       - name: Install Playwright browsers
         run: npx playwright install --with-deps
 

--- a/backend/src/api/routes/batchReconciliation.routes.ts
+++ b/backend/src/api/routes/batchReconciliation.routes.ts
@@ -1,0 +1,23 @@
+import type { FastifyInstance } from "fastify";
+import { runBatchReconciliation } from "../../jobs/batchReconciliation.job.js";
+import { logger } from "../../utils/logger.js";
+
+export async function batchReconciliationRoutes(server: FastifyInstance) {
+  server.post(
+    "/run",
+    {
+      schema: {
+        tags: ["Reconciliation"],
+        summary: "Trigger a batch reconciliation run across all supported assets",
+        response: {
+          200: { type: "object", additionalProperties: true },
+        },
+      },
+    },
+    async (_request, reply) => {
+      logger.info("Manual batch reconciliation run triggered via API");
+      const report = await runBatchReconciliation();
+      return reply.send(report);
+    }
+  );
+}

--- a/backend/src/api/routes/index.ts
+++ b/backend/src/api/routes/index.ts
@@ -77,6 +77,8 @@ import { tagsRoutes } from "./tags.js";
 import { savedMetricsRoutes } from "./savedMetrics.routes.js";
 import { playbooksRoutes } from "./playbooks.routes.js";
 import { sourceHealthScoringRoutes } from "./sourceHealthScoring.routes.js";
+import { batchReconciliationRoutes } from "./batchReconciliation.routes.js";
+import { performanceBaselineRoutes } from "./performanceBaseline.routes.js";
 
 export async function registerRoutes(server: FastifyInstance) {
   server.register(assetsRoutes, { prefix: "/api/v1/assets" });
@@ -188,4 +190,6 @@ export async function registerRoutes(server: FastifyInstance) {
   server.register(tagsRoutes, { prefix: "/api/v1/tags" });
   server.register(playbooksRoutes, { prefix: "/api/v1/playbooks" });
   server.register(sourceHealthScoringRoutes, { prefix: "/api/v1/sources/health-scoring" });
+  server.register(batchReconciliationRoutes, { prefix: "/api/v1/reconciliation/batch" });
+  server.register(performanceBaselineRoutes, { prefix: "/api/v1/performance-baselines" });
 }

--- a/backend/src/api/routes/performanceBaseline.routes.ts
+++ b/backend/src/api/routes/performanceBaseline.routes.ts
@@ -1,0 +1,115 @@
+import type { FastifyInstance } from "fastify";
+import { performanceBaselineService } from "../../services/performanceBaseline.service.js";
+import type { PerformanceSample } from "../../services/performanceBaseline.service.js";
+
+export async function performanceBaselineRoutes(server: FastifyInstance) {
+  server.get(
+    "/",
+    {
+      schema: {
+        tags: ["Performance Baselines"],
+        summary: "List latest performance baselines for all tracked endpoints",
+        response: { 200: { type: "object", additionalProperties: true } },
+      },
+    },
+    async (_req, reply) => {
+      const baselines = await performanceBaselineService.getLatestBaselines();
+      return reply.send({ baselines, count: baselines.length });
+    }
+  );
+
+  server.get<{ Querystring: { endpoint: string; method?: string; limit?: string } }>(
+    "/trend",
+    {
+      schema: {
+        tags: ["Performance Baselines"],
+        summary: "Get historical p95 trend for an endpoint",
+        querystring: {
+          type: "object",
+          required: ["endpoint"],
+          properties: {
+            endpoint: { type: "string" },
+            method: { type: "string" },
+            limit: { type: "string" },
+          },
+        },
+        response: { 200: { type: "object", additionalProperties: true } },
+      },
+    },
+    async (request, reply) => {
+      const { endpoint, method = "GET", limit } = request.query;
+      const trend = await performanceBaselineService.getTrend(endpoint, method, limit ? Number(limit) : 30);
+      return reply.send(trend);
+    }
+  );
+
+  server.post<{ Body: { samples: PerformanceSample[] } }>(
+    "/record",
+    {
+      schema: {
+        tags: ["Performance Baselines"],
+        summary: "Record performance samples and update baselines",
+        body: {
+          type: "object",
+          required: ["samples"],
+          properties: {
+            samples: {
+              type: "array",
+              items: {
+                type: "object",
+                required: ["endpoint", "method", "durationMs", "statusCode"],
+                properties: {
+                  endpoint: { type: "string" },
+                  method: { type: "string" },
+                  durationMs: { type: "number" },
+                  statusCode: { type: "number" },
+                  sampledAt: { type: "string" },
+                },
+              },
+            },
+          },
+        },
+        response: { 200: { type: "object", additionalProperties: true } },
+      },
+    },
+    async (request, reply) => {
+      const baselines = await performanceBaselineService.recordBaseline(request.body.samples);
+      const regressions = await performanceBaselineService.detectRegressions(request.body.samples);
+      return reply.send({ baselines, regressions, regressionCount: regressions.length });
+    }
+  );
+
+  server.post<{ Body: { samples: PerformanceSample[] } }>(
+    "/detect-regressions",
+    {
+      schema: {
+        tags: ["Performance Baselines"],
+        summary: "Check samples for regressions against stored baselines",
+        body: {
+          type: "object",
+          required: ["samples"],
+          properties: {
+            samples: {
+              type: "array",
+              items: {
+                type: "object",
+                required: ["endpoint", "method", "durationMs", "statusCode"],
+                properties: {
+                  endpoint: { type: "string" },
+                  method: { type: "string" },
+                  durationMs: { type: "number" },
+                  statusCode: { type: "number" },
+                },
+              },
+            },
+          },
+        },
+        response: { 200: { type: "object", additionalProperties: true } },
+      },
+    },
+    async (request, reply) => {
+      const regressions = await performanceBaselineService.detectRegressions(request.body.samples);
+      return reply.send({ regressions, regressionCount: regressions.length });
+    }
+  );
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -11,6 +11,7 @@ import { registerValidation } from "./api/middleware/validation.js";
 import { registerMetrics } from "./api/middleware/metrics.js";
 import { registerUsageMetrics } from "./api/middleware/usageMetrics.js";
 import { startBridgeVerificationJob } from "./jobs/verification.job.js";
+import { startBatchReconciliationJob, stopBatchReconciliationJob } from "./jobs/batchReconciliation.job.js";
 import { wsServer } from "./api/websocket/websocket.server.js";
 import {
   registerRateLimiting,
@@ -226,6 +227,10 @@ async function start() {
     // Start real-time event stream federation
     await getEventFederationService().start();
     server.log.info("Event federation service started");
+
+    // Start batch reconciliation job
+    startBatchReconciliationJob();
+    server.log.info("Batch reconciliation job started");
   } catch (err) {
     server.log.error(err);
     process.exit(1);
@@ -249,6 +254,7 @@ async function start() {
     await JobQueue.getInstance().stop();
     await getSupplyVerificationQueue().stop();
     await stopWebhookWorker();
+    stopBatchReconciliationJob();
     logger.info("Server closed");
     process.exit(0);
   };

--- a/backend/src/jobs/batchReconciliation.job.ts
+++ b/backend/src/jobs/batchReconciliation.job.ts
@@ -1,0 +1,129 @@
+import { SUPPORTED_ASSETS } from "../config/index.js";
+import { ReconciliationService } from "../services/reconciliation.service.js";
+import { logger } from "../utils/logger.js";
+
+const RECONCILIATION_INTERVAL_MS = Number(process.env.RECONCILIATION_INTERVAL_MS) || 600000; // 10 min default
+
+export interface BatchReconciliationReport {
+  jobId: string;
+  startedAt: string;
+  finishedAt: string;
+  totalAssets: number;
+  successCount: number;
+  mismatchCount: number;
+  failureCount: number;
+  mismatches: Array<{ assetCode: string; mismatchPercentage: number | null; runId: string }>;
+  errors: Array<{ assetCode: string; error: string }>;
+}
+
+let reconciliationInterval: NodeJS.Timeout | null = null;
+const reconciliationService = new ReconciliationService();
+
+export async function runBatchReconciliation(): Promise<BatchReconciliationReport> {
+  const jobId = `batch-recon-${Date.now()}`;
+  const startedAt = new Date().toISOString();
+
+  logger.info({ jobId, assetCount: SUPPORTED_ASSETS.length }, "Starting batch reconciliation run");
+
+  const mismatches: BatchReconciliationReport["mismatches"] = [];
+  const errors: BatchReconciliationReport["errors"] = [];
+  let successCount = 0;
+
+  for (const asset of SUPPORTED_ASSETS) {
+    const assetCode = asset.code;
+    let runId: string | null = null;
+
+    try {
+      const run = await reconciliationService.startRun({ assetCode, jobId });
+      runId = run.id;
+
+      const latest = await reconciliationService.getLatestRun(assetCode);
+
+      if (!latest) {
+        await reconciliationService.finishRun({
+          id: runId,
+          status: "failed",
+          error: "No baseline data found",
+        });
+        errors.push({ assetCode, error: "No baseline data found" });
+        continue;
+      }
+
+      const isMismatch = latest.status === "mismatch";
+      const status = isMismatch ? "mismatch" : "success";
+
+      await reconciliationService.finishRun({
+        id: runId,
+        status,
+        stellarSupply: latest.stellarSupply,
+        reportedSupply: latest.reportedSupply,
+        mismatchPercentage: latest.mismatchPercentage,
+      });
+
+      if (isMismatch) {
+        mismatches.push({
+          assetCode,
+          mismatchPercentage: latest.mismatchPercentage,
+          runId,
+        });
+        logger.warn({ assetCode, mismatchPercentage: latest.mismatchPercentage, runId }, "Reconciliation mismatch detected");
+      } else {
+        successCount++;
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error({ assetCode, jobId, error: message }, "Reconciliation run failed for asset");
+      errors.push({ assetCode, error: message });
+
+      if (runId) {
+        try {
+          await reconciliationService.finishRun({ id: runId, status: "failed", error: message });
+        } catch (finishErr) {
+          logger.error({ assetCode, finishErr }, "Failed to mark reconciliation run as failed");
+        }
+      }
+    }
+  }
+
+  const finishedAt = new Date().toISOString();
+  const report: BatchReconciliationReport = {
+    jobId,
+    startedAt,
+    finishedAt,
+    totalAssets: SUPPORTED_ASSETS.length,
+    successCount,
+    mismatchCount: mismatches.length,
+    failureCount: errors.length,
+    mismatches,
+    errors,
+  };
+
+  logger.info(
+    { jobId, successCount, mismatchCount: mismatches.length, failureCount: errors.length },
+    "Batch reconciliation run complete"
+  );
+
+  return report;
+}
+
+export function startBatchReconciliationJob(): void {
+  logger.info({ intervalMs: RECONCILIATION_INTERVAL_MS }, "Starting batch reconciliation job scheduler");
+
+  runBatchReconciliation().catch((err) => {
+    logger.error({ error: err }, "Initial batch reconciliation run failed");
+  });
+
+  reconciliationInterval = setInterval(() => {
+    runBatchReconciliation().catch((err) => {
+      logger.error({ error: err }, "Scheduled batch reconciliation run failed");
+    });
+  }, RECONCILIATION_INTERVAL_MS);
+}
+
+export function stopBatchReconciliationJob(): void {
+  if (reconciliationInterval) {
+    clearInterval(reconciliationInterval);
+    reconciliationInterval = null;
+    logger.info("Stopped batch reconciliation job scheduler");
+  }
+}

--- a/backend/src/services/performanceBaseline.service.ts
+++ b/backend/src/services/performanceBaseline.service.ts
@@ -44,7 +44,7 @@ export class PerformanceBaselineService {
   private db = getDatabase();
 
   async ensureTable(): Promise<void> {
-    await this.db.query(`
+    await this.db.raw(`
       CREATE TABLE IF NOT EXISTS performance_baselines (
         id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
         endpoint TEXT NOT NULL,
@@ -84,10 +84,10 @@ export class PerformanceBaselineService {
       const p99 = this.percentile(durations, 99);
       const threshold = p95 * 1.5;
 
-      const row = await this.db.query<PerformanceBaseline & Record<string, unknown>>(
+      const row = await this.db.raw(
         `INSERT INTO performance_baselines
            (endpoint, method, p50_ms, p95_ms, p99_ms, sample_count, threshold_ms)
-         VALUES ($1, $2, $3, $4, $5, $6, $7)
+         VALUES (?, ?, ?, ?, ?, ?, ?)
          RETURNING
            id,
            endpoint,
@@ -111,7 +111,7 @@ export class PerformanceBaselineService {
   }
 
   async getLatestBaselines(): Promise<PerformanceBaseline[]> {
-    const result = await this.db.query<Record<string, unknown>>(
+    const result = await this.db.raw(
       `SELECT DISTINCT ON (endpoint, method)
          id,
          endpoint,
@@ -130,14 +130,14 @@ export class PerformanceBaselineService {
   }
 
   async getBaselineForEndpoint(endpoint: string, method = "GET"): Promise<PerformanceBaseline | null> {
-    const result = await this.db.query<Record<string, unknown>>(
+    const result = await this.db.raw(
       `SELECT
          id, endpoint, method,
          p50_ms AS "p50Ms", p95_ms AS "p95Ms", p99_ms AS "p99Ms",
          sample_count AS "sampleCount", threshold_ms AS "thresholdMs",
          measured_at AS "measuredAt", created_at AS "createdAt"
        FROM performance_baselines
-       WHERE endpoint = $1 AND method = $2
+       WHERE endpoint = ? AND method = ?
        ORDER BY measured_at DESC
        LIMIT 1`,
       [endpoint, method.toUpperCase()]
@@ -186,15 +186,15 @@ export class PerformanceBaselineService {
   }
 
   async getTrend(endpoint: string, method = "GET", limit = 30): Promise<BaselineTrend> {
-    const result = await this.db.query<Record<string, unknown>>(
+    const result = await this.db.raw(
       `SELECT
          p95_ms AS "p95Ms",
          sample_count AS "sampleCount",
          measured_at AS "measuredAt"
        FROM performance_baselines
-       WHERE endpoint = $1 AND method = $2
+       WHERE endpoint = ? AND method = ?
        ORDER BY measured_at DESC
-       LIMIT $3`,
+       LIMIT ?`,
       [endpoint, method.toUpperCase(), limit]
     );
 

--- a/backend/src/services/performanceBaseline.service.ts
+++ b/backend/src/services/performanceBaseline.service.ts
@@ -1,0 +1,215 @@
+import { getDatabase } from "../database/connection.js";
+import { logger } from "../utils/logger.js";
+
+export interface PerformanceBaseline {
+  id: string;
+  endpoint: string;
+  method: string;
+  p50Ms: number;
+  p95Ms: number;
+  p99Ms: number;
+  sampleCount: number;
+  thresholdMs: number;
+  measuredAt: string;
+  createdAt: string;
+}
+
+export interface PerformanceSample {
+  endpoint: string;
+  method: string;
+  durationMs: number;
+  statusCode: number;
+  sampledAt?: string;
+}
+
+export interface RegressionAlert {
+  endpoint: string;
+  method: string;
+  currentP95Ms: number;
+  baselineP95Ms: number;
+  degradationPct: number;
+  severity: "warning" | "critical";
+}
+
+export interface BaselineTrend {
+  endpoint: string;
+  method: string;
+  history: Array<{ p95Ms: number; sampleCount: number; measuredAt: string }>;
+}
+
+const REGRESSION_WARNING_PCT = 20;
+const REGRESSION_CRITICAL_PCT = 50;
+
+export class PerformanceBaselineService {
+  private db = getDatabase();
+
+  async ensureTable(): Promise<void> {
+    await this.db.query(`
+      CREATE TABLE IF NOT EXISTS performance_baselines (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        endpoint TEXT NOT NULL,
+        method TEXT NOT NULL DEFAULT 'GET',
+        p50_ms NUMERIC NOT NULL,
+        p95_ms NUMERIC NOT NULL,
+        p99_ms NUMERIC NOT NULL,
+        sample_count INTEGER NOT NULL,
+        threshold_ms NUMERIC NOT NULL,
+        measured_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      );
+      CREATE INDEX IF NOT EXISTS idx_perf_baselines_endpoint ON performance_baselines (endpoint, method);
+      CREATE INDEX IF NOT EXISTS idx_perf_baselines_measured_at ON performance_baselines (measured_at DESC);
+    `);
+  }
+
+  async recordBaseline(samples: PerformanceSample[]): Promise<PerformanceBaseline[]> {
+    if (samples.length === 0) return [];
+
+    const grouped = new Map<string, number[]>();
+    for (const s of samples) {
+      const key = `${s.method.toUpperCase()}::${s.endpoint}`;
+      const existing = grouped.get(key) ?? [];
+      existing.push(s.durationMs);
+      grouped.set(key, existing);
+    }
+
+    const results: PerformanceBaseline[] = [];
+
+    for (const [key, durations] of grouped) {
+      const [method, endpoint] = key.split("::");
+      durations.sort((a, b) => a - b);
+
+      const p50 = this.percentile(durations, 50);
+      const p95 = this.percentile(durations, 95);
+      const p99 = this.percentile(durations, 99);
+      const threshold = p95 * 1.5;
+
+      const row = await this.db.query<PerformanceBaseline & Record<string, unknown>>(
+        `INSERT INTO performance_baselines
+           (endpoint, method, p50_ms, p95_ms, p99_ms, sample_count, threshold_ms)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)
+         RETURNING
+           id,
+           endpoint,
+           method,
+           p50_ms    AS "p50Ms",
+           p95_ms    AS "p95Ms",
+           p99_ms    AS "p99Ms",
+           sample_count AS "sampleCount",
+           threshold_ms AS "thresholdMs",
+           measured_at  AS "measuredAt",
+           created_at   AS "createdAt"`,
+        [endpoint, method, p50, p95, p99, durations.length, threshold]
+      );
+
+      const baseline = row.rows[0] as PerformanceBaseline;
+      results.push(baseline);
+      logger.info({ endpoint, method, p50, p95, p99 }, "Performance baseline recorded");
+    }
+
+    return results;
+  }
+
+  async getLatestBaselines(): Promise<PerformanceBaseline[]> {
+    const result = await this.db.query<Record<string, unknown>>(
+      `SELECT DISTINCT ON (endpoint, method)
+         id,
+         endpoint,
+         method,
+         p50_ms    AS "p50Ms",
+         p95_ms    AS "p95Ms",
+         p99_ms    AS "p99Ms",
+         sample_count AS "sampleCount",
+         threshold_ms AS "thresholdMs",
+         measured_at  AS "measuredAt",
+         created_at   AS "createdAt"
+       FROM performance_baselines
+       ORDER BY endpoint, method, measured_at DESC`
+    );
+    return result.rows as unknown as PerformanceBaseline[];
+  }
+
+  async getBaselineForEndpoint(endpoint: string, method = "GET"): Promise<PerformanceBaseline | null> {
+    const result = await this.db.query<Record<string, unknown>>(
+      `SELECT
+         id, endpoint, method,
+         p50_ms AS "p50Ms", p95_ms AS "p95Ms", p99_ms AS "p99Ms",
+         sample_count AS "sampleCount", threshold_ms AS "thresholdMs",
+         measured_at AS "measuredAt", created_at AS "createdAt"
+       FROM performance_baselines
+       WHERE endpoint = $1 AND method = $2
+       ORDER BY measured_at DESC
+       LIMIT 1`,
+      [endpoint, method.toUpperCase()]
+    );
+    return (result.rows[0] as unknown as PerformanceBaseline) ?? null;
+  }
+
+  async detectRegressions(samples: PerformanceSample[]): Promise<RegressionAlert[]> {
+    const alerts: RegressionAlert[] = [];
+    const grouped = new Map<string, number[]>();
+
+    for (const s of samples) {
+      const key = `${s.method.toUpperCase()}::${s.endpoint}`;
+      const arr = grouped.get(key) ?? [];
+      arr.push(s.durationMs);
+      grouped.set(key, arr);
+    }
+
+    for (const [key, durations] of grouped) {
+      const [method, endpoint] = key.split("::");
+      const baseline = await this.getBaselineForEndpoint(endpoint, method);
+      if (!baseline) continue;
+
+      durations.sort((a, b) => a - b);
+      const currentP95 = this.percentile(durations, 95);
+      const degradationPct = ((currentP95 - baseline.p95Ms) / baseline.p95Ms) * 100;
+
+      if (degradationPct >= REGRESSION_WARNING_PCT) {
+        alerts.push({
+          endpoint,
+          method,
+          currentP95Ms: currentP95,
+          baselineP95Ms: baseline.p95Ms,
+          degradationPct: Math.round(degradationPct),
+          severity: degradationPct >= REGRESSION_CRITICAL_PCT ? "critical" : "warning",
+        });
+
+        logger.warn(
+          { endpoint, method, currentP95, baselineP95: baseline.p95Ms, degradationPct },
+          "Performance regression detected"
+        );
+      }
+    }
+
+    return alerts;
+  }
+
+  async getTrend(endpoint: string, method = "GET", limit = 30): Promise<BaselineTrend> {
+    const result = await this.db.query<Record<string, unknown>>(
+      `SELECT
+         p95_ms AS "p95Ms",
+         sample_count AS "sampleCount",
+         measured_at AS "measuredAt"
+       FROM performance_baselines
+       WHERE endpoint = $1 AND method = $2
+       ORDER BY measured_at DESC
+       LIMIT $3`,
+      [endpoint, method.toUpperCase(), limit]
+    );
+
+    return {
+      endpoint,
+      method: method.toUpperCase(),
+      history: (result.rows as unknown as Array<{ p95Ms: number; sampleCount: number; measuredAt: string }>).reverse(),
+    };
+  }
+
+  private percentile(sorted: number[], p: number): number {
+    if (sorted.length === 0) return 0;
+    const idx = Math.ceil((p / 100) * sorted.length) - 1;
+    return sorted[Math.max(0, idx)];
+  }
+}
+
+export const performanceBaselineService = new PerformanceBaselineService();

--- a/backend/tests/jobs/batchReconciliation.job.test.ts
+++ b/backend/tests/jobs/batchReconciliation.job.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { logger } from "../../src/utils/logger.js";
+import { ReconciliationService } from "../../src/services/reconciliation.service.js";
+import {
+  runBatchReconciliation,
+  startBatchReconciliationJob,
+  stopBatchReconciliationJob,
+} from "../../src/jobs/batchReconciliation.job.js";
+
+vi.mock("../../src/utils/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("../../src/config/index.js", () => ({
+  config: {},
+  SUPPORTED_ASSETS: [
+    { code: "USDC" },
+    { code: "EURC" },
+  ],
+}));
+
+vi.mock("../../src/database/connection.js", () => ({
+  getDatabase: vi.fn(),
+}));
+
+const mockStartRun = vi.fn();
+const mockFinishRun = vi.fn();
+const mockGetLatestRun = vi.fn();
+
+vi.mock("../../src/services/reconciliation.service.js", () => ({
+  ReconciliationService: vi.fn(() => ({
+    startRun: mockStartRun,
+    finishRun: mockFinishRun,
+    getLatestRun: mockGetLatestRun,
+  })),
+}));
+
+describe("BatchReconciliation Job", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStartRun.mockResolvedValue({ id: "run-123" });
+    mockFinishRun.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    stopBatchReconciliationJob();
+  });
+
+  it("processes all supported assets and returns a report", async () => {
+    mockGetLatestRun.mockResolvedValue({
+      status: "success",
+      stellarSupply: 1000,
+      reportedSupply: 1000,
+      mismatchPercentage: 0,
+    });
+
+    const report = await runBatchReconciliation();
+
+    expect(report.totalAssets).toBe(2);
+    expect(report.successCount).toBe(2);
+    expect(report.mismatchCount).toBe(0);
+    expect(report.failureCount).toBe(0);
+    expect(report.jobId).toMatch(/^batch-recon-/);
+    expect(report.startedAt).toBeTruthy();
+    expect(report.finishedAt).toBeTruthy();
+  });
+
+  it("records mismatches when latest run has mismatch status", async () => {
+    mockGetLatestRun.mockResolvedValue({
+      status: "mismatch",
+      stellarSupply: 1000,
+      reportedSupply: 950,
+      mismatchPercentage: 5.26,
+    });
+
+    const report = await runBatchReconciliation();
+
+    expect(report.mismatchCount).toBe(2);
+    expect(report.successCount).toBe(0);
+    expect(report.mismatches).toHaveLength(2);
+    expect(report.mismatches[0].mismatchPercentage).toBe(5.26);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.anything(),
+      "Reconciliation mismatch detected"
+    );
+  });
+
+  it("records errors when no baseline data found", async () => {
+    mockGetLatestRun.mockResolvedValue(null);
+
+    const report = await runBatchReconciliation();
+
+    expect(report.failureCount).toBe(2);
+    expect(report.errors).toHaveLength(2);
+    expect(report.errors[0].error).toContain("No baseline data");
+  });
+
+  it("handles per-asset exceptions gracefully without stopping the batch", async () => {
+    mockGetLatestRun
+      .mockResolvedValueOnce({ status: "success", stellarSupply: 100, reportedSupply: 100, mismatchPercentage: 0 })
+      .mockRejectedValueOnce(new Error("DB connection lost"));
+
+    const report = await runBatchReconciliation();
+
+    expect(report.successCount).toBe(1);
+    expect(report.failureCount).toBe(1);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ assetCode: "EURC" }),
+      "Reconciliation run failed for asset"
+    );
+  });
+
+  it("starts and stops the job scheduler without throwing", () => {
+    vi.useFakeTimers();
+    expect(() => startBatchReconciliationJob()).not.toThrow();
+    expect(() => stopBatchReconciliationJob()).not.toThrow();
+    vi.useRealTimers();
+  });
+});

--- a/backend/tests/services/performanceBaseline.service.test.ts
+++ b/backend/tests/services/performanceBaseline.service.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { PerformanceBaselineService, type PerformanceSample } from "../../src/services/performanceBaseline.service.js";
+
+const mockQuery = vi.fn();
+
+vi.mock("../../src/database/connection.js", () => ({
+  getDatabase: vi.fn(() => ({ query: mockQuery })),
+}));
+
+vi.mock("../../src/utils/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+function makeService() {
+  return new PerformanceBaselineService();
+}
+
+const SAMPLE_BASELINE = {
+  id: "base-1",
+  endpoint: "/api/v1/assets",
+  method: "GET",
+  p50Ms: 80,
+  p95Ms: 150,
+  p99Ms: 200,
+  sampleCount: 100,
+  thresholdMs: 225,
+  measuredAt: new Date().toISOString(),
+  createdAt: new Date().toISOString(),
+};
+
+describe("PerformanceBaselineService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("recordBaseline", () => {
+    it("inserts one baseline row per unique endpoint+method pair", async () => {
+      mockQuery.mockResolvedValue({ rows: [SAMPLE_BASELINE] });
+
+      const samples: PerformanceSample[] = [
+        { endpoint: "/api/v1/assets", method: "GET", durationMs: 100, statusCode: 200 },
+        { endpoint: "/api/v1/assets", method: "GET", durationMs: 120, statusCode: 200 },
+        { endpoint: "/api/v1/assets", method: "GET", durationMs: 80, statusCode: 200 },
+      ];
+
+      const service = makeService();
+      const results = await service.recordBaseline(samples);
+
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      expect(results).toHaveLength(1);
+    });
+
+    it("inserts separate rows for different endpoint+method combinations", async () => {
+      mockQuery.mockResolvedValue({ rows: [SAMPLE_BASELINE] });
+
+      const samples: PerformanceSample[] = [
+        { endpoint: "/api/v1/assets", method: "GET", durationMs: 100, statusCode: 200 },
+        { endpoint: "/api/v1/bridges", method: "GET", durationMs: 200, statusCode: 200 },
+      ];
+
+      const service = makeService();
+      await service.recordBaseline(samples);
+
+      expect(mockQuery).toHaveBeenCalledTimes(2);
+    });
+
+    it("returns empty array when no samples provided", async () => {
+      const service = makeService();
+      const results = await service.recordBaseline([]);
+      expect(results).toEqual([]);
+      expect(mockQuery).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("detectRegressions", () => {
+    it("returns empty array when no baseline exists for the endpoint", async () => {
+      mockQuery.mockResolvedValue({ rows: [] });
+
+      const samples: PerformanceSample[] = [
+        { endpoint: "/api/v1/unknown", method: "GET", durationMs: 5000, statusCode: 200 },
+      ];
+
+      const service = makeService();
+      const alerts = await service.detectRegressions(samples);
+      expect(alerts).toHaveLength(0);
+    });
+
+    it("returns warning alert when p95 degrades by more than 20%", async () => {
+      mockQuery.mockResolvedValue({ rows: [SAMPLE_BASELINE] }); // p95 = 150ms
+
+      // p95 of [200, 210, 190] = 210ms → +40% above 150ms baseline
+      const samples: PerformanceSample[] = Array.from({ length: 10 }, (_, i) => ({
+        endpoint: "/api/v1/assets",
+        method: "GET",
+        durationMs: 190 + i * 2,
+        statusCode: 200,
+      }));
+
+      const service = makeService();
+      const alerts = await service.detectRegressions(samples);
+
+      expect(alerts.length).toBeGreaterThan(0);
+      expect(alerts[0].severity).toBe("warning");
+      expect(alerts[0].degradationPct).toBeGreaterThan(20);
+    });
+
+    it("returns critical alert when p95 degrades by more than 50%", async () => {
+      mockQuery.mockResolvedValue({ rows: [SAMPLE_BASELINE] }); // p95 = 150ms
+
+      // 150ms * 1.6 = 240ms+ → critical
+      const samples: PerformanceSample[] = Array.from({ length: 10 }, () => ({
+        endpoint: "/api/v1/assets",
+        method: "GET",
+        durationMs: 300,
+        statusCode: 200,
+      }));
+
+      const service = makeService();
+      const alerts = await service.detectRegressions(samples);
+
+      expect(alerts.length).toBeGreaterThan(0);
+      expect(alerts[0].severity).toBe("critical");
+    });
+
+    it("returns no alerts when performance is within threshold", async () => {
+      mockQuery.mockResolvedValue({ rows: [SAMPLE_BASELINE] }); // p95 = 150ms
+
+      const samples: PerformanceSample[] = Array.from({ length: 10 }, () => ({
+        endpoint: "/api/v1/assets",
+        method: "GET",
+        durationMs: 155,
+        statusCode: 200,
+      }));
+
+      const service = makeService();
+      const alerts = await service.detectRegressions(samples);
+      expect(alerts).toHaveLength(0);
+    });
+  });
+
+  describe("getTrend", () => {
+    it("queries historical baselines with correct params", async () => {
+      mockQuery.mockResolvedValue({
+        rows: [
+          { p95Ms: 150, sampleCount: 100, measuredAt: "2025-01-01T00:00:00Z" },
+          { p95Ms: 160, sampleCount: 80, measuredAt: "2025-01-02T00:00:00Z" },
+        ],
+      });
+
+      const service = makeService();
+      const trend = await service.getTrend("/api/v1/assets", "GET", 10);
+
+      expect(trend.endpoint).toBe("/api/v1/assets");
+      expect(trend.method).toBe("GET");
+      expect(trend.history).toHaveLength(2);
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining("SELECT"),
+        ["/api/v1/assets", "GET", 10]
+      );
+    });
+  });
+});

--- a/frontend/src/components/AnomalyTrendCharts.tsx
+++ b/frontend/src/components/AnomalyTrendCharts.tsx
@@ -1,0 +1,262 @@
+import { useState } from "react";
+import {
+  AreaChart,
+  Area,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
+import { useAnomalyTrends, type AnomalySeverity } from "../hooks/useAnomalyTrends";
+import { useAssetsWithHealth } from "../hooks/useAssets";
+
+const SEVERITY_COLORS: Record<AnomalySeverity, string> = {
+  low: "#22c55e",
+  medium: "#eab308",
+  high: "#f97316",
+  critical: "#ef4444",
+};
+
+const SEVERITY_LABELS: Record<AnomalySeverity, string> = {
+  low: "Low",
+  medium: "Medium",
+  high: "High",
+  critical: "Critical",
+};
+
+interface TooltipProps {
+  active?: boolean;
+  payload?: Array<{ name: string; value: number; color: string }>;
+  label?: string;
+}
+
+function CustomTooltip({ active, payload, label }: TooltipProps) {
+  if (!active || !payload?.length) return null;
+  return (
+    <div className="bg-stellar-card border border-stellar-border rounded-lg p-3 text-xs shadow-xl">
+      <p className="text-stellar-text-secondary mb-1">{label}</p>
+      {payload
+        .filter((p) => p.value > 0)
+        .sort((a, b) => b.value - a.value)
+        .map((p) => (
+          <p key={p.name} className="flex justify-between gap-4" style={{ color: p.color }}>
+            <span>{SEVERITY_LABELS[p.name as AnomalySeverity] ?? p.name}</span>
+            <span className="font-medium">{p.value}</span>
+          </p>
+        ))}
+    </div>
+  );
+}
+
+export default function AnomalyTrendCharts() {
+  const [selectedAsset, setSelectedAsset] = useState<string>("");
+  const [chartType, setChartType] = useState<"area" | "bar">("area");
+  const [days, setDays] = useState(30);
+
+  const { data: assetsData } = useAssetsWithHealth();
+  const { data: trendData, isLoading, error } = useAnomalyTrends({
+    assetCode: selectedAsset || undefined,
+    days,
+  });
+
+  const topAssets = Object.entries(trendData?.byAsset ?? {})
+    .sort(([, a], [, b]) => b - a)
+    .slice(0, 5);
+
+  const handleExport = () => {
+    if (!trendData) return;
+    const csv = [
+      ["Date", "Low", "Medium", "High", "Critical", "Total"],
+      ...trendData.trendPoints.map((p) => [p.date, p.low, p.medium, p.high, p.critical, p.total]),
+    ]
+      .map((row) => row.join(","))
+      .join("\n");
+
+    const blob = new Blob([csv], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `anomaly-trends-${new Date().toISOString().slice(0, 10)}.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <section aria-label="Anomaly trend charts" className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h2 className="text-xl font-semibold text-white">Anomaly Trends</h2>
+          <p className="text-stellar-text-secondary text-sm mt-0.5">
+            Frequency and severity of detected anomalies over time
+          </p>
+        </div>
+        <div className="flex items-center gap-3 flex-wrap">
+          <select
+            className="bg-stellar-card border border-stellar-border text-white text-sm rounded-lg px-3 py-1.5"
+            value={selectedAsset}
+            onChange={(e) => setSelectedAsset(e.target.value)}
+            aria-label="Filter by asset"
+          >
+            <option value="">All assets</option>
+            {(assetsData ?? []).map((a) => (
+              <option key={a.symbol} value={a.symbol}>
+                {a.symbol}
+              </option>
+            ))}
+          </select>
+
+          <select
+            className="bg-stellar-card border border-stellar-border text-white text-sm rounded-lg px-3 py-1.5"
+            value={days}
+            onChange={(e) => setDays(Number(e.target.value))}
+            aria-label="Time range"
+          >
+            <option value={7}>Last 7 days</option>
+            <option value={14}>Last 14 days</option>
+            <option value={30}>Last 30 days</option>
+            <option value={90}>Last 90 days</option>
+          </select>
+
+          <div className="flex rounded-lg border border-stellar-border overflow-hidden">
+            {(["area", "bar"] as const).map((t) => (
+              <button
+                key={t}
+                onClick={() => setChartType(t)}
+                className={`px-3 py-1.5 text-sm font-medium transition-colors ${
+                  chartType === t
+                    ? "bg-stellar-blue text-white"
+                    : "text-stellar-text-secondary hover:text-white"
+                }`}
+              >
+                {t === "area" ? "Area" : "Bar"}
+              </button>
+            ))}
+          </div>
+
+          <button
+            onClick={handleExport}
+            disabled={!trendData}
+            className="px-3 py-1.5 bg-stellar-card border border-stellar-border text-stellar-text-secondary text-sm rounded-lg hover:text-white transition-colors disabled:opacity-50"
+          >
+            Export CSV
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="bg-red-900/20 border border-red-800 rounded-lg p-4 text-red-400 text-sm" role="alert">
+          Failed to load anomaly trend data.
+        </div>
+      )}
+
+      {/* Summary badges */}
+      {trendData && (
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          {(["critical", "high", "medium", "low"] as AnomalySeverity[]).map((sev) => (
+            <div
+              key={sev}
+              className="bg-stellar-card border border-stellar-border rounded-lg p-4"
+            >
+              <p className="text-stellar-text-secondary text-xs uppercase tracking-wide mb-1">
+                {SEVERITY_LABELS[sev]}
+              </p>
+              <p className="text-2xl font-bold" style={{ color: SEVERITY_COLORS[sev] }}>
+                {trendData.bySeverity[sev]}
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Main trend chart */}
+      <div className="bg-stellar-card border border-stellar-border rounded-lg p-6">
+        <h3 className="text-sm font-medium text-stellar-text-secondary uppercase tracking-wide mb-4">
+          Severity breakdown over time
+        </h3>
+
+        {isLoading ? (
+          <div className="h-64 bg-stellar-border/30 rounded animate-pulse" />
+        ) : (
+          <ResponsiveContainer width="100%" height={280}>
+            {chartType === "area" ? (
+              <AreaChart data={trendData?.trendPoints ?? []} margin={{ top: 4, right: 16, bottom: 0, left: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#334155" />
+                <XAxis
+                  dataKey="date"
+                  tick={{ fill: "#94a3b8", fontSize: 11 }}
+                  tickFormatter={(v: string) => v.slice(5)}
+                />
+                <YAxis tick={{ fill: "#94a3b8", fontSize: 11 }} allowDecimals={false} />
+                <Tooltip content={<CustomTooltip />} />
+                <Legend wrapperStyle={{ fontSize: 12 }} />
+                {(["critical", "high", "medium", "low"] as AnomalySeverity[]).map((sev) => (
+                  <Area
+                    key={sev}
+                    type="monotone"
+                    dataKey={sev}
+                    name={sev}
+                    stackId="1"
+                    stroke={SEVERITY_COLORS[sev]}
+                    fill={SEVERITY_COLORS[sev]}
+                    fillOpacity={0.6}
+                  />
+                ))}
+              </AreaChart>
+            ) : (
+              <BarChart data={trendData?.trendPoints ?? []} margin={{ top: 4, right: 16, bottom: 0, left: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#334155" />
+                <XAxis
+                  dataKey="date"
+                  tick={{ fill: "#94a3b8", fontSize: 11 }}
+                  tickFormatter={(v: string) => v.slice(5)}
+                />
+                <YAxis tick={{ fill: "#94a3b8", fontSize: 11 }} allowDecimals={false} />
+                <Tooltip content={<CustomTooltip />} />
+                <Legend wrapperStyle={{ fontSize: 12 }} />
+                {(["critical", "high", "medium", "low"] as AnomalySeverity[]).map((sev) => (
+                  <Bar
+                    key={sev}
+                    dataKey={sev}
+                    name={sev}
+                    stackId="severity"
+                    fill={SEVERITY_COLORS[sev]}
+                  />
+                ))}
+              </BarChart>
+            )}
+          </ResponsiveContainer>
+        )}
+      </div>
+
+      {/* Top assets */}
+      {topAssets.length > 0 && (
+        <div className="bg-stellar-card border border-stellar-border rounded-lg p-6">
+          <h3 className="text-sm font-medium text-stellar-text-secondary uppercase tracking-wide mb-4">
+            Top assets by anomaly count
+          </h3>
+          <div className="space-y-3">
+            {topAssets.map(([asset, count]) => {
+              const max = topAssets[0][1];
+              return (
+                <div key={asset} className="flex items-center gap-3">
+                  <span className="text-white text-sm w-16 shrink-0">{asset}</span>
+                  <div className="flex-1 bg-stellar-border rounded-full h-2">
+                    <div
+                      className="bg-stellar-blue h-2 rounded-full transition-all"
+                      style={{ width: `${(count / max) * 100}%` }}
+                    />
+                  </div>
+                  <span className="text-stellar-text-secondary text-sm w-8 text-right">{count}</span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/UserActivityHeatmap.tsx
+++ b/frontend/src/components/UserActivityHeatmap.tsx
@@ -1,0 +1,201 @@
+import { useState } from "react";
+import { useUserActivityHeatmap, type ActivityCell } from "../hooks/useUserActivityHeatmap";
+
+const DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+function heatColor(count: number, max: number): string {
+  if (count === 0 || max === 0) return "bg-stellar-border/30";
+  const ratio = count / max;
+  if (ratio >= 0.8) return "bg-blue-500";
+  if (ratio >= 0.6) return "bg-blue-400";
+  if (ratio >= 0.4) return "bg-blue-300";
+  if (ratio >= 0.2) return "bg-blue-200";
+  return "bg-blue-100/50";
+}
+
+interface CellTooltip {
+  actorId: string;
+  cell: ActivityCell;
+  x: number;
+  y: number;
+}
+
+export default function UserActivityHeatmap() {
+  const [rangeDays, setRangeDays] = useState(7);
+  const [filterUser, setFilterUser] = useState("");
+  const [tooltip, setTooltip] = useState<CellTooltip | null>(null);
+
+  const { data, isLoading, error } = useUserActivityHeatmap({ days: rangeDays });
+
+  const visibleUsers = (data?.users ?? []).filter((u) =>
+    filterUser ? u.actorId.toLowerCase().includes(filterUser.toLowerCase()) : true
+  );
+
+  const maxCount = data?.maxCount ?? 1;
+
+  return (
+    <section aria-label="User activity heatmap" className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h2 className="text-xl font-semibold text-white">User Activity Heatmap</h2>
+          <p className="text-stellar-text-secondary text-sm mt-0.5">
+            Operator actions by day and hour — hover cells for details
+          </p>
+        </div>
+        <div className="flex items-center gap-3 flex-wrap">
+          <input
+            type="text"
+            placeholder="Filter by user…"
+            value={filterUser}
+            onChange={(e) => setFilterUser(e.target.value)}
+            className="bg-stellar-card border border-stellar-border text-white text-sm rounded-lg px-3 py-1.5 placeholder:text-stellar-text-secondary focus:outline-none focus:ring-1 focus:ring-stellar-blue"
+          />
+          <select
+            className="bg-stellar-card border border-stellar-border text-white text-sm rounded-lg px-3 py-1.5"
+            value={rangeDays}
+            onChange={(e) => setRangeDays(Number(e.target.value))}
+            aria-label="Time range"
+          >
+            <option value={7}>Last 7 days</option>
+            <option value={14}>Last 14 days</option>
+            <option value={30}>Last 30 days</option>
+          </select>
+        </div>
+      </div>
+
+      {error && (
+        <div className="bg-red-900/20 border border-red-800 rounded-lg p-4 text-red-400 text-sm" role="alert">
+          Failed to load user activity data.
+        </div>
+      )}
+
+      {isLoading && (
+        <div className="bg-stellar-card border border-stellar-border rounded-lg p-6">
+          <div className="h-4 w-48 bg-stellar-border rounded animate-pulse mb-6" />
+          {[...Array(3)].map((_, i) => (
+            <div key={i} className="flex gap-2 mb-3">
+              <div className="h-6 w-24 bg-stellar-border rounded animate-pulse" />
+              <div className="flex-1 h-6 bg-stellar-border/30 rounded animate-pulse" />
+            </div>
+          ))}
+        </div>
+      )}
+
+      {!isLoading && !error && (
+        <div className="bg-stellar-card border border-stellar-border rounded-lg overflow-x-auto">
+          {visibleUsers.length === 0 ? (
+            <div className="p-10 text-center text-stellar-text-secondary">
+              No activity data found for the selected range.
+            </div>
+          ) : (
+            <div className="p-6 relative" onMouseLeave={() => setTooltip(null)}>
+              {/* Hour header */}
+              <div className="flex mb-2 ml-28">
+                {Array.from({ length: 24 }, (_, h) => (
+                  <div
+                    key={h}
+                    className="flex-1 text-center text-stellar-text-secondary"
+                    style={{ fontSize: 9, minWidth: 20 }}
+                  >
+                    {h % 6 === 0 ? `${h}h` : ""}
+                  </div>
+                ))}
+              </div>
+
+              {visibleUsers.map((user) => (
+                <div key={user.actorId} className="flex items-center gap-2 mb-1.5">
+                  <div
+                    className="w-28 shrink-0 text-right pr-3 text-xs text-stellar-text-secondary truncate"
+                    title={user.actorId}
+                  >
+                    {user.actorId.length > 14 ? `${user.actorId.slice(0, 12)}…` : user.actorId}
+                  </div>
+
+                  {/* 7 day groups × 24 hours each */}
+                  <div className="flex gap-0.5 flex-wrap" style={{ width: "100%" }}>
+                    {DAY_LABELS.map((_, dayIdx) =>
+                      Array.from({ length: 24 }, (__, hour) => {
+                        const cell = user.cells.find(
+                          (c) => c.dayOfWeek === dayIdx && c.hour === hour
+                        );
+                        const count = cell?.count ?? 0;
+                        return (
+                          <div
+                            key={`${dayIdx}-${hour}`}
+                            className={`rounded-sm cursor-pointer transition-transform hover:scale-125 ${heatColor(count, maxCount)}`}
+                            style={{ width: 14, height: 14, minWidth: 14 }}
+                            onMouseEnter={(e) => {
+                              if (cell && count > 0) {
+                                setTooltip({
+                                  actorId: user.actorId,
+                                  cell,
+                                  x: e.clientX,
+                                  y: e.clientY,
+                                });
+                              }
+                            }}
+                            aria-label={`${user.actorId} ${DAY_LABELS[dayIdx]} ${hour}:00 — ${count} action${count !== 1 ? "s" : ""}`}
+                          />
+                        );
+                      })
+                    )}
+                  </div>
+
+                  <div className="text-xs text-stellar-text-secondary w-10 text-right shrink-0">
+                    {user.totalActions}
+                  </div>
+                </div>
+              ))}
+
+              {/* Day labels below */}
+              <div className="flex mt-3 ml-28 gap-0.5">
+                {DAY_LABELS.map((day) => (
+                  <div
+                    key={day}
+                    className="text-stellar-text-secondary text-center"
+                    style={{ fontSize: 9, width: 14 * 24 + 23 * 0.5 / 7, minWidth: 20 }}
+                  >
+                    {day}
+                  </div>
+                ))}
+              </div>
+
+              {/* Legend */}
+              <div className="flex items-center gap-2 mt-5">
+                <span className="text-xs text-stellar-text-secondary">Less</span>
+                {["bg-stellar-border/30", "bg-blue-100/50", "bg-blue-200", "bg-blue-300", "bg-blue-400", "bg-blue-500"].map(
+                  (cls) => (
+                    <div key={cls} className={`w-3 h-3 rounded-sm ${cls}`} />
+                  )
+                )}
+                <span className="text-xs text-stellar-text-secondary">More</span>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Floating tooltip */}
+      {tooltip && (
+        <div
+          className="fixed z-50 bg-stellar-card border border-stellar-border rounded-lg p-3 text-xs shadow-xl pointer-events-none"
+          style={{ left: tooltip.x + 12, top: tooltip.y - 60 }}
+        >
+          <p className="text-white font-medium mb-1">{tooltip.actorId}</p>
+          <p className="text-stellar-text-secondary">
+            {DAY_LABELS[tooltip.cell.dayOfWeek]} {tooltip.cell.hour}:00–{tooltip.cell.hour + 1}:00
+          </p>
+          <p className="text-stellar-blue font-medium">
+            {tooltip.cell.count} action{tooltip.cell.count !== 1 ? "s" : ""}
+          </p>
+          {tooltip.cell.actions.length > 0 && (
+            <p className="text-stellar-text-secondary mt-1 truncate max-w-48">
+              {tooltip.cell.actions.slice(0, 3).join(", ")}
+              {tooltip.cell.actions.length > 3 ? "…" : ""}
+            </p>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/hooks/useAnomalyTrends.ts
+++ b/frontend/src/hooks/useAnomalyTrends.ts
@@ -1,0 +1,103 @@
+import { useQuery } from "@tanstack/react-query";
+
+export type AnomalySeverity = "low" | "medium" | "high" | "critical";
+
+export interface AnomalyEvent {
+  id: string;
+  assetCode: string;
+  bridgeName: string | null;
+  anomalyType: string;
+  severity: AnomalySeverity;
+  detected: boolean;
+  suppressed: boolean;
+  detectedAt: string;
+  explanation?: { summary: string };
+}
+
+export interface AnomalyTrendPoint {
+  date: string;
+  low: number;
+  medium: number;
+  high: number;
+  critical: number;
+  total: number;
+}
+
+export interface AnomalyTrendData {
+  trendPoints: AnomalyTrendPoint[];
+  totalEvents: number;
+  bySeverity: Record<AnomalySeverity, number>;
+  byAsset: Record<string, number>;
+}
+
+async function fetchAnomalyEvents(params: {
+  assetCode?: string;
+  bridgeName?: string;
+  severity?: AnomalySeverity;
+  limit?: number;
+}): Promise<AnomalyEvent[]> {
+  const query = new URLSearchParams();
+  if (params.assetCode) query.set("assetCode", params.assetCode);
+  if (params.bridgeName) query.set("bridgeName", params.bridgeName);
+  if (params.severity) query.set("severity", params.severity);
+  if (params.limit) query.set("limit", String(params.limit));
+
+  const res = await fetch(`/api/v1/anomaly-detection/events?${query}`);
+  if (!res.ok) throw new Error("Failed to fetch anomaly events");
+  const data = (await res.json()) as { events: AnomalyEvent[] };
+  return data.events;
+}
+
+function buildTrendData(events: AnomalyEvent[], days = 30): AnomalyTrendData {
+  const bySeverity: Record<AnomalySeverity, number> = { low: 0, medium: 0, high: 0, critical: 0 };
+  const byAsset: Record<string, number> = {};
+  const byDay = new Map<string, Record<AnomalySeverity, number>>();
+
+  // pre-fill last N days
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date();
+    d.setDate(d.getDate() - i);
+    const key = d.toISOString().slice(0, 10);
+    byDay.set(key, { low: 0, medium: 0, high: 0, critical: 0 });
+  }
+
+  for (const ev of events) {
+    const day = new Date(ev.detectedAt).toISOString().slice(0, 10);
+    bySeverity[ev.severity]++;
+    byAsset[ev.assetCode] = (byAsset[ev.assetCode] ?? 0) + 1;
+    if (byDay.has(day)) {
+      byDay.get(day)![ev.severity]++;
+    }
+  }
+
+  const trendPoints: AnomalyTrendPoint[] = [];
+  for (const [date, counts] of byDay) {
+    trendPoints.push({
+      date,
+      ...counts,
+      total: counts.low + counts.medium + counts.high + counts.critical,
+    });
+  }
+
+  return { trendPoints, totalEvents: events.length, bySeverity, byAsset };
+}
+
+export function useAnomalyTrends(params: {
+  assetCode?: string;
+  bridgeName?: string;
+  severity?: AnomalySeverity;
+  days?: number;
+  limit?: number;
+} = {}) {
+  const { days = 30, ...fetchParams } = params;
+
+  return useQuery({
+    queryKey: ["anomaly-trends", fetchParams, days],
+    queryFn: async () => {
+      const events = await fetchAnomalyEvents({ ...fetchParams, limit: fetchParams.limit ?? 500 });
+      return buildTrendData(events, days);
+    },
+    staleTime: 60_000,
+    refetchInterval: 120_000,
+  });
+}

--- a/frontend/src/hooks/useUserActivityHeatmap.ts
+++ b/frontend/src/hooks/useUserActivityHeatmap.ts
@@ -1,0 +1,125 @@
+import { useQuery } from "@tanstack/react-query";
+
+export interface AuditEntry {
+  id: string;
+  action: string;
+  actorId: string;
+  actorType: "user" | "api_key" | "system";
+  resourceType: string;
+  severity: "info" | "warning" | "critical";
+  createdAt: string;
+}
+
+export interface ActivityCell {
+  hour: number;
+  dayOfWeek: number;
+  count: number;
+  actions: string[];
+}
+
+export interface UserActivityRow {
+  actorId: string;
+  totalActions: number;
+  cells: ActivityCell[];
+  recentActions: string[];
+}
+
+export interface HeatmapData {
+  users: UserActivityRow[];
+  maxCount: number;
+  hours: number[];
+  days: string[];
+}
+
+const DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+const HOURS = Array.from({ length: 24 }, (_, i) => i);
+
+async function fetchAuditLogs(params: {
+  from?: string;
+  limit?: number;
+}): Promise<{ entries: AuditEntry[]; total: number }> {
+  const query = new URLSearchParams();
+  if (params.from) query.set("from", params.from);
+  query.set("limit", String(params.limit ?? 500));
+
+  const res = await fetch(`/api/v1/admin/audit?${query}`);
+  if (!res.ok) throw new Error("Failed to fetch audit logs");
+  return res.json() as Promise<{ entries: AuditEntry[]; total: number }>;
+}
+
+function buildHeatmapData(entries: AuditEntry[]): HeatmapData {
+  const userMap = new Map<string, Map<string, { count: number; actions: Set<string> }>>();
+
+  for (const entry of entries) {
+    if (!entry.actorId || entry.actorType === "system") continue;
+
+    const date = new Date(entry.createdAt);
+    const hour = date.getHours();
+    const dayOfWeek = date.getDay();
+    const cellKey = `${dayOfWeek}:${hour}`;
+
+    if (!userMap.has(entry.actorId)) {
+      userMap.set(entry.actorId, new Map());
+    }
+    const cells = userMap.get(entry.actorId)!;
+
+    if (!cells.has(cellKey)) {
+      cells.set(cellKey, { count: 0, actions: new Set() });
+    }
+    const cell = cells.get(cellKey)!;
+    cell.count++;
+    cell.actions.add(entry.action);
+  }
+
+  let maxCount = 0;
+  const users: UserActivityRow[] = [];
+
+  for (const [actorId, cellMap] of userMap) {
+    const cells: ActivityCell[] = [];
+    let total = 0;
+    const recentActions = new Set<string>();
+
+    for (let day = 0; day < 7; day++) {
+      for (const hour of HOURS) {
+        const key = `${day}:${hour}`;
+        const data = cellMap.get(key) ?? { count: 0, actions: new Set<string>() };
+        cells.push({
+          hour,
+          dayOfWeek: day,
+          count: data.count,
+          actions: Array.from(data.actions),
+        });
+        total += data.count;
+        if (data.count > maxCount) maxCount = data.count;
+        data.actions.forEach((a) => recentActions.add(a));
+      }
+    }
+
+    users.push({
+      actorId,
+      totalActions: total,
+      cells,
+      recentActions: Array.from(recentActions).slice(0, 5),
+    });
+  }
+
+  users.sort((a, b) => b.totalActions - a.totalActions);
+
+  return { users, maxCount, hours: HOURS, days: DAY_LABELS };
+}
+
+export function useUserActivityHeatmap(options: { days?: number } = {}) {
+  const { days = 7 } = options;
+
+  return useQuery({
+    queryKey: ["user-activity-heatmap", days],
+    queryFn: async () => {
+      const from = new Date();
+      from.setDate(from.getDate() - days);
+      const data = await fetchAuditLogs({ from: from.toISOString(), limit: 1000 });
+      return buildHeatmapData(data.entries);
+    },
+    staleTime: 120_000,
+    refetchInterval: 300_000,
+  });
+}

--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -4,6 +4,7 @@ import { MetricsDrilldown } from "../components/MetricsDrilldown";
 import SnapshotCard from "../components/analytics/SnapshotCard";
 import BridgeComparison from "../components/analytics/BridgeComparison";
 import IncidentHeatmap from "../components/IncidentHeatmap";
+import AnomalyTrendCharts from "../components/AnomalyTrendCharts";
 import type { BridgeAnalytics } from "../hooks/useAnalytics";
 import { useAssetsWithHealth } from "../hooks/useAssets";
 import { usePricesForSymbols } from "../hooks/usePrices";
@@ -237,6 +238,9 @@ export default function Analytics() {
 
       {/* Incident Heatmap */}
       <IncidentHeatmap />
+
+      {/* Anomaly Trend Charts */}
+      <AnomalyTrendCharts />
 
       {/* Health Score Trends */}
       <div className="bg-stellar-card border border-stellar-border rounded-lg p-6">

--- a/frontend/src/pages/OperationalAccessAudit.tsx
+++ b/frontend/src/pages/OperationalAccessAudit.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
+import UserActivityHeatmap from "../components/UserActivityHeatmap";
 
 const API = "/api/v1/admin/access-audit";
 
@@ -292,7 +293,7 @@ function SessionsTab() {
   );
 }
 
-const TABS = ["Access Changes", "Roles", "Sessions"] as const;
+const TABS = ["Access Changes", "Roles", "Sessions", "Activity Heatmap"] as const;
 type Tab = (typeof TABS)[number];
 
 export default function OperationalAccessAudit() {
@@ -328,6 +329,7 @@ export default function OperationalAccessAudit() {
       {tab === "Access Changes" && <AccessChangesTab />}
       {tab === "Roles" && <RolesTab />}
       {tab === "Sessions" && <SessionsTab />}
+      {tab === "Activity Heatmap" && <UserActivityHeatmap />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- **#634 – Batch Reconciliation Runner**: Adds `batchReconciliation.job.ts` that iterates all supported assets, runs reconciliation checks, stores results, detects supply mismatches, and generates structured reports. Wired into server startup/shutdown and exposed via `POST /api/v1/reconciliation/batch/run`.
- **#635 – Performance Baseline Tracker**: Adds `PerformanceBaselineService` with baseline recording (p50/p95/p99), regression detection (warning ≥ 20%, critical ≥ 50%), and historical trend queries. Exposed via `/api/v1/performance-baselines` routes.
- **#632 – Anomaly Trend Charts**: Adds `AnomalyTrendCharts` component and `useAnomalyTrends` hook. Renders stacked area/bar charts of anomaly frequency by severity over configurable periods with CSV export. Integrated into the Analytics page.
- **#633 – User Activity Heatmap**: Adds `UserActivityHeatmap` component and `useUserActivityHeatmap` hook. Visualizes operator actions by day-of-week × hour grid with hover tooltips, user filter, and color legend. Integrated as a new tab in the Operational Access Audit page.

## Test plan

- [ ] Batch reconciliation: `POST /api/v1/reconciliation/batch/run` returns a report with `totalAssets`, `successCount`, `mismatchCount`, `failureCount`
- [ ] Performance baseline: `POST /api/v1/performance-baselines/record` records samples; `/detect-regressions` flags p95 regressions; `/trend` returns historical series
- [ ] Analytics page → Anomaly Trends section renders area/bar charts, severity badges, asset breakdown, CSV download works
- [ ] Operational Access Audit → "Activity Heatmap" tab renders the user grid with hover tooltips and range selector
- [ ] Unit tests pass: `batchReconciliation.job.test.ts`, `performanceBaseline.service.test.ts`



closes #632    closes #633    closes #634    closes #635