### PR TITLE
feat: wire bridge monitor worker alert routing and TimescaleDB persistence

### DIFF
--- a/backend/src/workers/bridgeMonitor.worker.ts
+++ b/backend/src/workers/bridgeMonitor.worker.ts
@@ -2,6 +2,8 @@ import { Worker, Queue } from "bullmq";
 import { config } from "../config/index.js";
 import { BridgeService } from "../services/bridge.service.js";
 import { logger } from "../utils/logger.js";
+import { alertRoutingService } from "../services/alertRouting.service.js";
+import { duplicateAlertCheckService } from "../services/duplicateAlertCheck.service.js";
 
 const QUEUE_NAME = "bridge-monitor";
 

--- a/backend/src/workers/bridgeMonitor.worker.ts
+++ b/backend/src/workers/bridgeMonitor.worker.ts
@@ -5,6 +5,7 @@ import { logger } from "../utils/logger.js";
 import { alertRoutingService, type RouteableAlert } from "../services/alertRouting.service.js";
 import { duplicateAlertCheckService } from "../services/duplicateAlertCheck.service.js";
 import type { AlertEvent } from "../services/alert.service.js";
+import { getDatabase } from "../database/connection.js";
 
 const QUEUE_NAME = "bridge-monitor";
 

--- a/backend/src/workers/bridgeMonitor.worker.ts
+++ b/backend/src/workers/bridgeMonitor.worker.ts
@@ -2,8 +2,9 @@ import { Worker, Queue } from "bullmq";
 import { config } from "../config/index.js";
 import { BridgeService } from "../services/bridge.service.js";
 import { logger } from "../utils/logger.js";
-import { alertRoutingService } from "../services/alertRouting.service.js";
+import { alertRoutingService, type RouteableAlert } from "../services/alertRouting.service.js";
 import { duplicateAlertCheckService } from "../services/duplicateAlertCheck.service.js";
+import type { AlertEvent } from "../services/alert.service.js";
 
 const QUEUE_NAME = "bridge-monitor";
 
@@ -14,6 +15,21 @@ const connection = {
 };
 
 export const bridgeMonitorQueue = new Queue(QUEUE_NAME, { connection });
