### PR TITLE
feat: persist health scores to TimescaleDB and trigger deteriorating trend alerts

### DIFF
--- a/backend/src/workers/healthCheck.worker.ts
+++ b/backend/src/workers/healthCheck.worker.ts
@@ -61,6 +61,12 @@ async function routeDeterioratingAlerts(scores: HealthScore[]): Promise<void> {
   }
 }
 
+/**
+ * Inserts one row per score into health_scores (TimescaleDB hypertable).
+ * Columns: time, symbol, overall_score, liquidity_depth_score, price_stability_score,
+ *          bridge_uptime_score, reserve_backing_score, volume_trend_score.
+ * Errors per-symbol are swallowed so a single bad row never halts the batch.
+ */
 async function persistHealthScores(scores: HealthScore[]): Promise<void> {
   const now = new Date();
   for (const score of scores) {

--- a/backend/src/workers/healthCheck.worker.ts
+++ b/backend/src/workers/healthCheck.worker.ts
@@ -36,6 +36,33 @@ function buildDeterioratingAlert(score: HealthScore): RouteableAlert {
   };
 }
 
+async function routeDeterioratingAlerts(scores: HealthScore[]): Promise<void> {
+  const deteriorating = scores.filter((s) => s.trend === "deteriorating");
+  for (const score of deteriorating) {
+    const dedupEvent: Omit<AlertEvent, "eventId"> = {
+      ruleId: `health-check-${score.symbol}`,
+      assetCode: score.symbol,
+      alertType: "health_deterioration",
+      priority: score.overallScore < 0.3 ? "critical" : "high",
+      triggeredValue: score.overallScore,
+      threshold: config.HEALTH_SCORE_THRESHOLD ?? 0.5,
+      metric: "overall_health_score",
+      webhookDelivered: false,
+      onChainEventId: null,
+    };
+
+    const dedupResult = duplicateAlertCheckService.check(dedupEvent);
+
+    if (!dedupResult.isDuplicate || dedupResult.action !== "block") {
+      const alert = buildDeterioratingAlert(score);
+      await alertRoutingService.routeAlert(alert);
+      logger.info({ symbol: score.symbol, score: score.overallScore }, "Health deterioration alert routed");
+    } else {
+      logger.debug({ symbol: score.symbol, reason: dedupResult.reason }, "Health deterioration alert suppressed by deduplication");
+    }
+  }
+}
+
 async function persistHealthScores(scores: HealthScore[]): Promise<void> {
   const now = new Date();
   for (const score of scores) {

--- a/backend/src/workers/healthCheck.worker.ts
+++ b/backend/src/workers/healthCheck.worker.ts
@@ -9,6 +9,8 @@ import { HealthScoreModel } from "../database/models/healthScore.model.js";
 
 const QUEUE_NAME = "health-check";
 
+const healthScoreModel = new HealthScoreModel();
+
 const connection = {
   host: config.REDIS_HOST,
   port: config.REDIS_PORT,
@@ -16,6 +18,28 @@ const connection = {
 };
 
 export const healthCheckQueue = new Queue(QUEUE_NAME, { connection });
+
+import type { HealthScore } from "../services/health.service.js";
+
+async function persistHealthScores(scores: HealthScore[]): Promise<void> {
+  const now = new Date();
+  for (const score of scores) {
+    try {
+      await healthScoreModel.insert({
+        time: now,
+        symbol: score.symbol,
+        overall_score: score.overallScore,
+        liquidity_depth_score: score.factors.liquidityDepth,
+        price_stability_score: score.factors.priceStability,
+        bridge_uptime_score: score.factors.bridgeUptime,
+        reserve_backing_score: score.factors.reserveBacking,
+        volume_trend_score: score.factors.volumeTrend,
+      });
+    } catch (err) {
+      logger.error({ err, symbol: score.symbol }, "Failed to persist health score");
+    }
+  }
+}
 
 /**
  * Worker that periodically computes composite health scores for all

--- a/backend/src/workers/healthCheck.worker.ts
+++ b/backend/src/workers/healthCheck.worker.ts
@@ -2,6 +2,10 @@ import { Worker, Queue } from "bullmq";
 import { config } from "../config/index.js";
 import { HealthService } from "../services/health.service.js";
 import { logger } from "../utils/logger.js";
+import { alertRoutingService, type RouteableAlert } from "../services/alertRouting.service.js";
+import { duplicateAlertCheckService } from "../services/duplicateAlertCheck.service.js";
+import type { AlertEvent } from "../services/alert.service.js";
+import { HealthScoreModel } from "../database/models/healthScore.model.js";
 
 const QUEUE_NAME = "health-check";
 

--- a/backend/src/workers/healthCheck.worker.ts
+++ b/backend/src/workers/healthCheck.worker.ts
@@ -21,6 +21,21 @@ export const healthCheckQueue = new Queue(QUEUE_NAME, { connection });
 
 import type { HealthScore } from "../services/health.service.js";
 
+function buildDeterioratingAlert(score: HealthScore): RouteableAlert {
+  return {
+    eventTime: new Date(),
+    alertRuleId: `health-check-${score.symbol}`,
+    ownerAddress: "system",
+    ruleName: "Health Score Deteriorating",
+    assetCode: score.symbol,
+    sourceType: "health_deterioration",
+    severity: score.overallScore < 0.3 ? "critical" : "high",
+    triggeredValue: score.overallScore,
+    threshold: config.HEALTH_SCORE_THRESHOLD ?? 0.5,
+    metric: "overall_health_score",
+  };
+}
+
 async function persistHealthScores(scores: HealthScore[]): Promise<void> {
   const now = new Date();
   for (const score of scores) {

--- a/backend/src/workers/healthCheck.worker.ts
+++ b/backend/src/workers/healthCheck.worker.ts
@@ -1,6 +1,6 @@
 import { Worker, Queue } from "bullmq";
 import { config } from "../config/index.js";
-import { HealthService } from "../services/health.service.js";
+import { HealthService, type HealthScore } from "../services/health.service.js";
 import { logger } from "../utils/logger.js";
 import { alertRoutingService, type RouteableAlert } from "../services/alertRouting.service.js";
 import { duplicateAlertCheckService } from "../services/duplicateAlertCheck.service.js";
@@ -18,8 +18,6 @@ const connection = {
 };
 
 export const healthCheckQueue = new Queue(QUEUE_NAME, { connection });
-
-import type { HealthScore } from "../services/health.service.js";
 
 function buildDeterioratingAlert(score: HealthScore): RouteableAlert {
   return {
@@ -83,28 +81,29 @@ async function persistHealthScores(scores: HealthScore[]): Promise<void> {
   }
 }
 
+export async function processHealthCheckJob(job: { id?: string }) {
+  const healthService = new HealthService();
+  logger.info({ jobId: job.id }, "Processing health check job");
+
+  const scores = await healthService.computeAllHealthScores();
+
+  await persistHealthScores(scores);
+  await routeDeterioratingAlerts(scores);
+
+  logger.info({ assetCount: scores.length }, "Health check completed for all assets");
+  return { success: true, scores };
+}
+
 /**
  * Worker that periodically computes composite health scores for all
- * monitored assets and persists them for trending analysis.
+ * monitored assets, persists them to TimescaleDB, and triggers alerts
+ * for any asset whose trend has become deteriorating.
  */
 export const healthCheckWorker = new Worker(
   QUEUE_NAME,
   async (job) => {
-    const healthService = new HealthService();
-    logger.info({ jobId: job.id }, "Processing health check job");
-
     try {
-      const scores = await healthService.computeAllHealthScores();
-
-      // TODO: Persist health scores to TimescaleDB
-      // TODO: Detect deteriorating trends and trigger alerts
-
-      logger.info(
-        { assetCount: scores.length },
-        "Health check completed for all assets"
-      );
-
-      return { success: true, scores };
+      return await processHealthCheckJob(job);
     } catch (error) {
       logger.error({ error }, "Health check job failed");
       throw error;

--- a/backend/tests/workers/healthCheck.worker.test.ts
+++ b/backend/tests/workers/healthCheck.worker.test.ts
@@ -210,6 +210,20 @@ describe("healthCheck.worker", () => {
       expect(routeAlertMock).toHaveBeenCalledOnce();
     });
 
+    it("routes one alert per deteriorating asset", async () => {
+      computeAllHealthScoresMock.mockResolvedValue([
+        makeScore("USDC", 0.4, "deteriorating"),
+        makeScore("EURC", 0.35, "deteriorating"),
+      ]);
+
+      await processHealthCheckJob({ id: "job-multi" });
+
+      expect(routeAlertMock).toHaveBeenCalledTimes(2);
+      const symbols = routeAlertMock.mock.calls.map((c) => c[0].assetCode);
+      expect(symbols).toContain("USDC");
+      expect(symbols).toContain("EURC");
+    });
+
     it("passes matching ruleId to both dedup check and alert routing", async () => {
       computeAllHealthScoresMock.mockResolvedValue([makeScore("EURC", 0.4, "deteriorating")]);
 

--- a/backend/tests/workers/healthCheck.worker.test.ts
+++ b/backend/tests/workers/healthCheck.worker.test.ts
@@ -174,6 +174,23 @@ describe("healthCheck.worker", () => {
     });
   });
 
+  describe("error propagation", () => {
+    it("throws when computeAllHealthScores fails", async () => {
+      computeAllHealthScoresMock.mockRejectedValueOnce(new Error("health service down"));
+
+      await expect(processHealthCheckJob({ id: "job-err" })).rejects.toThrow("health service down");
+    });
+
+    it("does not persist or alert when health service fails", async () => {
+      computeAllHealthScoresMock.mockRejectedValueOnce(new Error("timeout"));
+
+      await expect(processHealthCheckJob({ id: "job-err2" })).rejects.toThrow();
+
+      expect(insertHealthScoreMock).not.toHaveBeenCalled();
+      expect(routeAlertMock).not.toHaveBeenCalled();
+    });
+  });
+
   describe("deduplication", () => {
     it("suppresses alert when dedup check blocks", async () => {
       computeAllHealthScoresMock.mockResolvedValue([makeScore("USDC", 0.4, "deteriorating")]);

--- a/backend/tests/workers/healthCheck.worker.test.ts
+++ b/backend/tests/workers/healthCheck.worker.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ─── Hoisted mocks ───────────────────────────────────────────────────────────
+const computeAllHealthScoresMock = vi.hoisted(() => vi.fn());
+const routeAlertMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const checkDedupMock = vi.hoisted(() =>
+  vi.fn().mockReturnValue({ isDuplicate: false, action: "allow" })
+);
+const insertHealthScoreMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+vi.mock("../../src/services/health.service.js", () => ({
+  HealthService: class {
+    computeAllHealthScores = computeAllHealthScoresMock;
+  },
+}));
+
+vi.mock("../../src/services/alertRouting.service.js", () => ({
+  alertRoutingService: { routeAlert: routeAlertMock },
+}));
+
+vi.mock("../../src/services/duplicateAlertCheck.service.js", () => ({
+  duplicateAlertCheckService: { check: checkDedupMock },
+}));
+
+vi.mock("../../src/database/models/healthScore.model.js", () => ({
+  HealthScoreModel: class {
+    insert = insertHealthScoreMock;
+  },
+}));
+
+vi.mock("bullmq", () => ({
+  Worker: class {
+    on() {}
+  },
+  Queue: class {
+    add = vi.fn().mockResolvedValue({ id: "mock-job" });
+    on() {}
+  },
+}));
+
+vi.mock("../../src/config/index.js", () => ({
+  config: {
+    REDIS_HOST: "localhost",
+    REDIS_PORT: 6379,
+    HEALTH_SCORE_THRESHOLD: 0.5,
+  },
+}));
+
+import { processHealthCheckJob } from "../../src/workers/healthCheck.worker.js";
+
+const makeScore = (symbol: string, overallScore: number, trend: "improving" | "stable" | "deteriorating") => ({
+  symbol,
+  overallScore,
+  factors: {
+    liquidityDepth: 0.8,
+    priceStability: 0.8,
+    bridgeUptime: 0.8,
+    reserveBacking: 0.8,
+    volumeTrend: 0.8,
+  },
+  trend,
+  lastUpdated: new Date().toISOString(),
+});
+
+describe("healthCheck.worker", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    checkDedupMock.mockReturnValue({ isDuplicate: false, action: "allow" });
+  });
+
+  describe("basic job execution", () => {
+    it("returns success with computed scores", async () => {
+      const scores = [makeScore("USDC", 0.85, "stable")];
+      computeAllHealthScoresMock.mockResolvedValue(scores);
+
+      const result = await processHealthCheckJob({ id: "job-1" });
+
+      expect(result.success).toBe(true);
+      expect(result.scores).toHaveLength(1);
+    });
+
+    it("persists all scores regardless of trend", async () => {
+      const scores = [
+        makeScore("USDC", 0.85, "stable"),
+        makeScore("EURC", 0.4, "deteriorating"),
+        makeScore("BTC", 0.9, "improving"),
+      ];
+      computeAllHealthScoresMock.mockResolvedValue(scores);
+
+      await processHealthCheckJob({ id: "job-2" });
+
+      expect(insertHealthScoreMock).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe("health score persistence", () => {
+    it("persists correct fields to health_scores table", async () => {
+      const score = makeScore("USDC", 0.85, "stable");
+      computeAllHealthScoresMock.mockResolvedValue([score]);
+
+      await processHealthCheckJob({ id: "job-3" });
+
+      expect(insertHealthScoreMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          symbol: "USDC",
+          overall_score: 0.85,
+          liquidity_depth_score: 0.8,
+          price_stability_score: 0.8,
+          bridge_uptime_score: 0.8,
+          reserve_backing_score: 0.8,
+          volume_trend_score: 0.8,
+        })
+      );
+    });
+
+    it("continues processing other scores when one insert fails", async () => {
+      const scores = [makeScore("USDC", 0.85, "stable"), makeScore("EURC", 0.9, "stable")];
+      computeAllHealthScoresMock.mockResolvedValue(scores);
+      insertHealthScoreMock.mockRejectedValueOnce(new Error("DB timeout"));
+
+      const result = await processHealthCheckJob({ id: "job-4" });
+
+      expect(result.success).toBe(true);
+      expect(insertHealthScoreMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("deteriorating trend alerting", () => {
+    it("routes alert only for deteriorating scores", async () => {
+      const scores = [
+        makeScore("USDC", 0.85, "stable"),
+        makeScore("EURC", 0.4, "deteriorating"),
+        makeScore("BTC", 0.9, "improving"),
+      ];
+      computeAllHealthScoresMock.mockResolvedValue(scores);
+
+      await processHealthCheckJob({ id: "job-5" });
+
+      expect(routeAlertMock).toHaveBeenCalledOnce();
+      expect(routeAlertMock).toHaveBeenCalledWith(
+        expect.objectContaining({ assetCode: "EURC" })
+      );
+    });
+
+    it("does not route any alert when no scores are deteriorating", async () => {
+      computeAllHealthScoresMock.mockResolvedValue([
+        makeScore("USDC", 0.85, "stable"),
+        makeScore("EURC", 0.95, "improving"),
+      ]);
+
+      await processHealthCheckJob({ id: "job-6" });
+
+      expect(routeAlertMock).not.toHaveBeenCalled();
+    });
+
+    it("assigns critical severity when overallScore is below 0.3", async () => {
+      computeAllHealthScoresMock.mockResolvedValue([makeScore("USDC", 0.2, "deteriorating")]);
+
+      await processHealthCheckJob({ id: "job-7" });
+
+      expect(routeAlertMock).toHaveBeenCalledWith(
+        expect.objectContaining({ severity: "critical", assetCode: "USDC" })
+      );
+    });
+
+    it("assigns high severity when overallScore is between 0.3 and threshold", async () => {
+      computeAllHealthScoresMock.mockResolvedValue([makeScore("EURC", 0.4, "deteriorating")]);
+
+      await processHealthCheckJob({ id: "job-8" });
+
+      expect(routeAlertMock).toHaveBeenCalledWith(
+        expect.objectContaining({ severity: "high", assetCode: "EURC" })
+      );
+    });
+  });
+
+  describe("deduplication", () => {
+    it("suppresses alert when dedup check blocks", async () => {
+      computeAllHealthScoresMock.mockResolvedValue([makeScore("USDC", 0.4, "deteriorating")]);
+      checkDedupMock.mockReturnValue({ isDuplicate: true, action: "block", reason: "within window" });
+
+      await processHealthCheckJob({ id: "job-9" });
+
+      expect(routeAlertMock).not.toHaveBeenCalled();
+    });
+
+    it("allows alert when dedup action is escalate", async () => {
+      computeAllHealthScoresMock.mockResolvedValue([makeScore("USDC", 0.4, "deteriorating")]);
+      checkDedupMock.mockReturnValue({ isDuplicate: true, action: "escalate" });
+
+      await processHealthCheckJob({ id: "job-10" });
+
+      expect(routeAlertMock).toHaveBeenCalledOnce();
+    });
+
+    it("passes matching ruleId to both dedup check and alert routing", async () => {
+      computeAllHealthScoresMock.mockResolvedValue([makeScore("EURC", 0.4, "deteriorating")]);
+
+      await processHealthCheckJob({ id: "job-11" });
+
+      const dedupCall = checkDedupMock.mock.calls[0][0];
+      const alertCall = routeAlertMock.mock.calls[0][0];
+      expect(dedupCall.ruleId).toBe("health-check-EURC");
+      expect(alertCall.alertRuleId).toBe("health-check-EURC");
+    });
+  });
+});

--- a/backend/tests/workers/healthCheck.worker.test.ts
+++ b/backend/tests/workers/healthCheck.worker.test.ts
@@ -234,5 +234,16 @@ describe("healthCheck.worker", () => {
       expect(dedupCall.ruleId).toBe("health-check-EURC");
       expect(alertCall.alertRuleId).toBe("health-check-EURC");
     });
+
+    it("triggeredValue in dedup event and alert matches the actual overallScore", async () => {
+      computeAllHealthScoresMock.mockResolvedValue([makeScore("USDC", 0.45, "deteriorating")]);
+
+      await processHealthCheckJob({ id: "job-12" });
+
+      const dedupCall = checkDedupMock.mock.calls[0][0];
+      const alertCall = routeAlertMock.mock.calls[0][0];
+      expect(dedupCall.triggeredValue).toBeCloseTo(0.45);
+      expect(alertCall.triggeredValue).toBeCloseTo(0.45);
+    });
   });
 });


### PR DESCRIPTION
Closes #671

## What changed
- Imported `HealthScoreModel`, `alertRoutingService`, and `duplicateAlertCheckService` into the health check worker
- Added `persistHealthScores` — loops all computed scores and inserts each into the `health_scores` TimescaleDB hypertable; per-symbol errors are swallowed so one bad row never aborts the batch
- Added `buildDeterioratingAlert` — constructs a `RouteableAlert` with `critical` severity when `overallScore < 0.3`, otherwise `high`
- Added `routeDeterioratingAlerts` — filters scores by `trend === "deteriorating"`, runs a deduplication check per asset, and routes only non-blocked alerts
- Extracted core logic into exported `processHealthCheckJob` for unit testability without spinning up the BullMQ worker

## Why
- Health scores were computed but immediately discarded — no historical trend data was stored in TimescaleDB
- Deteriorating trend signals existed on the `HealthScore` object but were never surfaced to the alert routing pipeline

## How to test
- Run `vitest backend/tests/workers/healthCheck.worker.test.ts` — 13 unit tests cover: basic job success, persistence of all scores, correct DB field mapping, per-symbol insert-failure resilience, alert routing for deteriorating scores only, critical vs high severity thresholds, deduplication block/escalate, multi-asset deterioration routing, ruleId/alertRuleId consistency, triggeredValue propagation