### PR TITLE
feat(backend): provider circuit breaker, event replay, metrics rollups, source decommission

### DIFF
--- a/backend/src/api/routes/eventReplay.routes.ts
+++ b/backend/src/api/routes/eventReplay.routes.ts
@@ -1,0 +1,111 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { z } from "zod";
+import { authMiddleware } from "../middleware/auth.js";
+import { eventReplayService } from "../../services/eventReplay.service.js";
+
+const filterSchema = z.object({
+  aggregateType: z.string().trim().min(1).max(64).optional(),
+  aggregateId: z.string().trim().min(1).optional(),
+  eventType: z.string().trim().min(1).max(64).optional(),
+  status: z.enum(["delivered", "failed"]).optional(),
+  from: z.string().datetime().optional(),
+  to: z.string().datetime().optional(),
+  limit: z.number().int().positive().max(500).optional(),
+});
+
+const executeBodySchema = z.object({
+  filter: filterSchema,
+  dryRun: z.boolean().default(true),
+  reason: z.string().trim().max(500).optional(),
+  confirm: z.boolean().optional(),
+});
+
+export async function eventReplayRoutes(server: FastifyInstance) {
+  const requireOps = authMiddleware({ requiredScopes: ["admin:config"] });
+
+  server.post(
+    "/preview",
+    {
+      preHandler: requireOps,
+      schema: {
+        tags: ["Event Replay"],
+        summary: "Preview events matching a replay filter without replaying them",
+        body: { type: "object", additionalProperties: true },
+        response: { 200: { type: "object", additionalProperties: true } },
+      },
+    },
+    async (request: FastifyRequest<{ Body: unknown }>, reply: FastifyReply) => {
+      const filter = filterSchema.parse((request.body as { filter?: unknown })?.filter ?? request.body ?? {});
+      const result = await eventReplayService.previewReplay({
+        ...filter,
+        from: filter.from ? new Date(filter.from) : undefined,
+        to: filter.to ? new Date(filter.to) : undefined,
+      });
+      return reply.send(result);
+    }
+  );
+
+  server.post(
+    "/",
+    {
+      preHandler: requireOps,
+      schema: {
+        tags: ["Event Replay"],
+        summary: "Replay historical outbox events (dry run by default)",
+        body: { type: "object", additionalProperties: true },
+        response: { 200: { type: "object", additionalProperties: true } },
+      },
+    },
+    async (request: FastifyRequest<{ Body: unknown }>, reply: FastifyReply) => {
+      const body = executeBodySchema.parse(request.body);
+      const run = await eventReplayService.executeReplay({
+        filter: {
+          ...body.filter,
+          from: body.filter.from ? new Date(body.filter.from) : undefined,
+          to: body.filter.to ? new Date(body.filter.to) : undefined,
+        },
+        dryRun: body.dryRun,
+        reason: body.reason,
+        confirm: body.confirm,
+        requestedBy: request.apiKeyAuth?.id ?? request.apiKeyAuth?.name ?? "admin",
+      });
+      return reply.send({ run });
+    }
+  );
+
+  server.get(
+    "/",
+    {
+      preHandler: requireOps,
+      schema: {
+        tags: ["Event Replay"],
+        summary: "List recent event replay runs",
+        response: { 200: { type: "object", additionalProperties: true } },
+      },
+    },
+    async (_request, reply) => {
+      const runs = await eventReplayService.listReplayRuns();
+      return reply.send({ runs });
+    }
+  );
+
+  server.get<{ Params: { id: string } }>(
+    "/:id",
+    {
+      preHandler: requireOps,
+      schema: {
+        tags: ["Event Replay"],
+        summary: "Get the status of a single replay run",
+        params: { type: "object", required: ["id"], properties: { id: { type: "string" } } },
+        response: { 200: { type: "object", additionalProperties: true }, 404: { $ref: "Error#" } },
+      },
+    },
+    async (request, reply) => {
+      const run = await eventReplayService.getReplayRun(request.params.id);
+      if (!run) {
+        return reply.code(404).send({ error: "Replay run not found" });
+      }
+      return reply.send({ run });
+    }
+  );
+}

--- a/backend/src/api/routes/index.ts
+++ b/backend/src/api/routes/index.ts
@@ -79,6 +79,10 @@ import { playbooksRoutes } from "./playbooks.routes.js";
 import { sourceHealthScoringRoutes } from "./sourceHealthScoring.routes.js";
 import { batchReconciliationRoutes } from "./batchReconciliation.routes.js";
 import { performanceBaselineRoutes } from "./performanceBaseline.routes.js";