+
+function buildMismatchAlert(assetCode: string, supplyCheck: { mismatchPercentage?: number }): RouteableAlert {
+  return {
+    eventTime: new Date(),
+    alertRuleId: `bridge-monitor-${assetCode}`,
+    ownerAddress: "system",
+    ruleName: "Bridge Supply Mismatch",
+    assetCode,
+    sourceType: "supply_mismatch",
+    severity: "high",
+    triggeredValue: supplyCheck.mismatchPercentage ?? 0,
+    threshold: config.BRIDGE_MISMATCH_THRESHOLD ?? 0.01,
+    metric: "supply_mismatch_pct",
+  };
+}
 
 /**
  * Worker that continuously monitors bridge integrity:

--- a/backend/src/workers/bridgeMonitor.worker.ts
+++ b/backend/src/workers/bridgeMonitor.worker.ts
@@ -17,6 +17,25 @@ const connection = {
 
 export const bridgeMonitorQueue = new Queue(QUEUE_NAME, { connection });
 
+async function persistMonitorResult(
+  assetCode: string,
+  supplyCheck: { match: boolean; mismatchPercentage?: number; stellarSupply?: number; evmSupply?: number }
+): Promise<void> {
+  try {
+    const db = getDatabase();
+    await db("bridge_monitor_results").insert({
+      time: new Date(),
+      asset_code: assetCode,
+      supply_match: supplyCheck.match,
+      mismatch_pct: supplyCheck.mismatchPercentage ?? 0,
+      stellar_supply: supplyCheck.stellarSupply ?? null,
+      evm_supply: supplyCheck.evmSupply ?? null,
+    });
+  } catch (err) {
+    logger.error({ err, assetCode }, "Failed to persist bridge monitor result");
+  }
+}
+
 function buildMismatchAlert(assetCode: string, supplyCheck: { mismatchPercentage?: number }): RouteableAlert {
   return {
     eventTime: new Date(),

--- a/backend/src/workers/bridgeMonitor.worker.ts
+++ b/backend/src/workers/bridgeMonitor.worker.ts
@@ -52,6 +52,49 @@ function buildMismatchAlert(assetCode: string, supplyCheck: { mismatchPercentage
 }
 
 /**
+ * Core processor for a single bridge monitor job.
+ * Exported for unit testing without spinning up the BullMQ worker.
+ */
+export async function processMonitorJob(job: { id?: string; data: { assetCode: string } }) {
+  const bridgeService = new BridgeService();
+  logger.info({ jobId: job.id, data: job.data }, "Processing bridge monitor job");
+
+  const { assetCode } = job.data;
+
+  // Verify supply consistency
+  const supplyCheck = await bridgeService.verifySupply(assetCode);
+
+  if (!supplyCheck.match) {
+    logger.warn({ ...supplyCheck }, "Bridge supply mismatch detected");
+
+    const dedupEvent: Omit<AlertEvent, "eventId"> = {
+      ruleId: `bridge-monitor-${assetCode}`,
+      assetCode,
+      alertType: "supply_mismatch",
+      priority: "high",
+      triggeredValue: supplyCheck.mismatchPercentage ?? 0,
+      threshold: config.BRIDGE_MISMATCH_THRESHOLD ?? 0.01,
+      metric: "supply_mismatch_pct",
+      webhookDelivered: false,
+      onChainEventId: null,
+    };
+
+    const dedupResult = duplicateAlertCheckService.check(dedupEvent);
+
+    if (!dedupResult.isDuplicate || dedupResult.action !== "block") {
+      const alert = buildMismatchAlert(assetCode, supplyCheck);
+      await alertRoutingService.routeAlert(alert);
+      logger.info({ assetCode }, "Supply mismatch alert routed");
+    } else {
+      logger.debug({ assetCode, reason: dedupResult.reason }, "Mismatch alert suppressed by deduplication");
+    }
+  }
+
+  await persistMonitorResult(assetCode, supplyCheck);
+  return { success: true, assetCode, supplyCheck };
+}
+
+/**
  * Worker that continuously monitors bridge integrity:
  * - Tracks mint/burn events on Stellar
  * - Verifies supply consistency across chains
@@ -61,45 +104,10 @@ function buildMismatchAlert(assetCode: string, supplyCheck: { mismatchPercentage
 export const bridgeMonitorWorker = new Worker(
   QUEUE_NAME,
   async (job) => {
-    const bridgeService = new BridgeService();
-    logger.info({ jobId: job.id, data: job.data }, "Processing bridge monitor job");
-
-    const { assetCode } = job.data;
-
     try {
-      // Verify supply consistency
-      const supplyCheck = await bridgeService.verifySupply(assetCode);
-
-      if (!supplyCheck.match) {
-        logger.warn({ ...supplyCheck }, "Bridge supply mismatch detected");
-
-        const dedupEvent: Omit<AlertEvent, "eventId"> = {
-          ruleId: `bridge-monitor-${assetCode}`,
-          assetCode,
-          alertType: "supply_mismatch",
-          priority: "high",
-          triggeredValue: supplyCheck.mismatchPercentage ?? 0,
-          threshold: config.BRIDGE_MISMATCH_THRESHOLD ?? 0.01,
-          metric: "supply_mismatch_pct",
-          webhookDelivered: false,
-          onChainEventId: null,
-        };
-
-        const dedupResult = duplicateAlertCheckService.check(dedupEvent);
-
-        if (!dedupResult.isDuplicate || dedupResult.action !== "block") {
-          const alert = buildMismatchAlert(assetCode, supplyCheck);
-          await alertRoutingService.routeAlert(alert);
-          logger.info({ assetCode }, "Supply mismatch alert routed");
-        } else {
-          logger.debug({ assetCode, reason: dedupResult.reason }, "Mismatch alert suppressed by deduplication");
-        }
-      }
-
-      await persistMonitorResult(assetCode, supplyCheck);
-      return { success: true, assetCode, supplyCheck };
+      return await processMonitorJob(job);
     } catch (error) {
-      logger.error({ error, assetCode }, "Bridge monitor job failed");
+      logger.error({ error, assetCode: job.data?.assetCode }, "Bridge monitor job failed");
       throw error;
     }
   },

--- a/backend/src/workers/bridgeMonitor.worker.ts
+++ b/backend/src/workers/bridgeMonitor.worker.ts
@@ -17,6 +17,11 @@ const connection = {
 
 export const bridgeMonitorQueue = new Queue(QUEUE_NAME, { connection });
 
+/**
+ * Writes one row to bridge_monitor_results (TimescaleDB hypertable, time column = now).
+ * Columns: time, asset_code, supply_match, mismatch_pct, stellar_supply, evm_supply.
+ * Errors are swallowed so a DB outage never blocks the job from completing.
+ */
 async function persistMonitorResult(
   assetCode: string,
   supplyCheck: { match: boolean; mismatchPercentage?: number; stellarSupply?: number; evmSupply?: number }

--- a/backend/src/workers/bridgeMonitor.worker.ts
+++ b/backend/src/workers/bridgeMonitor.worker.ts
@@ -51,14 +51,32 @@ export const bridgeMonitorWorker = new Worker(
       const supplyCheck = await bridgeService.verifySupply(assetCode);
 
       if (!supplyCheck.match) {
-        logger.warn(
-          { ...supplyCheck },
-          "Bridge supply mismatch detected"
-        );
-        // TODO: Trigger alert via configured notification channel
+        logger.warn({ ...supplyCheck }, "Bridge supply mismatch detected");
+
+        const dedupEvent: Omit<AlertEvent, "eventId"> = {
+          ruleId: `bridge-monitor-${assetCode}`,
+          assetCode,
+          alertType: "supply_mismatch",
+          priority: "high",
+          triggeredValue: supplyCheck.mismatchPercentage ?? 0,
+          threshold: config.BRIDGE_MISMATCH_THRESHOLD ?? 0.01,
+          metric: "supply_mismatch_pct",
+          webhookDelivered: false,
+          onChainEventId: null,
+        };
+
+        const dedupResult = duplicateAlertCheckService.check(dedupEvent);
+
+        if (!dedupResult.isDuplicate || dedupResult.action !== "block") {
+          const alert = buildMismatchAlert(assetCode, supplyCheck);
+          await alertRoutingService.routeAlert(alert);
+          logger.info({ assetCode }, "Supply mismatch alert routed");
+        } else {
+          logger.debug({ assetCode, reason: dedupResult.reason }, "Mismatch alert suppressed by deduplication");
+        }
       }
 
-      // TODO: Record results in TimescaleDB for historical tracking
+      await persistMonitorResult(assetCode, supplyCheck);
       return { success: true, assetCode, supplyCheck };
     } catch (error) {
       logger.error({ error, assetCode }, "Bridge monitor job failed");

--- a/backend/tests/workers/bridgeMonitor.worker.test.ts
+++ b/backend/tests/workers/bridgeMonitor.worker.test.ts
@@ -164,5 +164,43 @@ describe("bridgeMonitor.worker", () => {
 
       expect(result.success).toBe(true);
     });
+
+    it("persists stellar and evm supply values when present", async () => {
+      verifySupplyMock.mockResolvedValue({
+        match: false,
+        mismatchPercentage: 0.02,
+        stellarSupply: 1_000_000,
+        evmSupply: 980_000,
+      });
+
+      await processMonitorJob({ id: "job-10", data: { assetCode: "USDC" } } as any);
+
+      expect(dbInsertMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          stellar_supply: 1_000_000,
+          evm_supply: 980_000,
+        })
+      );
+    });
+  });
+
+  describe("alert routing resilience", () => {
+    it("throws and propagates error when routeAlert fails", async () => {
+      verifySupplyMock.mockResolvedValue({ match: false, mismatchPercentage: 0.05 });
+      routeAlertMock.mockRejectedValueOnce(new Error("alert service unavailable"));
+
+      await expect(
+        processMonitorJob({ id: "job-11", data: { assetCode: "USDC" } } as any)
+      ).rejects.toThrow("alert service unavailable");
+    });
+
+    it("returns supplyCheck data in the result object", async () => {
+      const supplyCheck = { match: true, mismatchPercentage: 0, stellarSupply: 500_000, evmSupply: 500_000 };
+      verifySupplyMock.mockResolvedValue(supplyCheck);
+
+      const result = await processMonitorJob({ id: "job-12", data: { assetCode: "EURC" } } as any);
+
+      expect(result.supplyCheck).toMatchObject(supplyCheck);
+    });
   });
 });

--- a/backend/tests/workers/bridgeMonitor.worker.test.ts
+++ b/backend/tests/workers/bridgeMonitor.worker.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ─── Hoisted mocks ───────────────────────────────────────────────────────────
+const verifySupplyMock = vi.hoisted(() => vi.fn());
+const routeAlertMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const checkDedupMock = vi.hoisted(() =>
+  vi.fn().mockReturnValue({ isDuplicate: false, action: "allow" })
+);
+const dbInsertMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const dbTableMock = vi.hoisted(() => vi.fn(() => ({ insert: dbInsertMock })));
+
+vi.mock("../../src/services/bridge.service.js", () => ({
+  BridgeService: class {
+    verifySupply = verifySupplyMock;
+  },
+}));
+
+vi.mock("../../src/services/alertRouting.service.js", () => ({
+  alertRoutingService: { routeAlert: routeAlertMock },
+}));
+
+vi.mock("../../src/services/duplicateAlertCheck.service.js", () => ({
+  duplicateAlertCheckService: { check: checkDedupMock },
+}));
+
+vi.mock("../../src/database/connection.js", () => ({
+  getDatabase: () => dbTableMock,
+}));
+
+vi.mock("bullmq", () => ({
+  Worker: class {
+    on() {}
+  },
+  Queue: class {
+    add = vi.fn().mockResolvedValue({ id: "mock-job" });
+    on() {}
+  },
+}));
+
+vi.mock("../../src/config/index.js", () => ({
+  config: {
+    REDIS_HOST: "localhost",
+    REDIS_PORT: 6379,
+    BRIDGE_MISMATCH_THRESHOLD: 0.01,
+  },
+}));
+
+// Import the processor function under test
+import { processMonitorJob } from "../../src/workers/bridgeMonitor.worker.js";
+
+describe("bridgeMonitor.worker", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    checkDedupMock.mockReturnValue({ isDuplicate: false, action: "allow" });
+  });
+
+  describe("supply match path", () => {
+    it("returns success when supply matches", async () => {
+      verifySupplyMock.mockResolvedValue({ match: true, mismatchPercentage: 0 });
+
+      const result = await processMonitorJob({ id: "job-1", data: { assetCode: "USDC" } } as any);
+
+      expect(result.success).toBe(true);
+      expect(result.assetCode).toBe("USDC");
+    });
+
+    it("does not trigger alert when supply matches", async () => {
+      verifySupplyMock.mockResolvedValue({ match: true, mismatchPercentage: 0 });
+
+      await processMonitorJob({ id: "job-1", data: { assetCode: "USDC" } } as any);
+
+      expect(routeAlertMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("supply mismatch alert path", () => {
+    it("routes alert when supply mismatches and not duplicate", async () => {
+      verifySupplyMock.mockResolvedValue({ match: false, mismatchPercentage: 0.05 });
+
+      await processMonitorJob({ id: "job-2", data: { assetCode: "USDC" } } as any);
+
+      expect(routeAlertMock).toHaveBeenCalledOnce();
+      expect(routeAlertMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          assetCode: "USDC",
+          sourceType: "supply_mismatch",
+          severity: "high",
+        })
+      );
+    });
+
+    it("alert contains correct triggeredValue and metric", async () => {
+      verifySupplyMock.mockResolvedValue({ match: false, mismatchPercentage: 0.08 });
+
+      await processMonitorJob({ id: "job-3", data: { assetCode: "EURC" } } as any);
+
+      const call = routeAlertMock.mock.calls[0][0];
+      expect(call.triggeredValue).toBeCloseTo(0.08);
+      expect(call.metric).toBe("supply_mismatch_pct");
+    });
+  });
+
+  describe("deduplication", () => {
+    it("suppresses alert when duplicate check blocks", async () => {
+      verifySupplyMock.mockResolvedValue({ match: false, mismatchPercentage: 0.05 });
+      checkDedupMock.mockReturnValue({ isDuplicate: true, action: "block", reason: "within window" });
+
+      await processMonitorJob({ id: "job-4", data: { assetCode: "USDC" } } as any);
+
+      expect(routeAlertMock).not.toHaveBeenCalled();
+    });
+
+    it("allows alert when duplicate check escalates", async () => {
+      verifySupplyMock.mockResolvedValue({ match: false, mismatchPercentage: 0.05 });
+      checkDedupMock.mockReturnValue({ isDuplicate: true, action: "escalate" });
+
+      await processMonitorJob({ id: "job-5", data: { assetCode: "USDC" } } as any);
+
+      expect(routeAlertMock).toHaveBeenCalledOnce();
+    });
+
+    it("passes correct event fields to duplicate check", async () => {
+      verifySupplyMock.mockResolvedValue({ match: false, mismatchPercentage: 0.03 });
+
+      await processMonitorJob({ id: "job-6", data: { assetCode: "EURC" } } as any);
+
+      expect(checkDedupMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          assetCode: "EURC",
+          alertType: "supply_mismatch",
+          priority: "high",
+        })
+      );
+    });
+  });
+
+  describe("persistence", () => {
+    it("persists monitoring result after every job", async () => {
+      verifySupplyMock.mockResolvedValue({ match: true, mismatchPercentage: 0 });
+
+      await processMonitorJob({ id: "job-7", data: { assetCode: "USDC" } } as any);
+
+      expect(dbTableMock).toHaveBeenCalledWith("bridge_monitor_results");
+      expect(dbInsertMock).toHaveBeenCalledWith(
+        expect.objectContaining({ asset_code: "USDC", supply_match: true })
+      );
+    });
+
+    it("persists mismatch result with correct fields", async () => {
+      verifySupplyMock.mockResolvedValue({ match: false, mismatchPercentage: 0.07 });
+
+      await processMonitorJob({ id: "job-8", data: { assetCode: "USDC" } } as any);
+
+      expect(dbInsertMock).toHaveBeenCalledWith(
+        expect.objectContaining({ supply_match: false, mismatch_pct: 0.07 })
+      );
+    });
+
+    it("continues even when persistence fails", async () => {
+      verifySupplyMock.mockResolvedValue({ match: true, mismatchPercentage: 0 });
+      dbInsertMock.mockRejectedValueOnce(new Error("DB down"));
+
+      const result = await processMonitorJob({ id: "job-9", data: { assetCode: "USDC" } } as any);
+
+      expect(result.success).toBe(true);
+    });
+  });
+});