+import { metricsAggregationRoutes } from "./metricsAggregation.routes.js";
+import { eventReplayRoutes } from "./eventReplay.routes.js";
+import { sourceDecommissionRoutes } from "./sourceDecommission.routes.js";
+import { providerCircuitBreakerRoutes } from "./providerCircuitBreaker.routes.js";
 
 export async function registerRoutes(server: FastifyInstance) {
   server.register(assetsRoutes, { prefix: "/api/v1/assets" });
@@ -192,4 +196,8 @@ export async function registerRoutes(server: FastifyInstance) {
   server.register(sourceHealthScoringRoutes, { prefix: "/api/v1/sources/health-scoring" });
   server.register(batchReconciliationRoutes, { prefix: "/api/v1/reconciliation/batch" });
   server.register(performanceBaselineRoutes, { prefix: "/api/v1/performance-baselines" });
+  server.register(metricsAggregationRoutes, { prefix: "/api/v1/metrics/aggregation" });
+  server.register(eventReplayRoutes, { prefix: "/api/v1/events/replay" });
+  server.register(sourceDecommissionRoutes, { prefix: "/api/v1/sources/decommission" });
+  server.register(providerCircuitBreakerRoutes, { prefix: "/api/v1/providers/circuit-breaker" });
 }

--- a/backend/src/api/routes/metricsAggregation.routes.ts
+++ b/backend/src/api/routes/metricsAggregation.routes.ts
@@ -1,0 +1,191 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { z } from "zod";
+import { authMiddleware } from "../middleware/auth.js";
+import {
+  metricsAggregationService,
+  type MetricDataPoint,
+  type MetricGranularity,
+} from "../../services/metricsAggregation.service.js";
+
+const granularitySchema = z.enum(["hourly", "daily", "weekly"]);
+
+const ingestBodySchema = z.object({
+  points: z
+    .array(
+      z.object({
+        metricKey: z.string().trim().min(1).max(120),
+        value: z.number(),
+        tags: z.record(z.unknown()).optional(),
+        recordedAt: z.string().datetime().optional(),
+      })
+    )
+    .min(1)
+    .max(1000),
+});
+
+const retentionBodySchema = z.object({
+  retentionDays: z.number().int().positive(),
+});
+
+export async function metricsAggregationRoutes(server: FastifyInstance) {
+  const requireOps = authMiddleware({ requiredScopes: ["admin:config"] });
+
+  server.post<{ Body: { points: MetricDataPoint[] } }>(
+    "/ingest",
+    {
+      schema: {
+        tags: ["Metrics Aggregation"],
+        summary: "Ingest raw metric data points for aggregation",
+        body: { type: "object", additionalProperties: true },
+        response: { 200: { type: "object", additionalProperties: true } },
+      },
+    },
+    async (request: FastifyRequest<{ Body: { points: MetricDataPoint[] } }>, reply: FastifyReply) => {
+      const body = ingestBodySchema.parse(request.body);
+      const count = await metricsAggregationService.ingest(body.points);
+      return reply.send({ ingested: count });
+    }
+  );
+
+  server.get<{ Querystring: { metricKey?: string; granularity: MetricGranularity; from?: string; to?: string; limit?: string } }>(
+    "/",
+    {
+      schema: {
+        tags: ["Metrics Aggregation"],
+        summary: "Query metric rollups by granularity and time range",
+        querystring: {
+          type: "object",
+          required: ["granularity"],
+          properties: {
+            metricKey: { type: "string" },
+            granularity: { type: "string", enum: ["hourly", "daily", "weekly"] },
+            from: { type: "string" },
+            to: { type: "string" },
+            limit: { type: "string" },
+          },
+        },
+        response: { 200: { type: "object", additionalProperties: true } },
+      },
+    },
+    async (request, reply) => {
+      const { metricKey, granularity, from, to, limit } = request.query;
+      const rollups = await metricsAggregationService.getRollups({
+        metricKey,
+        granularity: granularitySchema.parse(granularity),
+        from: from ? new Date(from) : undefined,
+        to: to ? new Date(to) : undefined,
+        limit: limit ? Number(limit) : undefined,
+      });
+      return reply.send({ rollups, count: rollups.length });
+    }
+  );
+
+  server.get<{ Querystring: { metricKey?: string; granularity: MetricGranularity; from?: string; to?: string; format?: "json" | "csv" } }>(
+    "/export",
+    {
+      schema: {
+        tags: ["Metrics Aggregation"],
+        summary: "Export metric rollups as JSON or CSV",
+        querystring: {
+          type: "object",
+          required: ["granularity"],
+          properties: {
+            metricKey: { type: "string" },
+            granularity: { type: "string", enum: ["hourly", "daily", "weekly"] },
+            from: { type: "string" },
+            to: { type: "string" },
+            format: { type: "string", enum: ["json", "csv"] },
+          },
+        },
+      },
+    },
+    async (request, reply) => {
+      const { metricKey, granularity, from, to, format = "json" } = request.query;
+      const exported = await metricsAggregationService.exportRollups(
+        {
+          metricKey,
+          granularity: granularitySchema.parse(granularity),
+          from: from ? new Date(from) : undefined,
+          to: to ? new Date(to) : undefined,
+        },
+        format
+      );
+
+      reply.header(
+        "Content-Type",
+        format === "csv" ? "text/csv" : "application/json"
+      );
+      return reply.send(exported);
+    }
+  );
+
+  server.get(
+    "/retention-policies",
+    {
+      schema: {
+        tags: ["Metrics Aggregation"],
+        summary: "List metric retention policies by granularity",
+        response: { 200: { type: "object", additionalProperties: true } },
+      },
+    },
+    async (_request, reply) => {
+      const policies = await metricsAggregationService.listRetentionPolicies();
+      return reply.send({ policies });
+    }
+  );
+
+  server.put<{ Params: { granularity: string }; Body: { retentionDays: number } }>(
+    "/retention-policies/:granularity",
+    {
+      preHandler: requireOps,
+      schema: {
+        tags: ["Metrics Aggregation"],
+        summary: "Update the retention window for a granularity level",
+        params: {
+          type: "object",
+          required: ["granularity"],
+          properties: { granularity: { type: "string" } },
+        },
+        body: {
+          type: "object",
+          required: ["retentionDays"],
+          properties: { retentionDays: { type: "integer" } },
+        },
+        response: { 200: { type: "object", additionalProperties: true } },
+      },
+    },
+    async (request, reply) => {
+      const body = retentionBodySchema.parse(request.body);
+      const policy = await metricsAggregationService.setRetentionPolicy(
+        request.params.granularity,
+        body.retentionDays
+      );
+      return reply.send({ policy });
+    }
+  );
+
+  server.post<{ Body: { granularity?: MetricGranularity } }>(
+    "/run",
+    {
+      preHandler: requireOps,
+      schema: {
+        tags: ["Metrics Aggregation"],
+        summary: "Manually trigger a rollup run (all granularities if none specified)",
+        body: {
+          type: "object",
+          properties: { granularity: { type: "string", enum: ["hourly", "daily", "weekly"] } },
+        },
+        response: { 200: { type: "object", additionalProperties: true } },
+      },
+    },
+    async (request, reply) => {
+      const granularity = request.body?.granularity;
+      if (granularity) {
+        const windows = await metricsAggregationService.runRollup(granularitySchema.parse(granularity));
+        return reply.send({ granularity, windows });
+      }
+      const results = await metricsAggregationService.runAllRollups();
+      return reply.send({ results });
+    }
+  );
+}

--- a/backend/src/api/routes/providerCircuitBreaker.routes.ts
+++ b/backend/src/api/routes/providerCircuitBreaker.routes.ts
@@ -1,0 +1,159 @@
+import type { FastifyInstance } from "fastify";
+import { z } from "zod";
+import { authMiddleware } from "../middleware/auth.js";
+import { providerCircuitBreakerService } from "../../services/providerCircuitBreaker.service.js";
+
+const overrideBodySchema = z.object({
+  override: z.enum(["force_open", "force_closed"]).nullable(),
+});
+
+const fallbackBodySchema = z.object({
+  fallbackProviderKey: z.string().trim().min(1).max(120).nullable(),
+});
+
+const thresholdsBodySchema = z.object({
+  failureThreshold: z.number().int().positive().optional(),
+  recoveryTimeoutMs: z.number().int().positive().optional(),
+});
+
+export async function providerCircuitBreakerRoutes(server: FastifyInstance) {
+  const requireOps = authMiddleware({ requiredScopes: ["admin:config"] });
+
+  server.get(
+    "/",
+    {
+      schema: {
+        tags: ["Provider Circuit Breaker"],
+        summary: "List circuit breaker state for all tracked providers",
+        response: { 200: { type: "object", additionalProperties: true } },
+      },
+    },
+    async (_request, reply) => {
+      const breakers = await providerCircuitBreakerService.listStates();
+      return reply.send({ breakers, count: breakers.length });
+    }
+  );
+
+  server.get<{ Params: { providerKey: string } }>(
+    "/:providerKey",
+    {
+      schema: {
+        tags: ["Provider Circuit Breaker"],
+        summary: "Get circuit breaker state for a provider",
+        params: { type: "object", required: ["providerKey"], properties: { providerKey: { type: "string" } } },
+        response: { 200: { type: "object", additionalProperties: true } },
+      },
+    },
+    async (request, reply) => {
+      const breaker = await providerCircuitBreakerService.getState(request.params.providerKey);
+      return reply.send({ breaker });
+    }
+  );
+
+  server.get<{ Params: { providerKey: string }; Querystring: { limit?: string } }>(
+    "/:providerKey/history",
+    {
+      schema: {
+        tags: ["Provider Circuit Breaker"],
+        summary: "Get state transition history for a provider's circuit breaker",
+        params: { type: "object", required: ["providerKey"], properties: { providerKey: { type: "string" } } },
+        querystring: { type: "object", properties: { limit: { type: "string" } } },
+        response: { 200: { type: "object", additionalProperties: true } },
+      },
+    },
+    async (request, reply) => {
+      const history = await providerCircuitBreakerService.getTransitionHistory(
+        request.params.providerKey,
+        request.query.limit ? Number(request.query.limit) : undefined
+      );
+      return reply.send({ history });
+    }
+  );
+
+  server.get<{ Params: { providerKey: string } }>(
+    "/:providerKey/fallback",
+    {
+      schema: {
+        tags: ["Provider Circuit Breaker"],
+        summary: "Resolve the fallback provider to use if this provider's breaker is open",
+        params: { type: "object", required: ["providerKey"], properties: { providerKey: { type: "string" } } },
+        response: { 200: { type: "object", additionalProperties: true } },
+      },
+    },
+    async (request, reply) => {
+      const [available, fallbackProviderKey] = await Promise.all([
+        providerCircuitBreakerService.isAvailable(request.params.providerKey),
+        providerCircuitBreakerService.getFallbackProvider(request.params.providerKey),
+      ]);
+      return reply.send({ providerKey: request.params.providerKey, available, fallbackProviderKey });
+    }
+  );
+
+  server.put<{ Params: { providerKey: string }; Body: { fallbackProviderKey: string | null } }>(
+    "/:providerKey/fallback",
+    {
+      preHandler: requireOps,
+      schema: {
+        tags: ["Provider Circuit Breaker"],
+        summary: "Configure the fallback provider used when this provider's breaker is open",
+        params: { type: "object", required: ["providerKey"], properties: { providerKey: { type: "string" } } },
+        body: { type: "object", required: ["fallbackProviderKey"], properties: { fallbackProviderKey: { type: "string", nullable: true } } },
+        response: { 200: { type: "object", additionalProperties: true } },
+      },
+    },
+    async (request, reply) => {
+      const body = fallbackBodySchema.parse(request.body);
+      const breaker = await providerCircuitBreakerService.setFallback(
+        request.params.providerKey,
+        body.fallbackProviderKey,
+        request.apiKeyAuth?.id ?? request.apiKeyAuth?.name ?? "admin"
+      );
+      return reply.send({ breaker });
+    }
+  );
+
+  server.put<{ Params: { providerKey: string }; Body: { override: "force_open" | "force_closed" | null } }>(
+    "/:providerKey/override",
+    {
+      preHandler: requireOps,
+      schema: {
+        tags: ["Provider Circuit Breaker"],
+        summary: "Manually force a provider's circuit breaker open or closed (null clears the override)",
+        params: { type: "object", required: ["providerKey"], properties: { providerKey: { type: "string" } } },
+        body: { type: "object", required: ["override"], properties: { override: { type: "string", nullable: true } } },
+        response: { 200: { type: "object", additionalProperties: true } },
+      },
+    },
+    async (request, reply) => {
+      const body = overrideBodySchema.parse(request.body);
+      const breaker = await providerCircuitBreakerService.setManualOverride(
+        request.params.providerKey,
+        body.override,
+        request.apiKeyAuth?.id ?? request.apiKeyAuth?.name ?? "admin"
+      );
+      return reply.send({ breaker });
+    }
+  );
+
+  server.put<{ Params: { providerKey: string }; Body: { failureThreshold?: number; recoveryTimeoutMs?: number } }>(
+    "/:providerKey/thresholds",
+    {
+      preHandler: requireOps,
+      schema: {
+        tags: ["Provider Circuit Breaker"],
+        summary: "Configure failure threshold and recovery timeout for a provider",
+        params: { type: "object", required: ["providerKey"], properties: { providerKey: { type: "string" } } },
+        body: {
+          type: "object",
+          properties: { failureThreshold: { type: "integer" }, recoveryTimeoutMs: { type: "integer" } },
+        },
+        response: { 200: { type: "object", additionalProperties: true } },
+      },
+    },
+    async (request, reply) => {
+      const body = thresholdsBodySchema.parse(request.body);
+      const breaker = await providerCircuitBreakerService.configureThresholds(request.params.providerKey, body);
+      return reply.send({ breaker });
+    }
+  );
+}

--- a/backend/src/api/routes/sourceDecommission.routes.ts
+++ b/backend/src/api/routes/sourceDecommission.routes.ts
@@ -1,0 +1,183 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { z } from "zod";
+import { authMiddleware } from "../middleware/auth.js";
+import { sourceDecommissionService } from "../../services/sourceDecommission.service.js";
+
+const sourceKeySchema = z.string().trim().min(1).max(120);
+
+const startBodySchema = z.object({
+  sourceKey: sourceKeySchema,
+  replacementSourceKey: sourceKeySchema,
+  deprecationPeriodDays: z.number().int().positive().max(3650).optional(),
+  reason: z.string().trim().max(500).optional(),
+});
+
+const progressBodySchema = z.object({
+  progressPct: z.number().min(0).max(100),
+});
+
+const rollbackBodySchema = z.object({
+  reason: z.string().trim().max(500).optional(),
+});
+
+export async function sourceDecommissionRoutes(server: FastifyInstance) {
+  const requireOps = authMiddleware({ requiredScopes: ["admin:config"] });
+
+  server.get(
+    "/",
+    {
+      schema: {
+        tags: ["Source Decommission"],
+        summary: "List all source decommission flows",
+        response: { 200: { type: "object", additionalProperties: true } },
+      },
+    },
+    async (_request, reply) => {
+      const decommissions = await sourceDecommissionService.listDecommissions();
+      return reply.send({ decommissions });
+    }
+  );
+
+  server.get<{ Params: { sourceKey: string } }>(
+    "/:sourceKey",
+    {
+      schema: {
+        tags: ["Source Decommission"],
+        summary: "Get decommission status for a source",
+        params: { type: "object", required: ["sourceKey"], properties: { sourceKey: { type: "string" } } },
+        response: { 200: { type: "object", additionalProperties: true }, 404: { $ref: "Error#" } },
+      },
+    },
+    async (request, reply) => {
+      const decommission = await sourceDecommissionService.getStatus(request.params.sourceKey);
+      if (!decommission) {
+        return reply.code(404).send({ error: "No decommission found for source" });
+      }
+      return reply.send({ decommission });
+    }
+  );
+
+  server.get<{ Params: { sourceKey: string } }>(
+    "/:sourceKey/fallback",
+    {
+      schema: {
+        tags: ["Source Decommission"],
+        summary: "Resolve the active fallback source for a decommissioned source, if any",
+        params: { type: "object", required: ["sourceKey"], properties: { sourceKey: { type: "string" } } },
+        response: { 200: { type: "object", additionalProperties: true } },
+      },
+    },
+    async (request, reply) => {
+      const fallbackSourceKey = await sourceDecommissionService.getFallbackSource(request.params.sourceKey);
+      return reply.send({ sourceKey: request.params.sourceKey, fallbackSourceKey });
+    }
+  );
+
+  server.post(
+    "/",
+    {
+      preHandler: requireOps,
+      schema: {
+        tags: ["Source Decommission"],
+        summary: "Start a decommission flow for a data source",
+        body: { type: "object", additionalProperties: true },
+        response: { 201: { type: "object", additionalProperties: true } },
+      },
+    },
+    async (request: FastifyRequest<{ Body: unknown }>, reply: FastifyReply) => {
+      const body = startBodySchema.parse(request.body);
+      const decommission = await sourceDecommissionService.startDecommission({
+        ...body,
+        actorId: request.apiKeyAuth?.id ?? request.apiKeyAuth?.name ?? "admin",
+      });
+      return reply.code(201).send({ decommission });
+    }
+  );
+
+  server.put<{ Params: { sourceKey: string }; Body: { progressPct: number } }>(
+    "/:sourceKey/progress",
+    {
+      preHandler: requireOps,
+      schema: {
+        tags: ["Source Decommission"],
+        summary: "Update data migration progress for a decommission flow",
+        params: { type: "object", required: ["sourceKey"], properties: { sourceKey: { type: "string" } } },
+        body: { type: "object", required: ["progressPct"], properties: { progressPct: { type: "number" } } },
+        response: { 200: { type: "object", additionalProperties: true } },
+      },
+    },
+    async (request, reply) => {
+      const body = progressBodySchema.parse(request.body);
+      const decommission = await sourceDecommissionService.updateMigrationProgress(
+        request.params.sourceKey,
+        body.progressPct,
+        request.apiKeyAuth?.id ?? request.apiKeyAuth?.name ?? "admin"
+      );
+      return reply.send({ decommission });
+    }
+  );
+
+  server.get<{ Params: { sourceKey: string } }>(
+    "/:sourceKey/completion-check",
+    {
+      preHandler: requireOps,
+      schema: {
+        tags: ["Source Decommission"],
+        summary: "Check whether a decommission is eligible to be completed",
+        params: { type: "object", required: ["sourceKey"], properties: { sourceKey: { type: "string" } } },
+        response: { 200: { type: "object", additionalProperties: true } },
+      },
+    },
+    async (request, reply) => {
+      const check = await sourceDecommissionService.checkCompletion(request.params.sourceKey);
+      return reply.send(check);
+    }
+  );
+
+  server.post<{ Params: { sourceKey: string } }>(
+    "/:sourceKey/complete",
+    {
+      preHandler: requireOps,
+      schema: {
+        tags: ["Source Decommission"],
+        summary: "Finalize a decommission after verifying completion criteria",
+        params: { type: "object", required: ["sourceKey"], properties: { sourceKey: { type: "string" } } },
+        response: { 200: { type: "object", additionalProperties: true }, 400: { $ref: "Error#" } },
+      },
+    },
+    async (request, reply) => {
+      try {
+        const decommission = await sourceDecommissionService.completeDecommission(
+          request.params.sourceKey,
+          request.apiKeyAuth?.id ?? request.apiKeyAuth?.name ?? "admin"
+        );
+        return reply.send({ decommission });
+      } catch (error) {
+        return reply.code(400).send({ error: error instanceof Error ? error.message : "Completion check failed" });
+      }
+    }
+  );
+
+  server.post<{ Params: { sourceKey: string }; Body: { reason?: string } }>(
+    "/:sourceKey/rollback",
+    {
+      preHandler: requireOps,
+      schema: {
+        tags: ["Source Decommission"],
+        summary: "Roll back a decommission flow and disable fallback routing",
+        params: { type: "object", required: ["sourceKey"], properties: { sourceKey: { type: "string" } } },
+        body: { type: "object", properties: { reason: { type: "string" } } },
+        response: { 200: { type: "object", additionalProperties: true } },
+      },
+    },
+    async (request, reply) => {
+      const body = rollbackBodySchema.parse(request.body ?? {});
+      const decommission = await sourceDecommissionService.rollbackDecommission(
+        request.params.sourceKey,
+        request.apiKeyAuth?.id ?? request.apiKeyAuth?.name ?? "admin",
+        body.reason
+      );
+      return reply.send({ decommission });
+    }
+  );
+}

--- a/backend/src/database/migrations/038_metrics_aggregation_pipeline.ts
+++ b/backend/src/database/migrations/038_metrics_aggregation_pipeline.ts
@@ -1,0 +1,57 @@
+import type { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable("metric_data_points", (table) => {
+    table.uuid("id").primary().defaultTo(knex.raw("gen_random_uuid()"));
+    table.string("metric_key", 120).notNullable();
+    table.decimal("value", 20, 6).notNullable();
+    table.jsonb("tags").notNullable().defaultTo("{}");
+    table.timestamp("recorded_at", { useTz: true }).notNullable().defaultTo(knex.fn.now());
+    table.timestamp("created_at", { useTz: true }).notNullable().defaultTo(knex.fn.now());
+    table.index(["metric_key", "recorded_at"], "idx_metric_points_key_time");
+    table.index(["recorded_at"], "idx_metric_points_recorded_at");
+  });
+
+  await knex.schema.createTable("metric_rollups", (table) => {
+    table.uuid("id").primary().defaultTo(knex.raw("gen_random_uuid()"));
+    table.string("metric_key", 120).notNullable();
+    table.string("granularity", 20).notNullable();
+    table.timestamp("window_start", { useTz: true }).notNullable();
+    table.timestamp("window_end", { useTz: true }).notNullable();
+    table.integer("sample_count").notNullable().defaultTo(0);
+    table.decimal("sum_value", 24, 6).notNullable().defaultTo(0);
+    table.decimal("min_value", 20, 6).notNullable().defaultTo(0);
+    table.decimal("max_value", 20, 6).notNullable().defaultTo(0);
+    table.decimal("avg_value", 20, 6).notNullable().defaultTo(0);
+    table.decimal("p50_value", 20, 6).notNullable().defaultTo(0);
+    table.decimal("p95_value", 20, 6).notNullable().defaultTo(0);
+    table.decimal("p99_value", 20, 6).notNullable().defaultTo(0);
+    table.jsonb("tags").notNullable().defaultTo("{}");
+    table.timestamp("created_at", { useTz: true }).notNullable().defaultTo(knex.fn.now());
+    table.unique(["metric_key", "granularity", "window_start"], { indexName: "uniq_metric_rollup_window" });
+    table.index(["metric_key", "granularity", "window_start"], "idx_metric_rollups_query");
+    table.index(["granularity", "window_start"], "idx_metric_rollups_granularity_time");
+  });
+
+  await knex.schema.createTable("metric_retention_policies", (table) => {
+    table.string("granularity", 20).primary();
+    table.integer("retention_days").notNullable();
+    table.timestamp("updated_at", { useTz: true }).notNullable().defaultTo(knex.fn.now());
+  });
+
+  await knex("metric_retention_policies")
+    .insert([
+      { granularity: "raw", retention_days: 7 },
+      { granularity: "hourly", retention_days: 90 },
+      { granularity: "daily", retention_days: 365 },
+      { granularity: "weekly", retention_days: 1825 },
+    ])
+    .onConflict("granularity")
+    .ignore();
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists("metric_retention_policies");
+  await knex.schema.dropTableIfExists("metric_rollups");
+  await knex.schema.dropTableIfExists("metric_data_points");
+}

--- a/backend/src/database/migrations/039_event_replay_service.ts
+++ b/backend/src/database/migrations/039_event_replay_service.ts
@@ -1,0 +1,25 @@
+import type { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable("event_replay_runs", (table) => {
+    table.uuid("id").primary().defaultTo(knex.raw("gen_random_uuid()"));
+    table.string("requested_by", 120).notNullable();
+    table.jsonb("filter").notNullable().defaultTo("{}");
+    table.boolean("dry_run").notNullable().defaultTo(true);
+    table.string("reason", 500).nullable();
+    table.string("status", 20).notNullable().defaultTo("pending");
+    table.integer("total_matched").notNullable().defaultTo(0);
+    table.integer("total_replayed").notNullable().defaultTo(0);
+    table.integer("total_skipped").notNullable().defaultTo(0);
+    table.text("error_message").nullable();
+    table.timestamp("started_at", { useTz: true }).notNullable().defaultTo(knex.fn.now());
+    table.timestamp("completed_at", { useTz: true }).nullable();
+    table.timestamp("created_at", { useTz: true }).notNullable().defaultTo(knex.fn.now());
+    table.index(["status"], "idx_event_replay_runs_status");
+    table.index(["created_at"], "idx_event_replay_runs_created_at");
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists("event_replay_runs");
+}

--- a/backend/src/database/migrations/040_source_decommission_flow.ts
+++ b/backend/src/database/migrations/040_source_decommission_flow.ts
@@ -1,0 +1,26 @@
+import type { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable("source_decommissions", (table) => {
+    table.uuid("id").primary().defaultTo(knex.raw("gen_random_uuid()"));
+    table.string("source_key", 120).notNullable().unique();
+    table.string("replacement_source_key", 120).notNullable();
+    table.string("status", 20).notNullable().defaultTo("deprecated");
+    table.integer("deprecation_period_days").notNullable().defaultTo(30);
+    table.timestamp("deprecation_started_at", { useTz: true }).notNullable().defaultTo(knex.fn.now());
+    table.timestamp("deprecation_ends_at", { useTz: true }).notNullable();
+    table.boolean("fallback_routing_enabled").notNullable().defaultTo(true);
+    table.decimal("migration_progress_pct", 5, 2).notNullable().defaultTo(0);
+    table.boolean("completion_ready").notNullable().defaultTo(false);
+    table.timestamp("completion_verified_at", { useTz: true }).nullable();
+    table.string("created_by", 120).notNullable();
+    table.text("reason").nullable();
+    table.timestamps(true, true);
+    table.index(["status"], "idx_source_decommissions_status");
+    table.index(["deprecation_ends_at"], "idx_source_decommissions_ends_at");
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists("source_decommissions");
+}

--- a/backend/src/database/migrations/041_provider_circuit_breaker.ts
+++ b/backend/src/database/migrations/041_provider_circuit_breaker.ts
@@ -1,0 +1,35 @@
+import type { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable("provider_circuit_breaker_state", (table) => {
+    table.string("provider_key", 120).primary();
+    table.string("state", 20).notNullable().defaultTo("closed");
+    table.integer("consecutive_failures").notNullable().defaultTo(0);
+    table.integer("failure_threshold").notNullable().defaultTo(5);
+    table.integer("recovery_timeout_ms").notNullable().defaultTo(60_000);
+    table.integer("trip_count").notNullable().defaultTo(0);
+    table.string("fallback_provider_key", 120).nullable();
+    table.string("manual_override", 20).nullable();
+    table.timestamp("opened_at", { useTz: true }).nullable();
+    table.timestamp("half_opened_at", { useTz: true }).nullable();
+    table.timestamp("last_failure_at", { useTz: true }).nullable();
+    table.timestamp("last_success_at", { useTz: true }).nullable();
+    table.timestamps(true, true);
+    table.index(["state"], "idx_provider_breaker_state");
+  });
+
+  await knex.schema.createTable("provider_circuit_breaker_transitions", (table) => {
+    table.uuid("id").primary().defaultTo(knex.raw("gen_random_uuid()"));
+    table.string("provider_key", 120).notNullable();
+    table.string("from_state", 20).notNullable();
+    table.string("to_state", 20).notNullable();
+    table.string("reason", 255).notNullable();
+    table.timestamp("created_at", { useTz: true }).notNullable().defaultTo(knex.fn.now());
+    table.index(["provider_key", "created_at"], "idx_provider_breaker_transitions_key_time");
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists("provider_circuit_breaker_transitions");
+  await knex.schema.dropTableIfExists("provider_circuit_breaker_state");
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -12,6 +12,8 @@ import { registerMetrics } from "./api/middleware/metrics.js";
 import { registerUsageMetrics } from "./api/middleware/usageMetrics.js";
 import { startBridgeVerificationJob } from "./jobs/verification.job.js";
 import { startBatchReconciliationJob, stopBatchReconciliationJob } from "./jobs/batchReconciliation.job.js";
+import { startSourceDecommissionJob, stopSourceDecommissionJob } from "./jobs/sourceDecommission.job.js";
+import { startProviderCircuitBreakerJob, stopProviderCircuitBreakerJob } from "./jobs/providerCircuitBreaker.job.js";
 import { wsServer } from "./api/websocket/websocket.server.js";
 import {
   registerRateLimiting,
@@ -231,6 +233,14 @@ async function start() {
     // Start batch reconciliation job
     startBatchReconciliationJob();
     server.log.info("Batch reconciliation job started");
+
+    // Start source decommission readiness checks
+    startSourceDecommissionJob();
+    server.log.info("Source decommission readiness job started");
+
+    // Start provider circuit breaker recovery probe sweep
+    startProviderCircuitBreakerJob();
+    server.log.info("Provider circuit breaker job started");
   } catch (err) {
     server.log.error(err);
     process.exit(1);
@@ -255,6 +265,8 @@ async function start() {
     await getSupplyVerificationQueue().stop();
     await stopWebhookWorker();
     stopBatchReconciliationJob();
+    stopSourceDecommissionJob();
+    stopProviderCircuitBreakerJob();
     logger.info("Server closed");
     process.exit(0);
   };

--- a/backend/src/jobs/providerCircuitBreaker.job.ts
+++ b/backend/src/jobs/providerCircuitBreaker.job.ts
@@ -1,0 +1,37 @@
+import { providerCircuitBreakerService } from "../services/providerCircuitBreaker.service.js";
+import { logger } from "../utils/logger.js";
+
+const PROBE_SWEEP_INTERVAL_MS = Number(process.env.PROVIDER_BREAKER_PROBE_INTERVAL_MS) || 30_000; // 30s default
+
+let probeSweepInterval: NodeJS.Timeout | null = null;
+
+export async function runRecoveryProbeSweep(): Promise<number> {
+  try {
+    const probed = await providerCircuitBreakerService.runRecoveryProbeSweep();
+    if (probed > 0) {
+      logger.info({ probed }, "Provider circuit breaker recovery probe sweep transitioned breakers to half-open");
+    }
+    return probed;
+  } catch (err) {
+    logger.error({ error: err }, "Provider circuit breaker recovery probe sweep failed");
+    return 0;
+  }
+}
+
+export function startProviderCircuitBreakerJob(): void {
+  logger.info({ intervalMs: PROBE_SWEEP_INTERVAL_MS }, "Starting provider circuit breaker recovery probe job");
+
+  probeSweepInterval = setInterval(() => {
+    runRecoveryProbeSweep().catch((err) => {
+      logger.error({ error: err }, "Scheduled provider circuit breaker probe sweep failed");
+    });
+  }, PROBE_SWEEP_INTERVAL_MS);
+}
+
+export function stopProviderCircuitBreakerJob(): void {
+  if (probeSweepInterval) {
+    clearInterval(probeSweepInterval);
+    probeSweepInterval = null;
+    logger.info("Stopped provider circuit breaker recovery probe job");
+  }
+}

--- a/backend/src/jobs/sourceDecommission.job.ts
+++ b/backend/src/jobs/sourceDecommission.job.ts
@@ -1,0 +1,41 @@
+import { sourceDecommissionService } from "../services/sourceDecommission.service.js";
+import { logger } from "../utils/logger.js";
+
+const CHECK_INTERVAL_MS = Number(process.env.SOURCE_DECOMMISSION_CHECK_INTERVAL_MS) || 3_600_000; // 1 hour default
+
+let decommissionCheckInterval: NodeJS.Timeout | null = null;
+
+export async function runSourceDecommissionCheck(): Promise<number> {
+  try {
+    const updated = await sourceDecommissionService.refreshCompletionReadiness();
+    if (updated > 0) {
+      logger.info({ updated }, "Source decommission readiness check flagged sources ready to complete");
+    }
+    return updated;
+  } catch (err) {
+    logger.error({ error: err }, "Source decommission readiness check failed");
+    return 0;
+  }
+}
+
+export function startSourceDecommissionJob(): void {
+  logger.info({ intervalMs: CHECK_INTERVAL_MS }, "Starting source decommission readiness job scheduler");
+
+  runSourceDecommissionCheck().catch((err) => {
+    logger.error({ error: err }, "Initial source decommission readiness check failed");
+  });
+
+  decommissionCheckInterval = setInterval(() => {
+    runSourceDecommissionCheck().catch((err) => {
+      logger.error({ error: err }, "Scheduled source decommission readiness check failed");
+    });
+  }, CHECK_INTERVAL_MS);
+}
+
+export function stopSourceDecommissionJob(): void {
+  if (decommissionCheckInterval) {
+    clearInterval(decommissionCheckInterval);
+    decommissionCheckInterval = null;
+    logger.info("Stopped source decommission readiness job scheduler");
+  }
+}

--- a/backend/src/services/audit.service.ts
+++ b/backend/src/services/audit.service.ts
@@ -31,7 +31,15 @@ export type AuditAction =
   | "tag.updated"
   | "tag.deleted"
   | "tag.assigned"
-  | "tag.unassigned";
+  | "tag.unassigned"
+  | "event.replay_executed"
+  | "source.decommission_started"
+  | "source.decommission_progress_updated"
+  | "source.decommission_completed"
+  | "source.decommission_rolled_back"
+  | "provider.circuit_breaker_tripped"
+  | "provider.circuit_breaker_recovered"
+  | "provider.circuit_breaker_override";
 
 export type AuditSeverity = "info" | "warning" | "critical";
 
@@ -334,10 +342,14 @@ export class AuditService {
       action === "auth.api_key_revoked" ||
       action === "webhook.secret_rotated" ||
       action === "admin.config_changed" ||
-      action === "admin.provider_allowlist_changed"
+      action === "admin.provider_allowlist_changed" ||
+      action === "event.replay_executed" ||
+      action === "source.decommission_started" ||
+      action === "source.decommission_rolled_back" ||
+      action === "provider.circuit_breaker_override"
     ) return "warning";
 
-    if (action === "admin.retention_policy_changed") return "critical";
+    if (action === "admin.retention_policy_changed" || action === "source.decommission_completed") return "critical";
 
     return "info";
   }

--- a/backend/src/services/eventReplay.service.ts
+++ b/backend/src/services/eventReplay.service.ts
@@ -1,0 +1,205 @@
+import { getDatabase } from "../database/connection.js";
+import { OutboxProducer, type OutboxEventType } from "../outbox/eventProducer.js";
+import { auditService } from "./audit.service.js";
+import { logger } from "../utils/logger.js";
+
+export type ReplayableEventStatus = "delivered" | "failed";
+
+export interface EventReplayFilter {
+  aggregateType?: string;
+  aggregateId?: string;
+  eventType?: string;
+  status?: ReplayableEventStatus;
+  from?: Date;
+  to?: Date;
+  limit?: number;
+}
+
+export interface EventReplayRun {
+  id: string;
+  requestedBy: string;
+  filter: EventReplayFilter;
+  dryRun: boolean;
+  reason: string | null;
+  status: "pending" | "running" | "completed" | "failed";
+  totalMatched: number;
+  totalReplayed: number;
+  totalSkipped: number;
+  errorMessage: string | null;
+  startedAt: string;
+  completedAt: string | null;
+  createdAt: string;
+}
+
+export interface ExecuteReplayInput {
+  filter: EventReplayFilter;
+  dryRun: boolean;
+  requestedBy: string;
+  reason?: string;
+  confirm?: boolean;
+}
+
+// Safety guards: replays are capped, and only terminal events (already delivered
+// or failed) can be replayed so we never duplicate in-flight processing.
+const MAX_REPLAY_BATCH = 500;
+const REPLAYABLE_STATUSES: ReplayableEventStatus[] = ["delivered", "failed"];
+
+export class EventReplayService {
+  private db = getDatabase();
+  private producer = new OutboxProducer(this.db);
+
+  async previewReplay(filter: EventReplayFilter): Promise<{ totalMatched: number; sample: Record<string, unknown>[] }> {
+    const query = this.buildFilterQuery(filter);
+    const totalMatched = Number((await query.clone().count("id as count").first())?.count ?? 0);
+    const sample = await query.clone().orderBy("created_at", "desc").limit(10);
+    return { totalMatched, sample };
+  }
+
+  async executeReplay(input: ExecuteReplayInput): Promise<EventReplayRun> {
+    const limit = Math.min(input.filter.limit ?? MAX_REPLAY_BATCH, MAX_REPLAY_BATCH);
+
+    if (!input.dryRun && !input.confirm) {
+      throw new Error("Replaying events requires confirm=true as an explicit safety guard");
+    }
+
+    const [run] = await this.db("event_replay_runs")
+      .insert({
+        requested_by: input.requestedBy,
+        filter: JSON.stringify(input.filter),
+        dry_run: input.dryRun,
+        reason: input.reason ?? null,
+        status: "running",
+      })
+      .returning("*");
+
+    let runRecord = this.mapRun(run);
+
+    try {
+      const events = await this.buildFilterQuery(input.filter)
+        .orderBy([
+          { column: "aggregate_type", order: "asc" },
+          { column: "aggregate_id", order: "asc" },
+          { column: "sequence_no", order: "asc" },
+        ])
+        .limit(limit);
+
+      let replayed = 0;
+      let skipped = 0;
+
+      if (!input.dryRun) {
+        for (const event of events) {
+          try {
+            await this.producer.publish({
+              aggregateType: event.aggregate_type,
+              aggregateId: event.aggregate_id,
+              eventType: event.event_type as OutboxEventType,
+              payload: typeof event.payload === "string" ? JSON.parse(event.payload) : event.payload,
+              metadata: {
+                replay: true,
+                replayRunId: runRecord.id,
+                originalEventId: String(event.id),
+                replayReason: input.reason ?? null,
+              },
+            });
+            replayed++;
+          } catch (err) {
+            skipped++;
+            logger.error({ err, eventId: event.id }, "Failed to republish event during replay");
+          }
+        }
+      }
+
+      const [updated] = await this.db("event_replay_runs")
+        .where({ id: runRecord.id })
+        .update({
+          status: "completed",
+          total_matched: events.length,
+          total_replayed: replayed,
+          total_skipped: skipped,
+          completed_at: new Date(),
+        })
+        .returning("*");
+
+      runRecord = this.mapRun(updated);
+
+      await auditService.log({
+        action: "event.replay_executed",
+        actorId: input.requestedBy,
+        actorType: "api_key",
+        resourceType: "outbox_event",
+        resourceId: runRecord.id,
+        metadata: {
+          filter: input.filter,
+          dryRun: input.dryRun,
+          totalMatched: events.length,
+          totalReplayed: replayed,
+          totalSkipped: skipped,
+          reason: input.reason ?? null,
+        },
+      });
+
+      logger.info(
+        { runId: runRecord.id, dryRun: input.dryRun, totalMatched: events.length, replayed, skipped },
+        "Event replay run completed"
+      );
+
+      return runRecord;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const [failed] = await this.db("event_replay_runs")
+        .where({ id: runRecord.id })
+        .update({ status: "failed", error_message: message, completed_at: new Date() })
+        .returning("*");
+
+      logger.error({ runId: runRecord.id, error: message }, "Event replay run failed");
+      return this.mapRun(failed);
+    }
+  }
+
+  async getReplayRun(id: string): Promise<EventReplayRun | null> {
+    const row = await this.db("event_replay_runs").where({ id }).first();
+    return row ? this.mapRun(row) : null;
+  }
+
+  async listReplayRuns(limit = 50): Promise<EventReplayRun[]> {
+    const rows = await this.db("event_replay_runs")
+      .orderBy("created_at", "desc")
+      .limit(Math.min(limit, 200));
+    return rows.map((row) => this.mapRun(row));
+  }
+
+  private buildFilterQuery(filter: EventReplayFilter) {
+    let query = this.db("outbox_events").whereIn("status", REPLAYABLE_STATUSES);
+
+    if (filter.status) query = query.where("status", filter.status);
+    if (filter.aggregateType) query = query.where("aggregate_type", filter.aggregateType);
+    if (filter.aggregateId) query = query.where("aggregate_id", filter.aggregateId);
+    if (filter.eventType) query = query.where("event_type", filter.eventType);
+    if (filter.from) query = query.where("created_at", ">=", filter.from);
+    if (filter.to) query = query.where("created_at", "<=", filter.to);
+
+    return query;
+  }
+
+  private mapRun(row: Record<string, unknown>): EventReplayRun {
+    const filter = typeof row.filter === "string" ? JSON.parse(row.filter) : (row.filter as EventReplayFilter) ?? {};
+
+    return {
+      id: String(row.id),
+      requestedBy: String(row.requested_by),
+      filter,
+      dryRun: Boolean(row.dry_run),
+      reason: row.reason ? String(row.reason) : null,
+      status: row.status as EventReplayRun["status"],
+      totalMatched: Number(row.total_matched ?? 0),
+      totalReplayed: Number(row.total_replayed ?? 0),
+      totalSkipped: Number(row.total_skipped ?? 0),
+      errorMessage: row.error_message ? String(row.error_message) : null,
+      startedAt: new Date(String(row.started_at)).toISOString(),
+      completedAt: row.completed_at ? new Date(String(row.completed_at)).toISOString() : null,
+      createdAt: new Date(String(row.created_at)).toISOString(),
+    };
+  }
+}
+
+export const eventReplayService = new EventReplayService();

--- a/backend/src/services/metricsAggregation.service.ts
+++ b/backend/src/services/metricsAggregation.service.ts
@@ -1,0 +1,346 @@
+import { getDatabase } from "../database/connection.js";
+import { logger } from "../utils/logger.js";
+
+export type MetricGranularity = "hourly" | "daily" | "weekly";
+
+const GRANULARITY_ORDER: MetricGranularity[] = ["hourly", "daily", "weekly"];
+
+const GRANULARITY_CONFIG: Record<
+  MetricGranularity,
+  { truncUnit: "hour" | "day" | "week"; sourceGranularity: "raw" | MetricGranularity }
+> = {
+  hourly: { truncUnit: "hour", sourceGranularity: "raw" },
+  daily: { truncUnit: "day", sourceGranularity: "hourly" },
+  weekly: { truncUnit: "week", sourceGranularity: "daily" },
+};
+
+export interface MetricDataPoint {
+  metricKey: string;
+  value: number;
+  tags?: Record<string, unknown>;
+  recordedAt?: string;
+}
+
+export interface MetricRollup {
+  id: string;
+  metricKey: string;
+  granularity: MetricGranularity;
+  windowStart: string;
+  windowEnd: string;
+  sampleCount: number;
+  sumValue: number;
+  minValue: number;
+  maxValue: number;
+  avgValue: number;
+  p50Value: number;
+  p95Value: number;
+  p99Value: number;
+  tags: Record<string, unknown>;
+  createdAt: string;
+}
+
+export interface RollupQuery {
+  metricKey?: string;
+  granularity: MetricGranularity;
+  from?: Date;
+  to?: Date;
+  limit?: number;
+}
+
+export interface RetentionPolicy {
+  granularity: "raw" | MetricGranularity;
+  retentionDays: number;
+  updatedAt: string;
+}
+
+const MAX_INGEST_BATCH = 1000;
+const MAX_QUERY_LIMIT = 5000;
+
+export class MetricsAggregationService {
+  private db = getDatabase();
+
+  async ingest(points: MetricDataPoint[]): Promise<number> {
+    if (points.length === 0) return 0;
+    if (points.length > MAX_INGEST_BATCH) {
+      throw new Error(`Cannot ingest more than ${MAX_INGEST_BATCH} points per request`);
+    }
+
+    const rows = points.map((p) => ({
+      metric_key: p.metricKey,
+      value: p.value,
+      tags: JSON.stringify(p.tags ?? {}),
+      recorded_at: p.recordedAt ? new Date(p.recordedAt) : new Date(),
+    }));
+
+    await this.db("metric_data_points").insert(rows);
+    logger.info({ count: rows.length }, "Ingested raw metric data points");
+    return rows.length;
+  }
+
+  /**
+   * Rolls up the given granularity from its source (raw data for "hourly",
+   * the previous granularity's rollups for "daily"/"weekly"). Only windows
+   * that have fully elapsed are rolled up, and rows are upserted so reruns
+   * are idempotent.
+   */
+  async runRollup(granularity: MetricGranularity): Promise<number> {
+    const { truncUnit, sourceGranularity } = GRANULARITY_CONFIG[granularity];
+
+    const groups =
+      sourceGranularity === "raw"
+        ? await this.aggregateFromRaw(truncUnit)
+        : await this.aggregateFromRollups(sourceGranularity, truncUnit);
+
+    if (groups.length === 0) return 0;
+
+    for (const group of groups) {
+      await this.db("metric_rollups")
+        .insert({
+          metric_key: group.metricKey,
+          granularity,
+          window_start: group.windowStart,
+          window_end: group.windowEnd,
+          sample_count: group.sampleCount,
+          sum_value: group.sumValue,
+          min_value: group.minValue,
+          max_value: group.maxValue,
+          avg_value: group.avgValue,
+          p50_value: group.p50Value,
+          p95_value: group.p95Value,
+          p99_value: group.p99Value,
+          tags: JSON.stringify({}),
+        })
+        .onConflict(["metric_key", "granularity", "window_start"])
+        .merge({
+          window_end: group.windowEnd,
+          sample_count: group.sampleCount,
+          sum_value: group.sumValue,
+          min_value: group.minValue,
+          max_value: group.maxValue,
+          avg_value: group.avgValue,
+          p50_value: group.p50Value,
+          p95_value: group.p95Value,
+          p99_value: group.p99Value,
+        });
+    }
+
+    logger.info({ granularity, windows: groups.length }, "Metrics rollup completed");
+    return groups.length;
+  }
+
+  async runAllRollups(): Promise<Record<MetricGranularity, number>> {
+    const results: Record<MetricGranularity, number> = { hourly: 0, daily: 0, weekly: 0 };
+    for (const granularity of GRANULARITY_ORDER) {
+      results[granularity] = await this.runRollup(granularity);
+    }
+    return results;
+  }
+
+  async getRollups(query: RollupQuery): Promise<MetricRollup[]> {
+    const limit = Math.min(query.limit ?? 100, MAX_QUERY_LIMIT);
+
+    let q = this.db("metric_rollups").where("granularity", query.granularity);
+    if (query.metricKey) q = q.where("metric_key", query.metricKey);
+    if (query.from) q = q.where("window_start", ">=", query.from);
+    if (query.to) q = q.where("window_start", "<=", query.to);
+
+    const rows = await q.orderBy("window_start", "desc").limit(limit);
+    return rows.map((row) => this.mapRollup(row));
+  }
+
+  async exportRollups(query: RollupQuery, format: "json" | "csv"): Promise<string> {
+    const rollups = await this.getRollups({ ...query, limit: query.limit ?? MAX_QUERY_LIMIT });
+
+    if (format === "json") {
+      return JSON.stringify(rollups, null, 2);
+    }
+
+    const header = [
+      "metricKey", "granularity", "windowStart", "windowEnd", "sampleCount",
+      "sumValue", "minValue", "maxValue", "avgValue", "p50Value", "p95Value", "p99Value",
+    ].join(",");
+
+    const rows = rollups.map((r) =>
+      [
+        r.metricKey, r.granularity, r.windowStart, r.windowEnd, r.sampleCount,
+        r.sumValue, r.minValue, r.maxValue, r.avgValue, r.p50Value, r.p95Value, r.p99Value,
+      ].join(",")
+    );
+
+    return [header, ...rows].join("\n");
+  }
+
+  async listRetentionPolicies(): Promise<RetentionPolicy[]> {
+    const rows = await this.db("metric_retention_policies").select("*").orderBy("granularity");
+    return rows.map((row) => ({
+      granularity: row.granularity,
+      retentionDays: Number(row.retention_days),
+      updatedAt: new Date(row.updated_at).toISOString(),
+    }));
+  }
+
+  async setRetentionPolicy(granularity: string, retentionDays: number): Promise<RetentionPolicy> {
+    if (retentionDays <= 0) {
+      throw new Error("retentionDays must be a positive integer");
+    }
+
+    const [row] = await this.db("metric_retention_policies")
+      .insert({ granularity, retention_days: retentionDays, updated_at: new Date() })
+      .onConflict("granularity")
+      .merge({ retention_days: retentionDays, updated_at: new Date() })
+      .returning("*");
+
+    return {
+      granularity: row.granularity,
+      retentionDays: Number(row.retention_days),
+      updatedAt: new Date(row.updated_at).toISOString(),
+    };
+  }
+
+  /**
+   * Deletes raw points and rollup windows older than their configured
+   * retention policy. Returns the number of rows deleted per granularity.
+   */
+  async applyRetentionPolicies(): Promise<Record<string, number>> {
+    const policies = await this.listRetentionPolicies();
+    const deleted: Record<string, number> = {};
+
+    for (const policy of policies) {
+      const cutoff = new Date(Date.now() - policy.retentionDays * 86_400_000);
+
+      if (policy.granularity === "raw") {
+        deleted.raw = await this.db("metric_data_points").where("recorded_at", "<", cutoff).delete();
+      } else {
+        deleted[policy.granularity] = await this.db("metric_rollups")
+          .where("granularity", policy.granularity)
+          .where("window_start", "<", cutoff)
+          .delete();
+      }
+    }
+
+    logger.info({ deleted }, "Metric retention policies applied");
+    return deleted;
+  }
+
+  private async aggregateFromRaw(truncUnit: "hour" | "day" | "week"): Promise<
+    Array<{
+      metricKey: string;
+      windowStart: Date;
+      windowEnd: Date;
+      sampleCount: number;
+      sumValue: number;
+      minValue: number;
+      maxValue: number;
+      avgValue: number;
+      p50Value: number;
+      p95Value: number;
+      p99Value: number;
+    }>
+  > {
+    const result = await this.db.raw(
+      `
+      SELECT
+        metric_key AS "metricKey",
+        date_trunc(?, recorded_at) AS "windowStart",
+        date_trunc(?, recorded_at) + ?::interval AS "windowEnd",
+        COUNT(*)::int AS "sampleCount",
+        SUM(value) AS "sumValue",
+        MIN(value) AS "minValue",
+        MAX(value) AS "maxValue",
+        AVG(value) AS "avgValue",
+        PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY value) AS "p50Value",
+        PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY value) AS "p95Value",
+        PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY value) AS "p99Value"
+      FROM metric_data_points
+      WHERE recorded_at < date_trunc(?, now())
+      GROUP BY metric_key, date_trunc(?, recorded_at)
+      `,
+      [truncUnit, truncUnit, `1 ${truncUnit}`, truncUnit, truncUnit]
+    );
+
+    return result.rows.map((row: Record<string, unknown>) => this.normalizeAggregateRow(row));
+  }
+
+  private async aggregateFromRollups(
+    sourceGranularity: MetricGranularity,
+    truncUnit: "hour" | "day" | "week"
+  ): Promise<
+    Array<{
+      metricKey: string;
+      windowStart: Date;
+      windowEnd: Date;
+      sampleCount: number;
+      sumValue: number;
+      minValue: number;
+      maxValue: number;
+      avgValue: number;
+      p50Value: number;
+      p95Value: number;
+      p99Value: number;
+    }>
+  > {
+    // Higher-granularity rollups are built from already-aggregated rows, so exact
+    // percentiles are no longer available; we approximate with a sample-weighted
+    // average of the constituent percentiles, which is sufficient for trend reporting.
+    const result = await this.db.raw(
+      `
+      SELECT
+        metric_key AS "metricKey",
+        date_trunc(?, window_start) AS "windowStart",
+        date_trunc(?, window_start) + ?::interval AS "windowEnd",
+        SUM(sample_count)::int AS "sampleCount",
+        SUM(sum_value) AS "sumValue",
+        MIN(min_value) AS "minValue",
+        MAX(max_value) AS "maxValue",
+        CASE WHEN SUM(sample_count) = 0 THEN 0 ELSE SUM(sum_value) / SUM(sample_count) END AS "avgValue",
+        CASE WHEN SUM(sample_count) = 0 THEN 0 ELSE SUM(p50_value * sample_count) / SUM(sample_count) END AS "p50Value",
+        CASE WHEN SUM(sample_count) = 0 THEN 0 ELSE SUM(p95_value * sample_count) / SUM(sample_count) END AS "p95Value",
+        MAX(p99_value) AS "p99Value"
+      FROM metric_rollups
+      WHERE granularity = ? AND window_start < date_trunc(?, now())
+      GROUP BY metric_key, date_trunc(?, window_start)
+      `,
+      [truncUnit, truncUnit, `1 ${truncUnit}`, sourceGranularity, truncUnit, truncUnit]
+    );
+
+    return result.rows.map((row: Record<string, unknown>) => this.normalizeAggregateRow(row));
+  }
+
+  private normalizeAggregateRow(row: Record<string, unknown>) {
+    return {
+      metricKey: String(row.metricKey),
+      windowStart: new Date(String(row.windowStart)),
+      windowEnd: new Date(String(row.windowEnd)),
+      sampleCount: Number(row.sampleCount),
+      sumValue: Number(row.sumValue),
+      minValue: Number(row.minValue),
+      maxValue: Number(row.maxValue),
+      avgValue: Number(row.avgValue),
+      p50Value: Number(row.p50Value),
+      p95Value: Number(row.p95Value),
+      p99Value: Number(row.p99Value),
+    };
+  }
+
+  private mapRollup(row: Record<string, unknown>): MetricRollup {
+    return {
+      id: String(row.id),
+      metricKey: String(row.metric_key),
+      granularity: row.granularity as MetricGranularity,
+      windowStart: new Date(String(row.window_start)).toISOString(),
+      windowEnd: new Date(String(row.window_end)).toISOString(),
+      sampleCount: Number(row.sample_count),
+      sumValue: Number(row.sum_value),
+      minValue: Number(row.min_value),
+      maxValue: Number(row.max_value),
+      avgValue: Number(row.avg_value),
+      p50Value: Number(row.p50_value),
+      p95Value: Number(row.p95_value),
+      p99Value: Number(row.p99_value),
+      tags: typeof row.tags === "string" ? JSON.parse(row.tags) : (row.tags as Record<string, unknown>) ?? {},
+      createdAt: new Date(String(row.created_at)).toISOString(),
+    };
+  }
+}
+
+export const metricsAggregationService = new MetricsAggregationService();

--- a/backend/src/services/providerCircuitBreaker.service.ts
+++ b/backend/src/services/providerCircuitBreaker.service.ts
@@ -1,0 +1,319 @@
+import { getDatabase } from "../database/connection.js";
+import { auditService } from "./audit.service.js";
+import { logger } from "../utils/logger.js";
+
+export type BreakerState = "closed" | "open" | "half_open";
+export type ManualOverride = "force_open" | "force_closed" | null;
+
+export interface ProviderBreakerState {
+  providerKey: string;
+  state: BreakerState;
+  consecutiveFailures: number;
+  failureThreshold: number;
+  recoveryTimeoutMs: number;
+  tripCount: number;
+  fallbackProviderKey: string | null;
+  manualOverride: ManualOverride;
+  openedAt: string | null;
+  halfOpenedAt: string | null;
+  lastFailureAt: string | null;
+  lastSuccessAt: string | null;
+  updatedAt: string;
+}
+
+export interface BreakerTransition {
+  id: string;
+  providerKey: string;
+  fromState: BreakerState;
+  toState: BreakerState;
+  reason: string;
+  createdAt: string;
+}
+
+const DEFAULT_FAILURE_THRESHOLD = 5;
+const DEFAULT_RECOVERY_TIMEOUT_MS = 60_000;
+
+export class ProviderCircuitBreakerService {
+  private db = getDatabase();
+
+  async getState(providerKey: string): Promise<ProviderBreakerState> {
+    const row = await this.ensureState(providerKey);
+    return this.mapRow(row);
+  }
+
+  async listStates(): Promise<ProviderBreakerState[]> {
+    const rows = await this.db("provider_circuit_breaker_state").orderBy("provider_key");
+    return rows.map((row) => this.mapRow(row));
+  }
+
+  async getTransitionHistory(providerKey: string, limit = 50): Promise<BreakerTransition[]> {
+    const rows = await this.db("provider_circuit_breaker_transitions")
+      .where({ provider_key: providerKey })
+      .orderBy("created_at", "desc")
+      .limit(Math.min(limit, 200));
+
+    return rows.map((row) => ({
+      id: String(row.id),
+      providerKey: String(row.provider_key),
+      fromState: row.from_state as BreakerState,
+      toState: row.to_state as BreakerState,
+      reason: String(row.reason),
+      createdAt: new Date(String(row.created_at)).toISOString(),
+    }));
+  }
+
+  /**
+   * Returns true if a call to this provider should be attempted. A half-open
+   * breaker allows exactly the caller that observes the transition through as
+   * a recovery probe; the result of that call drives the next transition.
+   */
+  async isAvailable(providerKey: string): Promise<boolean> {
+    const row = await this.ensureState(providerKey);
+    const state = this.mapRow(row);
+
+    if (state.manualOverride === "force_open") return false;
+    if (state.manualOverride === "force_closed") return true;
+
+    if (state.state === "closed") return true;
+
+    if (state.state === "open") {
+      const openedAt = state.openedAt ? new Date(state.openedAt).getTime() : 0;
+      if (Date.now() >= openedAt + state.recoveryTimeoutMs) {
+        await this.transition(providerKey, "open", "half_open", "recovery timeout elapsed; allowing probe");
+        return true;
+      }
+      return false;
+    }
+
+    // half_open: a probe is already in flight, but the caller is free to attempt it
+    return true;
+  }
+
+  async recordSuccess(providerKey: string): Promise<ProviderBreakerState> {
+    const row = await this.ensureState(providerKey);
+    const state = this.mapRow(row);
+
+    await this.db("provider_circuit_breaker_state")
+      .where({ provider_key: providerKey })
+      .update({ last_success_at: new Date(), consecutive_failures: 0, updated_at: new Date() });
+
+    if (state.state === "half_open") {
+      await this.transition(providerKey, "half_open", "closed", "recovery probe succeeded");
+      await auditService.log({
+        action: "provider.circuit_breaker_recovered",
+        actorId: "system",
+        actorType: "system",
+        resourceType: "provider",
+        resourceId: providerKey,
+      });
+    }
+
+    return this.getState(providerKey);
+  }
+
+  async recordFailure(providerKey: string, reason = "request failed"): Promise<ProviderBreakerState> {
+    const row = await this.ensureState(providerKey);
+    const state = this.mapRow(row);
+    const consecutiveFailures = state.consecutiveFailures + 1;
+
+    await this.db("provider_circuit_breaker_state")
+      .where({ provider_key: providerKey })
+      .update({ last_failure_at: new Date(), consecutive_failures: consecutiveFailures, updated_at: new Date() });
+
+    if (state.state === "half_open") {
+      await this.tripOpen(providerKey, "half_open", "recovery probe failed");
+    } else if (state.state === "closed" && consecutiveFailures >= state.failureThreshold) {
+      await this.tripOpen(providerKey, "closed", `failure threshold reached (${consecutiveFailures}/${state.failureThreshold}): ${reason}`);
+    }
+
+    return this.getState(providerKey);
+  }
+
+  /**
+   * Convenience wrapper so callers can route a provider call through the
+   * breaker without manually tracking success/failure bookkeeping.
+   */
+  async callWithBreaker<T>(providerKey: string, fn: () => Promise<T>): Promise<T> {
+    const available = await this.isAvailable(providerKey);
+    if (!available) {
+      const fallback = await this.getFallbackProvider(providerKey);
+      throw new Error(
+        fallback
+          ? `Provider "${providerKey}" circuit is open; fall back to "${fallback}"`
+          : `Provider "${providerKey}" circuit is open and no fallback is configured`
+      );
+    }
+
+    try {
+      const result = await fn();
+      await this.recordSuccess(providerKey);
+      return result;
+    } catch (error) {
+      await this.recordFailure(providerKey, error instanceof Error ? error.message : String(error));
+      throw error;
+    }
+  }
+
+  async getFallbackProvider(providerKey: string): Promise<string | null> {
+    const state = await this.getState(providerKey);
+    if (state.state === "closed" && state.manualOverride !== "force_open") return null;
+    return state.fallbackProviderKey;
+  }
+
+  async setFallback(providerKey: string, fallbackProviderKey: string | null, actorId: string): Promise<ProviderBreakerState> {
+    await this.ensureState(providerKey);
+    await this.db("provider_circuit_breaker_state")
+      .where({ provider_key: providerKey })
+      .update({ fallback_provider_key: fallbackProviderKey, updated_at: new Date() });
+
+    await auditService.log({
+      action: "provider.circuit_breaker_override",
+      actorId,
+      actorType: "api_key",
+      resourceType: "provider",
+      resourceId: providerKey,
+      metadata: { fallbackProviderKey },
+    });
+
+    return this.getState(providerKey);
+  }
+
+  async setManualOverride(providerKey: string, override: ManualOverride, actorId: string): Promise<ProviderBreakerState> {
+    await this.ensureState(providerKey);
+    const updates: Record<string, unknown> = { manual_override: override, updated_at: new Date() };
+
+    if (override === "force_closed") {
+      updates.state = "closed";
+      updates.consecutive_failures = 0;
+    } else if (override === "force_open") {
+      updates.state = "open";
+      updates.opened_at = new Date();
+    }
+
+    await this.db("provider_circuit_breaker_state").where({ provider_key: providerKey }).update(updates);
+
+    await auditService.log({
+      action: "provider.circuit_breaker_override",
+      actorId,
+      actorType: "api_key",
+      resourceType: "provider",
+      resourceId: providerKey,
+      metadata: { override },
+    });
+
+    logger.warn({ providerKey, override }, "Provider circuit breaker manual override applied");
+    return this.getState(providerKey);
+  }
+
+  async configureThresholds(
+    providerKey: string,
+    options: { failureThreshold?: number; recoveryTimeoutMs?: number }
+  ): Promise<ProviderBreakerState> {
+    await this.ensureState(providerKey);
+    const updates: Record<string, unknown> = { updated_at: new Date() };
+    if (options.failureThreshold !== undefined) updates.failure_threshold = options.failureThreshold;
+    if (options.recoveryTimeoutMs !== undefined) updates.recovery_timeout_ms = options.recoveryTimeoutMs;
+
+    await this.db("provider_circuit_breaker_state").where({ provider_key: providerKey }).update(updates);
+    return this.getState(providerKey);
+  }
+
+  /** Scheduled sweep: flips any open breaker past its recovery timeout into half-open. */
+  async runRecoveryProbeSweep(): Promise<number> {
+    const openBreakers = await this.db("provider_circuit_breaker_state").where({ state: "open" });
+    let probed = 0;
+
+    for (const row of openBreakers) {
+      const state = this.mapRow(row);
+      if (state.manualOverride === "force_open") continue;
+
+      const openedAt = state.openedAt ? new Date(state.openedAt).getTime() : 0;
+      if (Date.now() >= openedAt + state.recoveryTimeoutMs) {
+        await this.transition(state.providerKey, "open", "half_open", "scheduled recovery probe sweep");
+        probed++;
+      }
+    }
+
+    return probed;
+  }
+
+  private async tripOpen(providerKey: string, fromState: BreakerState, reason: string): Promise<void> {
+    await this.db("provider_circuit_breaker_state")
+      .where({ provider_key: providerKey })
+      .update({
+        state: "open",
+        opened_at: new Date(),
+        updated_at: new Date(),
+        trip_count: this.db.raw("trip_count + 1"),
+      });
+
+    await this.recordTransition(providerKey, fromState, "open", reason);
+
+    await auditService.log({
+      action: "provider.circuit_breaker_tripped",
+      actorId: "system",
+      actorType: "system",
+      resourceType: "provider",
+      resourceId: providerKey,
+      metadata: { reason },
+    });
+
+    logger.warn({ providerKey, reason }, "Provider circuit breaker tripped open");
+  }
+
+  private async transition(providerKey: string, fromState: BreakerState, toState: BreakerState, reason: string): Promise<void> {
+    const updates: Record<string, unknown> = { state: toState, updated_at: new Date() };
+    if (toState === "half_open") updates.half_opened_at = new Date();
+    if (toState === "closed") updates.opened_at = null;
+
+    await this.db("provider_circuit_breaker_state").where({ provider_key: providerKey }).update(updates);
+    await this.recordTransition(providerKey, fromState, toState, reason);
+  }
+
+  private async recordTransition(providerKey: string, fromState: BreakerState, toState: BreakerState, reason: string): Promise<void> {
+    await this.db("provider_circuit_breaker_transitions").insert({
+      provider_key: providerKey,
+      from_state: fromState,
+      to_state: toState,
+      reason,
+    });
+  }
+
+  private async ensureState(providerKey: string): Promise<Record<string, unknown>> {
+    const existing = await this.db("provider_circuit_breaker_state").where({ provider_key: providerKey }).first();
+    if (existing) return existing;
+
+    const [row] = await this.db("provider_circuit_breaker_state")
+      .insert({
+        provider_key: providerKey,
+        state: "closed",
+        failure_threshold: DEFAULT_FAILURE_THRESHOLD,
+        recovery_timeout_ms: DEFAULT_RECOVERY_TIMEOUT_MS,
+      })
+      .onConflict("provider_key")
+      .merge({})
+      .returning("*");
+
+    return row;
+  }
+
+  private mapRow(row: Record<string, unknown>): ProviderBreakerState {
+    return {
+      providerKey: String(row.provider_key),
+      state: row.state as BreakerState,
+      consecutiveFailures: Number(row.consecutive_failures ?? 0),
+      failureThreshold: Number(row.failure_threshold ?? DEFAULT_FAILURE_THRESHOLD),
+      recoveryTimeoutMs: Number(row.recovery_timeout_ms ?? DEFAULT_RECOVERY_TIMEOUT_MS),
+      tripCount: Number(row.trip_count ?? 0),
+      fallbackProviderKey: row.fallback_provider_key ? String(row.fallback_provider_key) : null,
+      manualOverride: (row.manual_override as ManualOverride) ?? null,
+      openedAt: row.opened_at ? new Date(String(row.opened_at)).toISOString() : null,
+      halfOpenedAt: row.half_opened_at ? new Date(String(row.half_opened_at)).toISOString() : null,
+      lastFailureAt: row.last_failure_at ? new Date(String(row.last_failure_at)).toISOString() : null,
+      lastSuccessAt: row.last_success_at ? new Date(String(row.last_success_at)).toISOString() : null,
+      updatedAt: row.updated_at ? new Date(String(row.updated_at)).toISOString() : new Date().toISOString(),
+    };
+  }
+}
+
+export const providerCircuitBreakerService = new ProviderCircuitBreakerService();

--- a/backend/src/services/sourceDecommission.service.ts
+++ b/backend/src/services/sourceDecommission.service.ts
@@ -1,0 +1,292 @@
+import { getDatabase } from "../database/connection.js";
+import { auditService } from "./audit.service.js";
+import { logger } from "../utils/logger.js";
+
+export type SourceDecommissionStatus = "deprecated" | "migrating" | "completed" | "rolled_back";
+
+export interface SourceDecommission {
+  id: string;
+  sourceKey: string;
+  replacementSourceKey: string;
+  status: SourceDecommissionStatus;
+  deprecationPeriodDays: number;
+  deprecationStartedAt: string;
+  deprecationEndsAt: string;
+  fallbackRoutingEnabled: boolean;
+  migrationProgressPct: number;
+  completionReady: boolean;
+  completionVerifiedAt: string | null;
+  createdBy: string;
+  reason: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface StartDecommissionInput {
+  sourceKey: string;
+  replacementSourceKey: string;
+  deprecationPeriodDays?: number;
+  actorId: string;
+  reason?: string;
+}
+
+export interface CompletionCheck {
+  verified: boolean;
+  reasons: string[];
+}
+
+const DEFAULT_DEPRECATION_PERIOD_DAYS = 30;
+
+export class SourceDecommissionService {
+  private db = getDatabase();
+
+  async startDecommission(input: StartDecommissionInput): Promise<SourceDecommission> {
+    if (input.sourceKey === input.replacementSourceKey) {
+      throw new Error("Replacement source must differ from the source being decommissioned");
+    }
+
+    const existing = await this.getStatus(input.sourceKey);
+    if (existing && existing.status !== "rolled_back") {
+      throw new Error(`Source "${input.sourceKey}" already has an active decommission (status: ${existing.status})`);
+    }
+
+    const periodDays = input.deprecationPeriodDays ?? DEFAULT_DEPRECATION_PERIOD_DAYS;
+    const startedAt = new Date();
+    const endsAt = new Date(startedAt.getTime() + periodDays * 86_400_000);
+
+    const [row] = await this.db("source_decommissions")
+      .insert({
+        source_key: input.sourceKey,
+        replacement_source_key: input.replacementSourceKey,
+        status: "deprecated",
+        deprecation_period_days: periodDays,
+        deprecation_started_at: startedAt,
+        deprecation_ends_at: endsAt,
+        fallback_routing_enabled: true,
+        migration_progress_pct: 0,
+        completion_ready: false,
+        created_by: input.actorId,
+        reason: input.reason ?? null,
+      })
+      .onConflict("source_key")
+      .merge({
+        replacement_source_key: input.replacementSourceKey,
+        status: "deprecated",
+        deprecation_period_days: periodDays,
+        deprecation_started_at: startedAt,
+        deprecation_ends_at: endsAt,
+        fallback_routing_enabled: true,
+        migration_progress_pct: 0,
+        completion_ready: false,
+        completion_verified_at: null,
+        created_by: input.actorId,
+        reason: input.reason ?? null,
+        updated_at: new Date(),
+      })
+      .returning("*");
+
+    const decommission = this.mapRow(row);
+
+    await auditService.log({
+      action: "source.decommission_started",
+      actorId: input.actorId,
+      actorType: "api_key",
+      resourceType: "source",
+      resourceId: input.sourceKey,
+      after: decommission as unknown as Record<string, unknown>,
+      metadata: { replacementSourceKey: input.replacementSourceKey, deprecationPeriodDays: periodDays },
+    });
+
+    logger.info({ sourceKey: input.sourceKey, replacementSourceKey: input.replacementSourceKey }, "Source decommission started");
+    return decommission;
+  }
+
+  async getStatus(sourceKey: string): Promise<SourceDecommission | null> {
+    const row = await this.db("source_decommissions").where({ source_key: sourceKey }).first();
+    return row ? this.mapRow(row) : null;
+  }
+
+  async listDecommissions(): Promise<SourceDecommission[]> {
+    const rows = await this.db("source_decommissions").orderBy("created_at", "desc");
+    return rows.map((row) => this.mapRow(row));
+  }
+
+  /**
+   * Returns the replacement source key when fallback routing should be used,
+   * so callers resolving a data source can transparently redirect traffic
+   * away from a source that is being decommissioned.
+   */
+  async getFallbackSource(sourceKey: string): Promise<string | null> {
+    const decommission = await this.getStatus(sourceKey);
+    if (!decommission) return null;
+    if (decommission.status === "rolled_back" || decommission.status === "completed") return null;
+    return decommission.fallbackRoutingEnabled ? decommission.replacementSourceKey : null;
+  }
+
+  async updateMigrationProgress(sourceKey: string, progressPct: number, actorId: string): Promise<SourceDecommission> {
+    if (progressPct < 0 || progressPct > 100) {
+      throw new Error("progressPct must be between 0 and 100");
+    }
+
+    const existing = await this.requireActive(sourceKey);
+
+    const completionReady = await this.isEligibleForCompletion(existing, progressPct);
+
+    const [row] = await this.db("source_decommissions")
+      .where({ source_key: sourceKey })
+      .update({
+        status: progressPct >= 100 ? existing.status : "migrating",
+        migration_progress_pct: progressPct,
+        completion_ready: completionReady,
+        updated_at: new Date(),
+      })
+      .returning("*");
+
+    const updated = this.mapRow(row);
+
+    await auditService.log({
+      action: "source.decommission_progress_updated",
+      actorId,
+      actorType: "api_key",
+      resourceType: "source",
+      resourceId: sourceKey,
+      before: existing as unknown as Record<string, unknown>,
+      after: updated as unknown as Record<string, unknown>,
+    });
+
+    return updated;
+  }
+
+  async checkCompletion(sourceKey: string): Promise<CompletionCheck> {
+    const decommission = await this.requireActive(sourceKey);
+    const reasons: string[] = [];
+
+    if (decommission.migrationProgressPct < 100) {
+      reasons.push(`Data migration is ${decommission.migrationProgressPct}% complete; must reach 100%`);
+    }
+    if (new Date(decommission.deprecationEndsAt) > new Date()) {
+      reasons.push(`Deprecation period has not elapsed (ends ${decommission.deprecationEndsAt})`);
+    }
+
+    return { verified: reasons.length === 0, reasons };
+  }
+
+  async completeDecommission(sourceKey: string, actorId: string): Promise<SourceDecommission> {
+    const existing = await this.requireActive(sourceKey);
+    const check = await this.checkCompletion(sourceKey);
+
+    if (!check.verified) {
+      throw new Error(`Cannot complete decommission for "${sourceKey}": ${check.reasons.join("; ")}`);
+    }
+
+    const [row] = await this.db("source_decommissions")
+      .where({ source_key: sourceKey })
+      .update({
+        status: "completed",
+        fallback_routing_enabled: false,
+        completion_verified_at: new Date(),
+        updated_at: new Date(),
+      })
+      .returning("*");
+
+    const completed = this.mapRow(row);
+
+    await auditService.log({
+      action: "source.decommission_completed",
+      actorId,
+      actorType: "api_key",
+      resourceType: "source",
+      resourceId: sourceKey,
+      before: existing as unknown as Record<string, unknown>,
+      after: completed as unknown as Record<string, unknown>,
+    });
+
+    logger.info({ sourceKey }, "Source decommission completed and verified");
+    return completed;
+  }
+
+  async rollbackDecommission(sourceKey: string, actorId: string, reason?: string): Promise<SourceDecommission> {
+    const existing = await this.requireActive(sourceKey);
+
+    const [row] = await this.db("source_decommissions")
+      .where({ source_key: sourceKey })
+      .update({
+        status: "rolled_back",
+        fallback_routing_enabled: false,
+        completion_ready: false,
+        reason: reason ?? existing.reason,
+        updated_at: new Date(),
+      })
+      .returning("*");
+
+    const rolledBack = this.mapRow(row);
+
+    await auditService.log({
+      action: "source.decommission_rolled_back",
+      actorId,
+      actorType: "api_key",
+      resourceType: "source",
+      resourceId: sourceKey,
+      before: existing as unknown as Record<string, unknown>,
+      after: rolledBack as unknown as Record<string, unknown>,
+      metadata: { reason: reason ?? null },
+    });
+
+    logger.warn({ sourceKey, reason }, "Source decommission rolled back");
+    return rolledBack;
+  }
+
+  /** Periodic sweep used by the scheduled job to flag decommissions ready to complete. */
+  async refreshCompletionReadiness(): Promise<number> {
+    const active = await this.db("source_decommissions").whereIn("status", ["deprecated", "migrating"]);
+    let updated = 0;
+
+    for (const row of active) {
+      const decommission = this.mapRow(row);
+      const ready = await this.isEligibleForCompletion(decommission, decommission.migrationProgressPct);
+      if (ready !== decommission.completionReady) {
+        await this.db("source_decommissions").where({ source_key: decommission.sourceKey }).update({ completion_ready: ready });
+        updated++;
+      }
+    }
+
+    return updated;
+  }
+
+  private async isEligibleForCompletion(decommission: SourceDecommission, progressPct: number): Promise<boolean> {
+    return progressPct >= 100 && new Date(decommission.deprecationEndsAt) <= new Date();
+  }
+
+  private async requireActive(sourceKey: string): Promise<SourceDecommission> {
+    const existing = await this.getStatus(sourceKey);
+    if (!existing) {
+      throw new Error(`No decommission found for source "${sourceKey}"`);
+    }
+    if (existing.status === "completed" || existing.status === "rolled_back") {
+      throw new Error(`Decommission for "${sourceKey}" is already ${existing.status}`);
+    }
+    return existing;
+  }
+
+  private mapRow(row: Record<string, unknown>): SourceDecommission {
+    return {
+      id: String(row.id),
+      sourceKey: String(row.source_key),
+      replacementSourceKey: String(row.replacement_source_key),
+      status: row.status as SourceDecommissionStatus,
+      deprecationPeriodDays: Number(row.deprecation_period_days),
+      deprecationStartedAt: new Date(String(row.deprecation_started_at)).toISOString(),
+      deprecationEndsAt: new Date(String(row.deprecation_ends_at)).toISOString(),
+      fallbackRoutingEnabled: Boolean(row.fallback_routing_enabled),
+      migrationProgressPct: Number(row.migration_progress_pct),
+      completionReady: Boolean(row.completion_ready),
+      completionVerifiedAt: row.completion_verified_at ? new Date(String(row.completion_verified_at)).toISOString() : null,
+      createdBy: String(row.created_by),
+      reason: row.reason ? String(row.reason) : null,
+      createdAt: new Date(String(row.created_at)).toISOString(),
+      updatedAt: new Date(String(row.updated_at)).toISOString(),
+    };
+  }
+}
+
+export const sourceDecommissionService = new SourceDecommissionService();

--- a/backend/src/workers/index.ts
+++ b/backend/src/workers/index.ts
@@ -15,6 +15,7 @@ import { initSupplyVerificationJob } from "../jobs/supplyVerification.job.js";
 import { runAuditRetentionJob } from "../jobs/auditRetention.job.js";
 import { processCachePriming } from "./cachePrimer.job.js";
 import { processAnomalyDetection } from "./anomalyDetection.job.js";
+import { processMetricsAggregation } from "./metricsAggregation.worker.js";
 
 export async function initJobSystem() {
   const jobQueue = JobQueue.getInstance();
@@ -69,6 +70,9 @@ export async function initJobSystem() {
         break;
       case "anomaly-detection":
         await processAnomalyDetection(job);
+        break;
+      case "metrics-aggregation-pipeline":
+        await processMetricsAggregation(job);
         break;
       default:
         logger.warn({ jobName: job.name }, "Unknown job name in worker");
@@ -154,6 +158,13 @@ export async function initJobSystem() {
   // Cache priming: High priority every hour, Full every day at 03:00 UTC
   await jobQueue.addRepeatableJob("cache-priming", { priority: "high" }, "0 * * * *");
   await jobQueue.addRepeatableJob("cache-priming", {}, "0 3 * * *");
+
+  // Metrics aggregation pipeline: hourly rollups every hour, daily rollups just after
+  // midnight, weekly rollups Monday at 01:00, retention cleanup daily at 03:00 UTC.
+  await jobQueue.addRepeatableJob("metrics-aggregation-pipeline", { type: "hourly" }, "5 * * * *");
+  await jobQueue.addRepeatableJob("metrics-aggregation-pipeline", { type: "daily" }, "15 0 * * *");
+  await jobQueue.addRepeatableJob("metrics-aggregation-pipeline", { type: "weekly" }, "30 1 * * 1");
+  await jobQueue.addRepeatableJob("metrics-aggregation-pipeline", { type: "retention" }, "0 3 * * *");
 
   logger.info("Scheduled job system initialized");
 }

--- a/backend/src/workers/metricsAggregation.worker.ts
+++ b/backend/src/workers/metricsAggregation.worker.ts
@@ -1,0 +1,29 @@
+import { Job } from "bullmq";
+import { metricsAggregationService, type MetricGranularity } from "../services/metricsAggregation.service.js";
+import { logger } from "../utils/logger.js";
+
+/**
+ * Worker that rolls up raw metric data points into multi-level summaries
+ * (hourly -> daily -> weekly) and prunes data per the retention policy.
+ */
+export async function processMetricsAggregation(job: Job) {
+  const { type } = job.data as { type: "hourly" | "daily" | "weekly" | "retention" };
+
+  logger.info({ jobId: job.id, type }, "Starting metrics aggregation job");
+
+  try {
+    if (type === "retention") {
+      const deleted = await metricsAggregationService.applyRetentionPolicies();
+      logger.info({ deleted }, "Completed metrics retention cleanup");
+      return { success: true, deleted };
+    }
+
+    const granularity = type as MetricGranularity;
+    const windows = await metricsAggregationService.runRollup(granularity);
+    logger.info({ granularity, windows }, "Completed metrics rollup");
+    return { success: true, windows };
+  } catch (error) {
+    logger.error({ error, jobId: job.id }, "Metrics aggregation job failed");
+    throw error;
+  }
+}

--- a/backend/tests/services/eventReplay.service.test.ts
+++ b/backend/tests/services/eventReplay.service.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { EventReplayService } from "../../src/services/eventReplay.service.js";
+
+const createQueryBuilder = (rows: any[] = []) => {
+  const builder: any = {
+    whereIn: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    orderBy: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+    returning: vi.fn().mockResolvedValue(rows),
+    count: vi.fn().mockReturnThis(),
+    first: vi.fn().mockResolvedValue(rows[0]),
+    clone: vi.fn(() => builder),
+    then: (resolve: (value: any) => any) => resolve(rows),
+  };
+  return builder;
+};
+
+const mockKnex = vi.hoisted(() => {
+  const knex: any = vi.fn(() => createQueryBuilder([]));
+  return knex;
+});
+
+const publishMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const auditLogMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+vi.mock("../../src/database/connection.js", () => ({
+  getDatabase: () => mockKnex,
+}));
+
+vi.mock("../../src/outbox/eventProducer.js", () => ({
+  OutboxProducer: class {
+    publish = publishMock;
+  },
+}));
+
+vi.mock("../../src/services/audit.service.js", () => ({
+  auditService: { log: auditLogMock },
+}));
+
+vi.mock("../../src/utils/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const RUN_ROW = {
+  id: "run-1",
+  requested_by: "admin",
+  filter: "{}",
+  dry_run: true,
+  reason: null,
+  status: "running",
+  total_matched: 0,
+  total_replayed: 0,
+  total_skipped: 0,
+  error_message: null,
+  started_at: "2024-01-01T00:00:00Z",
+  completed_at: null,
+  created_at: "2024-01-01T00:00:00Z",
+};
+
+describe("EventReplayService", () => {
+  let service: EventReplayService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    publishMock.mockResolvedValue(undefined);
+    service = new EventReplayService();
+  });
+
+  describe("executeReplay", () => {
+    it("rejects a real replay without explicit confirmation", async () => {
+      await expect(
+        service.executeReplay({ filter: {}, dryRun: false, requestedBy: "admin" })
+      ).rejects.toThrow(/confirm=true/);
+      expect(mockKnex).not.toHaveBeenCalled();
+    });
+
+    it("does not republish events on a dry run", async () => {
+      const matchedEvents = [
+        { id: "1", aggregate_type: "Alert", aggregate_id: "a1", sequence_no: 1, event_type: "alert.triggered", payload: "{}", status: "delivered" },
+      ];
+
+      mockKnex.mockImplementation((table: string) => {
+        if (table === "event_replay_runs") {
+          const builder = createQueryBuilder([RUN_ROW]);
+          builder.returning = vi.fn().mockResolvedValue([
+            { ...RUN_ROW, status: "completed", total_matched: 1, total_replayed: 0, total_skipped: 0 },
+          ]);
+          return builder;
+        }
+        return createQueryBuilder(matchedEvents);
+      });
+
+      const run = await service.executeReplay({ filter: {}, dryRun: true, requestedBy: "admin" });
+
+      expect(publishMock).not.toHaveBeenCalled();
+      expect(run.status).toBe("completed");
+      expect(run.totalMatched).toBe(1);
+      expect(run.totalReplayed).toBe(0);
+    });
+
+    it("republishes matched events with replay metadata when confirmed", async () => {
+      const matchedEvents = [
+        { id: "1", aggregate_type: "Alert", aggregate_id: "a1", sequence_no: 1, event_type: "alert.triggered", payload: "{}", status: "delivered" },
+      ];
+
+      mockKnex.mockImplementation((table: string) => {
+        if (table === "event_replay_runs") {
+          const builder = createQueryBuilder([RUN_ROW]);
+          builder.returning = vi.fn().mockResolvedValue([
+            { ...RUN_ROW, status: "completed", total_matched: 1, total_replayed: 1, total_skipped: 0 },
+          ]);
+          return builder;
+        }
+        return createQueryBuilder(matchedEvents);
+      });
+
+      const run = await service.executeReplay({
+        filter: { aggregateType: "Alert" },
+        dryRun: false,
+        confirm: true,
+        requestedBy: "admin",
+        reason: "recovery test",
+      });
+
+      expect(publishMock).toHaveBeenCalledTimes(1);
+      expect(publishMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          aggregateType: "Alert",
+          metadata: expect.objectContaining({ replay: true, originalEventId: "1" }),
+        })
+      );
+      expect(auditLogMock).toHaveBeenCalledWith(
+        expect.objectContaining({ action: "event.replay_executed" })
+      );
+      expect(run.totalReplayed).toBe(1);
+    });
+  });
+
+  describe("previewReplay", () => {
+    it("returns matched count and a sample without replaying", async () => {
+      mockKnex.mockImplementation(() => createQueryBuilder([{ count: "3" }]));
+      const result = await service.previewReplay({ aggregateType: "Alert" });
+      expect(publishMock).not.toHaveBeenCalled();
+      expect(result.totalMatched).toBe(3);
+    });
+  });
+
+  describe("listReplayRuns / getReplayRun", () => {
+    it("caps the list limit at 200", async () => {
+      const builder = createQueryBuilder([RUN_ROW]);
+      mockKnex.mockImplementation(() => builder);
+
+      await service.listReplayRuns(10_000);
+
+      expect(builder.limit).toHaveBeenCalledWith(200);
+    });
+
+    it("returns null for an unknown run id", async () => {
+      const builder = createQueryBuilder([]);
+      builder.first = vi.fn().mockResolvedValue(undefined);
+      mockKnex.mockImplementation(() => builder);
+
+      const run = await service.getReplayRun("missing");
+      expect(run).toBeNull();
+    });
+  });
+});

--- a/backend/tests/services/metricsAggregation.service.test.ts
+++ b/backend/tests/services/metricsAggregation.service.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { MetricsAggregationService } from "../../src/services/metricsAggregation.service.js";
+
+const createQueryBuilder = (rows: any[] = []) => {
+  const builder: any = {
+    insert: vi.fn().mockReturnThis(),
+    select: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    orderBy: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    delete: vi.fn().mockResolvedValue(rows.length),
+    onConflict: vi.fn().mockReturnThis(),
+    merge: vi.fn().mockResolvedValue(rows),
+    ignore: vi.fn().mockResolvedValue(rows),
+    returning: vi.fn().mockResolvedValue(rows),
+    then: (resolve: (value: any) => any) => resolve(rows),
+  };
+  return builder;
+};
+
+const mockKnex = vi.hoisted(() => {
+  const knex: any = vi.fn(() => createQueryBuilder([]));
+  knex.raw = vi.fn().mockResolvedValue({ rows: [] });
+  return knex;
+});
+
+vi.mock("../../src/database/connection.js", () => ({
+  getDatabase: () => mockKnex,
+}));
+
+vi.mock("../../src/utils/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+describe("MetricsAggregationService", () => {
+  let service: MetricsAggregationService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockKnex.raw.mockResolvedValue({ rows: [] });
+    service = new MetricsAggregationService();
+  });
+
+  describe("ingest", () => {
+    it("inserts raw data points and returns the count", async () => {
+      mockKnex.mockImplementation(() => createQueryBuilder([]));
+
+      const count = await service.ingest([
+        { metricKey: "bridge.latency_ms", value: 120 },
+        { metricKey: "bridge.latency_ms", value: 95 },
+      ]);
+
+      expect(count).toBe(2);
+      expect(mockKnex).toHaveBeenCalledWith("metric_data_points");
+    });
+
+    it("returns 0 without touching the database when no points are given", async () => {
+      const count = await service.ingest([]);
+      expect(count).toBe(0);
+      expect(mockKnex).not.toHaveBeenCalled();
+    });
+
+    it("rejects batches larger than the configured maximum", async () => {
+      const points = Array.from({ length: 1001 }, (_, i) => ({ metricKey: "x", value: i }));
+      await expect(service.ingest(points)).rejects.toThrow(/Cannot ingest more than/);
+    });
+  });
+
+  describe("runRollup", () => {
+    it("aggregates hourly windows from raw points and upserts rollups", async () => {
+      mockKnex.raw.mockResolvedValue({
+        rows: [
+          {
+            metricKey: "bridge.latency_ms",
+            windowStart: "2024-01-01T00:00:00Z",
+            windowEnd: "2024-01-01T01:00:00Z",
+            sampleCount: 10,
+            sumValue: 1000,
+            minValue: 50,
+            maxValue: 200,
+            avgValue: 100,
+            p50Value: 95,
+            p95Value: 180,
+            p99Value: 195,
+          },
+        ],
+      });
+      const builder = createQueryBuilder([]);
+      mockKnex.mockImplementation(() => builder);
+
+      const windows = await service.runRollup("hourly");
+
+      expect(windows).toBe(1);
+      expect(mockKnex.raw).toHaveBeenCalledTimes(1);
+      expect(builder.onConflict).toHaveBeenCalledWith(["metric_key", "granularity", "window_start"]);
+    });
+
+    it("returns 0 when there are no complete windows to roll up", async () => {
+      mockKnex.raw.mockResolvedValue({ rows: [] });
+      const windows = await service.runRollup("daily");
+      expect(windows).toBe(0);
+    });
+  });
+
+  describe("getRollups", () => {
+    it("filters by metric key and time range", async () => {
+      const rows = [
+        {
+          id: "r1",
+          metric_key: "bridge.latency_ms",
+          granularity: "hourly",
+          window_start: "2024-01-01T00:00:00Z",
+          window_end: "2024-01-01T01:00:00Z",
+          sample_count: 5,
+          sum_value: 500,
+          min_value: 50,
+          max_value: 150,
+          avg_value: 100,
+          p50_value: 95,
+          p95_value: 140,
+          p99_value: 148,
+          tags: "{}",
+          created_at: "2024-01-01T01:00:00Z",
+        },
+      ];
+      const builder = createQueryBuilder(rows);
+      mockKnex.mockImplementation(() => builder);
+
+      const result = await service.getRollups({ metricKey: "bridge.latency_ms", granularity: "hourly" });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].metricKey).toBe("bridge.latency_ms");
+      expect(builder.where).toHaveBeenCalledWith("granularity", "hourly");
+    });
+  });
+
+  describe("exportRollups", () => {
+    it("exports rollups as CSV with a header row", async () => {
+      const rows = [
+        {
+          id: "r1",
+          metric_key: "bridge.latency_ms",
+          granularity: "hourly",
+          window_start: "2024-01-01T00:00:00Z",
+          window_end: "2024-01-01T01:00:00Z",
+          sample_count: 5,
+          sum_value: 500,
+          min_value: 50,
+          max_value: 150,
+          avg_value: 100,
+          p50_value: 95,
+          p95_value: 140,
+          p99_value: 148,
+          tags: "{}",
+          created_at: "2024-01-01T01:00:00Z",
+        },
+      ];
+      mockKnex.mockImplementation(() => createQueryBuilder(rows));
+
+      const csv = await service.exportRollups({ granularity: "hourly" }, "csv");
+
+      expect(csv.split("\n")[0]).toContain("metricKey");
+      expect(csv).toContain("bridge.latency_ms");
+    });
+
+    it("exports rollups as JSON", async () => {
+      mockKnex.mockImplementation(() => createQueryBuilder([]));
+      const json = await service.exportRollups({ granularity: "daily" }, "json");
+      expect(JSON.parse(json)).toEqual([]);
+    });
+  });
+
+  describe("retention policies", () => {
+    it("rejects non-positive retention windows", async () => {
+      await expect(service.setRetentionPolicy("hourly", 0)).rejects.toThrow(/positive integer/);
+    });
+
+    it("applies retention by deleting rows older than the cutoff per granularity", async () => {
+      const policyRows = [
+        { granularity: "raw", retention_days: 7, updated_at: "2024-01-01T00:00:00Z" },
+        { granularity: "hourly", retention_days: 90, updated_at: "2024-01-01T00:00:00Z" },
+      ];
+      const deleteBuilder = createQueryBuilder([]);
+      deleteBuilder.delete = vi.fn().mockResolvedValue(3);
+
+      mockKnex.mockImplementation((table: string) => {
+        if (table === "metric_retention_policies") return createQueryBuilder(policyRows);
+        return deleteBuilder;
+      });
+
+      const deleted = await service.applyRetentionPolicies();
+
+      expect(deleted.raw).toBe(3);
+      expect(deleted.hourly).toBe(3);
+    });
+  });
+});

--- a/backend/tests/services/providerCircuitBreaker.service.test.ts
+++ b/backend/tests/services/providerCircuitBreaker.service.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { ProviderCircuitBreakerService } from "../../src/services/providerCircuitBreaker.service.js";
+
+const createQueryBuilder = (rows: any[] = []) => {
+  const builder: any = {
+    where: vi.fn().mockReturnThis(),
+    orderBy: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockReturnThis(),
+    update: vi.fn().mockResolvedValue(1),
+    onConflict: vi.fn().mockReturnThis(),
+    merge: vi.fn().mockReturnThis(),
+    returning: vi.fn().mockResolvedValue(rows),
+    first: vi.fn().mockResolvedValue(rows[0]),
+    then: (resolve: (value: any) => any) => resolve(rows),
+  };
+  return builder;
+};
+
+const mockKnex = vi.hoisted(() => {
+  const knex: any = vi.fn(() => createQueryBuilder([]));
+  knex.raw = vi.fn((sql: string) => sql);
+  return knex;
+});
+
+const auditLogMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+vi.mock("../../src/database/connection.js", () => ({
+  getDatabase: () => mockKnex,
+}));
+
+vi.mock("../../src/services/audit.service.js", () => ({
+  auditService: { log: auditLogMock },
+}));
+
+vi.mock("../../src/utils/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+function makeStateRow(overrides: Record<string, unknown> = {}) {
+  return {
+    provider_key: "coingecko",
+    state: "closed",
+    consecutive_failures: 0,
+    failure_threshold: 3,
+    recovery_timeout_ms: 60_000,
+    trip_count: 0,
+    fallback_provider_key: "coinmarketcap",
+    manual_override: null,
+    opened_at: null,
+    half_opened_at: null,
+    last_failure_at: null,
+    last_success_at: null,
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe("ProviderCircuitBreakerService", () => {
+  let service: ProviderCircuitBreakerService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new ProviderCircuitBreakerService();
+  });
+
+  describe("isAvailable", () => {
+    it("is available when closed", async () => {
+      mockKnex.mockImplementation(() => {
+        const builder = createQueryBuilder([]);
+        builder.first = vi.fn().mockResolvedValue(makeStateRow());
+        return builder;
+      });
+
+      expect(await service.isAvailable("coingecko")).toBe(true);
+    });
+
+    it("is unavailable while open and within the recovery timeout", async () => {
+      mockKnex.mockImplementation(() => {
+        const builder = createQueryBuilder([]);
+        builder.first = vi.fn().mockResolvedValue(
+          makeStateRow({ state: "open", opened_at: new Date().toISOString() })
+        );
+        return builder;
+      });
+
+      expect(await service.isAvailable("coingecko")).toBe(false);
+    });
+
+    it("transitions to half-open and allows a probe once the timeout elapses", async () => {
+      mockKnex.mockImplementation(() => {
+        const builder = createQueryBuilder([]);
+        builder.first = vi.fn().mockResolvedValue(
+          makeStateRow({ state: "open", opened_at: new Date(Date.now() - 120_000).toISOString() })
+        );
+        return builder;
+      });
+
+      const available = await service.isAvailable("coingecko");
+
+      expect(available).toBe(true);
+      expect(mockKnex).toHaveBeenCalledWith("provider_circuit_breaker_transitions");
+    });
+
+    it("respects a force_open manual override regardless of state", async () => {
+      mockKnex.mockImplementation(() => {
+        const builder = createQueryBuilder([]);
+        builder.first = vi.fn().mockResolvedValue(makeStateRow({ manual_override: "force_open" }));
+        return builder;
+      });
+
+      expect(await service.isAvailable("coingecko")).toBe(false);
+    });
+  });
+
+  describe("recordFailure", () => {
+    it("trips the breaker open once the failure threshold is reached", async () => {
+      mockKnex.mockImplementation(() => {
+        const builder = createQueryBuilder([]);
+        builder.first = vi.fn().mockResolvedValue(
+          makeStateRow({ consecutive_failures: 2, failure_threshold: 3 })
+        );
+        return builder;
+      });
+
+      await service.recordFailure("coingecko", "timeout");
+
+      expect(mockKnex).toHaveBeenCalledWith("provider_circuit_breaker_state");
+      expect(auditLogMock).toHaveBeenCalledWith(
+        expect.objectContaining({ action: "provider.circuit_breaker_tripped" })
+      );
+    });
+
+    it("does not trip below the failure threshold", async () => {
+      mockKnex.mockImplementation(() => {
+        const builder = createQueryBuilder([]);
+        builder.first = vi.fn().mockResolvedValue(
+          makeStateRow({ consecutive_failures: 0, failure_threshold: 3 })
+        );
+        return builder;
+      });
+
+      await service.recordFailure("coingecko", "timeout");
+
+      expect(auditLogMock).not.toHaveBeenCalledWith(
+        expect.objectContaining({ action: "provider.circuit_breaker_tripped" })
+      );
+    });
+  });
+
+  describe("recordSuccess", () => {
+    it("closes the breaker after a successful half-open probe", async () => {
+      mockKnex.mockImplementation(() => {
+        const builder = createQueryBuilder([]);
+        builder.first = vi.fn().mockResolvedValue(makeStateRow({ state: "half_open" }));
+        return builder;
+      });
+
+      await service.recordSuccess("coingecko");
+
+      expect(auditLogMock).toHaveBeenCalledWith(
+        expect.objectContaining({ action: "provider.circuit_breaker_recovered" })
+      );
+    });
+  });
+
+  describe("getFallbackProvider", () => {
+    it("returns null while the breaker is closed with no override", async () => {
+      mockKnex.mockImplementation(() => {
+        const builder = createQueryBuilder([]);
+        builder.first = vi.fn().mockResolvedValue(makeStateRow());
+        return builder;
+      });
+
+      expect(await service.getFallbackProvider("coingecko")).toBeNull();
+    });
+
+    it("returns the configured fallback while open", async () => {
+      mockKnex.mockImplementation(() => {
+        const builder = createQueryBuilder([]);
+        builder.first = vi.fn().mockResolvedValue(makeStateRow({ state: "open" }));
+        return builder;
+      });
+
+      expect(await service.getFallbackProvider("coingecko")).toBe("coinmarketcap");
+    });
+  });
+
+  describe("callWithBreaker", () => {
+    it("throws without invoking the function when the breaker is open", async () => {
+      mockKnex.mockImplementation(() => {
+        const builder = createQueryBuilder([]);
+        builder.first = vi.fn().mockResolvedValue(
+          makeStateRow({ state: "open", opened_at: new Date().toISOString() })
+        );
+        return builder;
+      });
+
+      const fn = vi.fn();
+      await expect(service.callWithBreaker("coingecko", fn)).rejects.toThrow(/circuit is open/);
+      expect(fn).not.toHaveBeenCalled();
+    });
+
+    it("records success when the wrapped call succeeds", async () => {
+      mockKnex.mockImplementation(() => {
+        const builder = createQueryBuilder([]);
+        builder.first = vi.fn().mockResolvedValue(makeStateRow());
+        return builder;
+      });
+
+      const fn = vi.fn().mockResolvedValue("ok");
+      const result = await service.callWithBreaker("coingecko", fn);
+
+      expect(result).toBe("ok");
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/backend/tests/services/sourceDecommission.service.test.ts
+++ b/backend/tests/services/sourceDecommission.service.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { SourceDecommissionService } from "../../src/services/sourceDecommission.service.js";
+
+const createQueryBuilder = (rows: any[] = []) => {
+  const builder: any = {
+    where: vi.fn().mockReturnThis(),
+    whereIn: vi.fn().mockReturnThis(),
+    orderBy: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+    onConflict: vi.fn().mockReturnThis(),
+    merge: vi.fn().mockReturnThis(),
+    returning: vi.fn().mockResolvedValue(rows),
+    first: vi.fn().mockResolvedValue(rows[0]),
+    then: (resolve: (value: any) => any) => resolve(rows),
+  };
+  return builder;
+};
+
+const mockKnex = vi.hoisted(() => {
+  const knex: any = vi.fn(() => createQueryBuilder([]));
+  return knex;
+});
+
+const auditLogMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+vi.mock("../../src/database/connection.js", () => ({
+  getDatabase: () => mockKnex,
+}));
+
+vi.mock("../../src/services/audit.service.js", () => ({
+  auditService: { log: auditLogMock },
+}));
+
+vi.mock("../../src/utils/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+function makeRow(overrides: Record<string, unknown> = {}) {
+  const now = new Date();
+  return {
+    id: "d1",
+    source_key: "old-source",
+    replacement_source_key: "new-source",
+    status: "deprecated",
+    deprecation_period_days: 30,
+    deprecation_started_at: now.toISOString(),
+    deprecation_ends_at: new Date(now.getTime() - 1000).toISOString(),
+    fallback_routing_enabled: true,
+    migration_progress_pct: "0.00",
+    completion_ready: false,
+    completion_verified_at: null,
+    created_by: "admin",
+    reason: null,
+    created_at: now.toISOString(),
+    updated_at: now.toISOString(),
+    ...overrides,
+  };
+}
+
+describe("SourceDecommissionService", () => {
+  let service: SourceDecommissionService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new SourceDecommissionService();
+  });
+
+  describe("startDecommission", () => {
+    it("rejects decommissioning a source into itself", async () => {
+      await expect(
+        service.startDecommission({ sourceKey: "a", replacementSourceKey: "a", actorId: "admin" })
+      ).rejects.toThrow(/must differ/);
+    });
+
+    it("creates a decommission row and writes an audit entry", async () => {
+      mockKnex.mockImplementation((table: string) => {
+        if (table === "source_decommissions") {
+          const builder = createQueryBuilder([]);
+          builder.first = vi.fn().mockResolvedValue(undefined);
+          builder.returning = vi.fn().mockResolvedValue([makeRow()]);
+          return builder;
+        }
+        return createQueryBuilder([]);
+      });
+
+      const result = await service.startDecommission({
+        sourceKey: "old-source",
+        replacementSourceKey: "new-source",
+        actorId: "admin",
+      });
+
+      expect(result.sourceKey).toBe("old-source");
+      expect(result.status).toBe("deprecated");
+      expect(auditLogMock).toHaveBeenCalledWith(
+        expect.objectContaining({ action: "source.decommission_started" })
+      );
+    });
+
+    it("refuses to start a new decommission while one is already active", async () => {
+      mockKnex.mockImplementation(() => {
+        const builder = createQueryBuilder([]);
+        builder.first = vi.fn().mockResolvedValue(makeRow({ status: "migrating" }));
+        return builder;
+      });
+
+      await expect(
+        service.startDecommission({ sourceKey: "old-source", replacementSourceKey: "new-source", actorId: "admin" })
+      ).rejects.toThrow(/already has an active decommission/);
+    });
+  });
+
+  describe("getFallbackSource", () => {
+    it("returns the replacement when fallback routing is enabled", async () => {
+      mockKnex.mockImplementation(() => {
+        const builder = createQueryBuilder([]);
+        builder.first = vi.fn().mockResolvedValue(makeRow());
+        return builder;
+      });
+
+      const fallback = await service.getFallbackSource("old-source");
+      expect(fallback).toBe("new-source");
+    });
+
+    it("returns null once the decommission is completed", async () => {
+      mockKnex.mockImplementation(() => {
+        const builder = createQueryBuilder([]);
+        builder.first = vi.fn().mockResolvedValue(makeRow({ status: "completed" }));
+        return builder;
+      });
+
+      const fallback = await service.getFallbackSource("old-source");
+      expect(fallback).toBeNull();
+    });
+  });
+
+  describe("completeDecommission", () => {
+    it("blocks completion when migration progress is below 100%", async () => {
+      mockKnex.mockImplementation(() => {
+        const builder = createQueryBuilder([]);
+        builder.first = vi.fn().mockResolvedValue(makeRow({ migration_progress_pct: "40.00" }));
+        return builder;
+      });
+
+      await expect(service.completeDecommission("old-source", "admin")).rejects.toThrow(/40/);
+    });
+
+    it("blocks completion before the deprecation period elapses", async () => {
+      mockKnex.mockImplementation(() => {
+        const builder = createQueryBuilder([]);
+        builder.first = vi.fn().mockResolvedValue(
+          makeRow({ migration_progress_pct: "100.00", deprecation_ends_at: new Date(Date.now() + 86_400_000).toISOString() })
+        );
+        return builder;
+      });
+
+      await expect(service.completeDecommission("old-source", "admin")).rejects.toThrow(/deprecation period/);
+    });
+
+    it("completes and audits once all criteria are satisfied", async () => {
+      const eligibleRow = makeRow({ migration_progress_pct: "100.00" });
+      mockKnex.mockImplementation(() => {
+        const builder = createQueryBuilder([]);
+        builder.first = vi.fn().mockResolvedValue(eligibleRow);
+        builder.returning = vi.fn().mockResolvedValue([{ ...eligibleRow, status: "completed" }]);
+        return builder;
+      });
+
+      const result = await service.completeDecommission("old-source", "admin");
+
+      expect(result.status).toBe("completed");
+      expect(auditLogMock).toHaveBeenCalledWith(
+        expect.objectContaining({ action: "source.decommission_completed" })
+      );
+    });
+  });
+
+  describe("rollbackDecommission", () => {
+    it("marks the flow rolled back and disables fallback routing", async () => {
+      mockKnex.mockImplementation(() => {
+        const builder = createQueryBuilder([]);
+        builder.first = vi.fn().mockResolvedValue(makeRow());
+        builder.returning = vi.fn().mockResolvedValue([makeRow({ status: "rolled_back", fallback_routing_enabled: false })]);
+        return builder;
+      });
+
+      const result = await service.rollbackDecommission("old-source", "admin", "replacement unstable");
+
+      expect(result.status).toBe("rolled_back");
+      expect(result.fallbackRoutingEnabled).toBe(false);
+      expect(auditLogMock).toHaveBeenCalledWith(
+        expect.objectContaining({ action: "source.decommission_rolled_back" })
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds four related operational backend capabilities:

- **Provider circuit breaker** (#637) — per-provider failure tracking with configurable thresholds, automatic disable once the threshold trips, scheduled recovery probing (open → half-open → closed/open), fallback provider routing, manual override controls, and state/transition-history endpoints for metrics output.
- **Event replay service** (#638) — preview and replay historical outbox events filtered by aggregate type, event type, status, and time range. Replay ordering follows the original per-aggregate sequence, dry-run is the default mode, real replays are gated behind an explicit `confirm` flag and a capped batch size, and every run is recorded to the audit trail.
- **Metrics aggregation pipeline** (#639) — multi-level rollups (hourly → daily → weekly) computed from raw ingested data points, run on a schedule through the existing job system, with configurable per-granularity retention policies and JSON/CSV export for reporting.
- **Source decommission flow** (#640) — start a deprecation period for a source with fallback routing to its replacement, track data migration progress, verify completion criteria (100% migrated and deprecation period elapsed) before allowing finalization, support rollback, and record every transition to the audit trail.

Each feature follows the repo's existing service/job/route conventions: a Knex migration, a service class with an exported singleton, a scheduled job (BullMQ for the metrics pipeline, `setInterval` workers for the breaker probe sweep and decommission readiness checks), Fastify routes registered under `/api/v1`, and unit tests under `tests/services`.

## Test plan

- [ ] Run migrations: `npm run migrate`
- [ ] `npm run test:unit` — new suites: `metricsAggregation.service.test.ts`, `eventReplay.service.test.ts`, `sourceDecommission.service.test.ts`, `providerCircuitBreaker.service.test.ts`
- [ ] `npm run build` and `npm run lint`
- [ ] Manually exercise each new route group:
  - `POST /api/v1/metrics/aggregation/ingest` → `POST /run` → `GET /` and `GET /export`
  - `POST /api/v1/events/replay/preview` → `POST /api/v1/events/replay` (dry run, then confirmed)
  - `POST /api/v1/sources/decommission` → `PUT /:sourceKey/progress` → `GET /:sourceKey/completion-check` → `POST /:sourceKey/complete`
  - `GET /api/v1/providers/circuit-breaker` and `PUT /:providerKey/override`

Closes #637
Closes #638
Closes #639
Closes #640