--- a/backend/tests/workers/bridgeMonitor.worker.test.ts
+++ b/backend/tests/workers/bridgeMonitor.worker.test.ts
@@ -184,6 +184,19 @@ describe("bridgeMonitor.worker", () => {
     });
   });
 
+  describe("alert rule ID consistency", () => {
+    it("uses the same ruleId for dedup check and alert routing", async () => {
+      verifySupplyMock.mockResolvedValue({ match: false, mismatchPercentage: 0.04 });
+
+      await processMonitorJob({ id: "job-13", data: { assetCode: "USDC" } } as any);
+
+      const dedupCall = checkDedupMock.mock.calls[0][0];
+      const alertCall = routeAlertMock.mock.calls[0][0];
+      expect(dedupCall.ruleId).toBe(alertCall.alertRuleId);
+      expect(dedupCall.ruleId).toBe("bridge-monitor-USDC");
+    });
+  });
+
   describe("alert routing resilience", () => {
     it("throws and propagates error when routeAlert fails", async () => {
       verifySupplyMock.mockResolvedValue({ match: false, mismatchPercentage: 0.05 });


### PR DESCRIPTION
Closes #670

## What changed
- Imported `alertRoutingService` and `duplicateAlertCheckService` into the bridge monitor worker
- Added `buildMismatchAlert` helper that constructs a `RouteableAlert` with correct severity, metric, and threshold from config
- Added deduplication check before routing each mismatch alert — blocked duplicates are suppressed, escalated/reviewed ones are allowed through
- Added `persistMonitorResult` that writes to the `bridge_monitor_results` TimescaleDB hypertable (time, asset_code, supply_match, mismatch_pct, stellar_supply, evm_supply) with error-swallowing so a DB outage never kills the job
- Extracted core logic into exported `processMonitorJob` for unit testability without spinning up the BullMQ worker

## Why
- Supply mismatch events were logged but never routed to notification channels or persisted for trend analysis
- Without persistence, historical mismatch data is lost between worker restarts

## How to test
- Run `vitest backend/tests/workers/bridgeMonitor.worker.test.ts` — 13 unit tests cover: supply match (no alert), mismatch alert routing, deduplication block/escalate/pass, persistence on every job, stellarSupply/evmSupply column values, DB-failure resilience, ruleId/alertRuleId consistency