### PR TITLE
Feature/issues 680 695 719 720

### DIFF
--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -205,14 +205,23 @@ export interface StellarAssetConfig {
   issuer: string;
 }
 
+function validateIssuerAddress(asset: StellarAssetConfig): void {
+  if (asset.issuer !== "native" && asset.issuer.length !== 56) {
+    throw new Error(
+      `[config] Invalid issuer for ${asset.code}: expected 56 chars, got ${asset.issuer.length}`
+    );
+  }
+}
+
 export const SUPPORTED_ASSETS: StellarAssetConfig[] = [
   { code: "XLM", issuer: "native" },
   { code: "USDC", issuer: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN" },
   { code: "PYUSD", issuer: "GBHZAE5IQTOPQZ66TFWZYIYCHQ6T3GMWHDKFEXAKYWJ2BHLZQ227KRYE" },
   { code: "EURC", issuer: "GDQOE23CFSUMSVZZ4YRVXGW7PCFNIAHLMRAHDE4Z32DIBQGH4KZZK2KZ" },
-  // TODO: FOBXX issuer address is truncated (46 chars instead of 56). Verify correct address before enabling.
-  // { code: "FOBXX", issuer: "GBX7VUT2UTUKO2H76J26D7QYWNFW6C2NYN6K74Y3K43HGBXYZ" },
+  { code: "FOBXX", issuer: "GBHNGLLIE3KWGKCHIKMHJ5HVZHYIK7WTBE4QF5PLAKL4CJGSEU7HZIW5" },
 ];
+
+SUPPORTED_ASSETS.forEach(validateIssuerAddress);
 
 const parsed = envSchema.safeParse(process.env);
 

--- a/backend/tests/api/alerts.test.ts
+++ b/backend/tests/api/alerts.test.ts
@@ -1,0 +1,357 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
+import { buildServer } from "../../src/index.js";
+import type { FastifyInstance } from "fastify";
+
+vi.mock("../../src/api/middleware/auth.js", () => ({
+  authMiddleware: () => async () => {},
+}));
+
+const alertServiceMocks = vi.hoisted(() => ({
+  getRulesForOwner: vi.fn(),
+  createRule: vi.fn(),
+  getRule: vi.fn(),
+  updateRule: vi.fn(),
+  deleteRule: vi.fn(),
+  setRuleActive: vi.fn(),
+  getRecentAlerts: vi.fn(),
+  getAlertHistory: vi.fn(),
+  getAlertsForRule: vi.fn(),
+  getAlertStats: vi.fn(),
+  dryRunAlert: vi.fn(),
+  bulkCreateRules: vi.fn(),
+  bulkUpdateRules: vi.fn(),
+  bulkDeleteRules: vi.fn(),
+}));
+
+vi.mock("../../src/services/alert.service.js", () => ({
+  AlertService: class AlertService {
+    getRulesForOwner = alertServiceMocks.getRulesForOwner;
+    createRule = alertServiceMocks.createRule;
+    getRule = alertServiceMocks.getRule;
+    updateRule = alertServiceMocks.updateRule;
+    deleteRule = alertServiceMocks.deleteRule;
+    setRuleActive = alertServiceMocks.setRuleActive;
+    getRecentAlerts = alertServiceMocks.getRecentAlerts;
+    getAlertHistory = alertServiceMocks.getAlertHistory;
+    getAlertsForRule = alertServiceMocks.getAlertsForRule;
+    getAlertStats = alertServiceMocks.getAlertStats;
+    dryRunAlert = alertServiceMocks.dryRunAlert;
+    bulkCreateRules = alertServiceMocks.bulkCreateRules;
+    bulkUpdateRules = alertServiceMocks.bulkUpdateRules;
+    bulkDeleteRules = alertServiceMocks.bulkDeleteRules;
+  },
+}));
+
+const TEST_OWNER = "GBHNGLLIE3KWGKCHIKMHJ5HVZHYIK7WTBE4QF5PLAKL4CJGSEU7HZIW5";
+const TEST_RULE_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+const mockCondition = {
+  metric: "health_score",
+  alertType: "health_score_drop" as const,
+  compareOp: "lt" as const,
+  threshold: 80,
+};
+
+const mockRule = {
+  id: TEST_RULE_ID,
+  ownerAddress: TEST_OWNER,
+  name: "USDC health drop",
+  assetCode: "USDC",
+  conditions: [mockCondition],
+  conditionOp: "AND",
+  priority: "high",
+  cooldownSeconds: 300,
+  isActive: true,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+describe("Alerts API", () => {
+  let server: FastifyInstance;
+
+  beforeAll(async () => {
+    server = await buildServer();
+  });
+
+  afterAll(async () => {
+    await server.close();
+  });
+
+  beforeEach(() => {
+    Object.values(alertServiceMocks).forEach((mock) => mock.mockReset());
+  });
+
+  describe("GET /api/v1/alerts/rules", () => {
+    it("returns list of rules for a valid owner", async () => {
+      alertServiceMocks.getRulesForOwner.mockResolvedValue([mockRule]);
+
+      const response = await server.inject({
+        method: "GET",
+        url: `/api/v1/alerts/rules?owner=${TEST_OWNER}`,
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body).toHaveProperty("rules");
+      expect(Array.isArray(body.rules)).toBe(true);
+      expect(alertServiceMocks.getRulesForOwner).toHaveBeenCalledWith(TEST_OWNER);
+    });
+
+    it("returns 400 when owner query param is missing", async () => {
+      const response = await server.inject({
+        method: "GET",
+        url: "/api/v1/alerts/rules",
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+  });
+
+  describe("POST /api/v1/alerts/rules", () => {
+    it("creates a rule and returns 201", async () => {
+      alertServiceMocks.createRule.mockResolvedValue(mockRule);
+
+      const response = await server.inject({
+        method: "POST",
+        url: "/api/v1/alerts/rules",
+        payload: {
+          ownerAddress: TEST_OWNER,
+          name: "USDC health drop",
+          assetCode: "USDC",
+          conditions: [mockCondition],
+          conditionOp: "AND",
+          priority: "high",
+          cooldownSeconds: 300,
+        },
+      });
+
+      expect(response.statusCode).toBe(201);
+      const body = JSON.parse(response.body);
+      expect(body).toHaveProperty("rule");
+    });
+
+    it("returns 400 when required fields are missing", async () => {
+      const response = await server.inject({
+        method: "POST",
+        url: "/api/v1/alerts/rules",
+        payload: {
+          ownerAddress: TEST_OWNER,
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it("returns 400 when ownerAddress is missing", async () => {
+      const response = await server.inject({
+        method: "POST",
+        url: "/api/v1/alerts/rules",
+        payload: {
+          name: "USDC health drop",
+          assetCode: "USDC",
+          conditions: [{ metric: "health_score", operator: "lt", threshold: 80 }],
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+  });
+
+  describe("GET /api/v1/alerts/rules/:ruleId", () => {
+    it("returns a single rule by ID", async () => {
+      alertServiceMocks.getRule.mockResolvedValue(mockRule);
+
+      const response = await server.inject({
+        method: "GET",
+        url: `/api/v1/alerts/rules/${TEST_RULE_ID}`,
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body).toHaveProperty("rule");
+      expect(alertServiceMocks.getRule).toHaveBeenCalledWith(TEST_RULE_ID);
+    });
+
+    it("returns 404 when rule does not exist", async () => {
+      alertServiceMocks.getRule.mockResolvedValue(null);
+
+      const response = await server.inject({
+        method: "GET",
+        url: `/api/v1/alerts/rules/${TEST_RULE_ID}`,
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+  });
+
+  describe("PATCH /api/v1/alerts/rules/:ruleId", () => {
+    it("updates a rule and returns 200", async () => {
+      alertServiceMocks.updateRule.mockResolvedValue({ ...mockRule, name: "Updated name" });
+
+      const response = await server.inject({
+        method: "PATCH",
+        url: `/api/v1/alerts/rules/${TEST_RULE_ID}`,
+        payload: {
+          ownerAddress: TEST_OWNER,
+          name: "Updated name",
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body).toHaveProperty("rule");
+    });
+
+    it("returns 404 when rule does not exist", async () => {
+      alertServiceMocks.updateRule.mockResolvedValue(null);
+
+      const response = await server.inject({
+        method: "PATCH",
+        url: `/api/v1/alerts/rules/${TEST_RULE_ID}`,
+        payload: {
+          ownerAddress: TEST_OWNER,
+          name: "Updated name",
+        },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+  });
+
+  describe("DELETE /api/v1/alerts/rules/:ruleId", () => {
+    it("deletes a rule and returns 204", async () => {
+      alertServiceMocks.deleteRule.mockResolvedValue(true);
+
+      const response = await server.inject({
+        method: "DELETE",
+        url: `/api/v1/alerts/rules/${TEST_RULE_ID}`,
+        payload: {
+          ownerAddress: TEST_OWNER,
+        },
+      });
+
+      expect(response.statusCode).toBe(204);
+    });
+
+    it("returns 404 when rule does not exist", async () => {
+      alertServiceMocks.deleteRule.mockResolvedValue(false);
+
+      const response = await server.inject({
+        method: "DELETE",
+        url: `/api/v1/alerts/rules/${TEST_RULE_ID}`,
+        payload: {
+          ownerAddress: TEST_OWNER,
+        },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    it("returns 400 when ownerAddress is missing", async () => {
+      const response = await server.inject({
+        method: "DELETE",
+        url: `/api/v1/alerts/rules/${TEST_RULE_ID}`,
+        payload: {},
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+  });
+
+  describe("GET /api/v1/alerts/history", () => {
+    it("returns paginated alert history", async () => {
+      const mockEvents = [{ id: "evt1", ruleId: TEST_RULE_ID, firedAt: new Date().toISOString() }];
+      alertServiceMocks.getRecentAlerts.mockResolvedValue(mockEvents);
+
+      const response = await server.inject({
+        method: "GET",
+        url: "/api/v1/alerts/history",
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body).toHaveProperty("data");
+      expect(Array.isArray(body.data)).toBe(true);
+    });
+  });
+
+  describe("GET /api/v1/alerts/history/:assetCode", () => {
+    it("returns alert history for a specific asset", async () => {
+      const mockEvents = [{ id: "evt1", assetCode: "USDC", firedAt: new Date().toISOString() }];
+      alertServiceMocks.getAlertHistory.mockResolvedValue(mockEvents);
+
+      const response = await server.inject({
+        method: "GET",
+        url: "/api/v1/alerts/history/USDC",
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body).toHaveProperty("events");
+      expect(Array.isArray(body.events)).toBe(true);
+      expect(alertServiceMocks.getAlertHistory).toHaveBeenCalledWith("USDC", expect.any(Number));
+    });
+  });
+
+  describe("GET /api/v1/alerts/stats", () => {
+    it("returns alert statistics for a valid owner", async () => {
+      const mockStats = { totalRules: 3, activeRules: 2, totalFired: 10, lastFiredAt: null };
+      alertServiceMocks.getAlertStats.mockResolvedValue(mockStats);
+
+      const response = await server.inject({
+        method: "GET",
+        url: `/api/v1/alerts/stats?owner=${TEST_OWNER}`,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(alertServiceMocks.getAlertStats).toHaveBeenCalledWith(TEST_OWNER);
+    });
+
+    it("returns 400 when owner is missing", async () => {
+      const response = await server.inject({
+        method: "GET",
+        url: "/api/v1/alerts/stats",
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+  });
+
+  describe("GET /api/v1/alerts/recent", () => {
+    it("returns recent alert events", async () => {
+      const mockEvents = [{ id: "evt1", ruleId: TEST_RULE_ID, firedAt: new Date().toISOString() }];
+      alertServiceMocks.getRecentAlerts.mockResolvedValue(mockEvents);
+
+      const response = await server.inject({
+        method: "GET",
+        url: "/api/v1/alerts/recent",
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body).toHaveProperty("events");
+      expect(Array.isArray(body.events)).toBe(true);
+    });
+  });
+
+  describe("GET /api/v1/alerts/rules/:ruleId/events", () => {
+    it("returns events for a specific rule", async () => {
+      const mockEvents = [{ id: "evt1", ruleId: TEST_RULE_ID, firedAt: new Date().toISOString() }];
+      alertServiceMocks.getAlertsForRule.mockResolvedValue(mockEvents);
+
+      const response = await server.inject({
+        method: "GET",
+        url: `/api/v1/alerts/rules/${TEST_RULE_ID}/events`,
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body).toHaveProperty("events");
+      expect(Array.isArray(body.events)).toBe(true);
+      expect(alertServiceMocks.getAlertsForRule).toHaveBeenCalledWith(
+        TEST_RULE_ID,
+        expect.any(Number)
+      );
+    });
+  });
+});

--- a/backend/tests/api/config.test.ts
+++ b/backend/tests/api/config.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { SUPPORTED_ASSETS, type StellarAssetConfig } from "../../src/config/index.js";
+
+describe("SUPPORTED_ASSETS configuration", () => {
+  it("includes FOBXX as a tracked asset", () => {
+    const fobxx = SUPPORTED_ASSETS.find((a) => a.code === "FOBXX");
+    expect(fobxx).toBeDefined();
+  });
+
+  it("FOBXX has a valid 56-character Stellar issuer address", () => {
+    const fobxx = SUPPORTED_ASSETS.find((a) => a.code === "FOBXX");
+    expect(fobxx?.issuer).toHaveLength(56);
+  });
+
+  it("all non-native issuers are exactly 56 characters", () => {
+    for (const asset of SUPPORTED_ASSETS) {
+      if (asset.issuer === "native") continue;
+      expect(asset.issuer).toHaveLength(56);
+    }
+  });
+
+  it("startup validation rejects a truncated issuer address at module load time", () => {
+    const badAsset: StellarAssetConfig = {
+      code: "TEST",
+      issuer: "GBX7VUT2UTUKO2H76J26D7QYWNFW6C2NYN6K74Y3K43HGBXYZ",
+    };
+
+    function validateIssuerAddress(asset: StellarAssetConfig): void {
+      if (asset.issuer !== "native" && asset.issuer.length !== 56) {
+        throw new Error(
+          `[config] Invalid issuer for ${asset.code}: expected 56 chars, got ${asset.issuer.length}`
+        );
+      }
+    }
+
+    expect(() => validateIssuerAddress(badAsset)).toThrow(
+      /Invalid issuer for TEST/
+    );
+  });
+
+  it("startup validation passes for a valid 56-character issuer", () => {
+    const goodAsset: StellarAssetConfig = {
+      code: "TEST",
+      issuer: "GBHNGLLIE3KWGKCHIKMHJ5HVZHYIK7WTBE4QF5PLAKL4CJGSEU7HZIW5",
+    };
+
+    function validateIssuerAddress(asset: StellarAssetConfig): void {
+      if (asset.issuer !== "native" && asset.issuer.length !== 56) {
+        throw new Error(
+          `[config] Invalid issuer for ${asset.code}: expected 56 chars, got ${asset.issuer.length}`
+        );
+      }
+    }
+
+    expect(() => validateIssuerAddress(goodAsset)).not.toThrow();
+  });
+
+  it("startup validation passes for the XLM native entry", () => {
+    function validateIssuerAddress(asset: StellarAssetConfig): void {
+      if (asset.issuer !== "native" && asset.issuer.length !== 56) {
+        throw new Error(
+          `[config] Invalid issuer for ${asset.code}: expected 56 chars, got ${asset.issuer.length}`
+        );
+      }
+    }
+
+    expect(() => validateIssuerAddress({ code: "XLM", issuer: "native" })).not.toThrow();
+  });
+});

--- a/contracts/soroban/src/rate_limiter.rs
+++ b/contracts/soroban/src/rate_limiter.rs
@@ -2073,4 +2073,149 @@ mod tests {
             ConsumeResult::Rejected(RateLimitError::MonthlyValueLimitExceeded as u32)
         );
     }
+
+    // -----------------------------------------------------------------------
+    // Per-user isolation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_per_user_isolation() {
+        let (env, client, _admin) = setup();
+        let user_a = Address::generate(&env);
+        let user_b = Address::generate(&env);
+
+        // User A consumes near the daily limit
+        let near_limit = DEFAULT_DAILY_LIMIT - 1;
+        let result_a = client.try_consume_limit(&user_a, &near_limit);
+        assert!(result_a.is_ok());
+
+        // User B is unaffected — still has full capacity
+        let check_b = client.check_limit(&user_b, &DEFAULT_DAILY_LIMIT);
+        assert!(check_b.allowed);
+        assert_eq!(check_b.daily_remaining_value, DEFAULT_DAILY_LIMIT);
+
+        let result_b = client.try_consume_limit(&user_b, &100_000_000);
+        assert!(result_b.is_ok());
+    }
+
+    // -----------------------------------------------------------------------
+    // Rejected consume must not record usage
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_rejected_consume_does_not_record_usage() {
+        let (env, client, _admin) = setup();
+        let user = Address::generate(&env);
+
+        // Attempt to consume more than the daily limit in one call — must be rejected
+        let result = client.consume_limit(&user, &(DEFAULT_DAILY_LIMIT + 1));
+        assert_eq!(
+            result,
+            ConsumeResult::Rejected(RateLimitError::DailyValueLimitExceeded as u32)
+        );
+
+        // Daily remaining must be unchanged — rejected transfers must not be recorded
+        let check = client.check_limit(&user, &1);
+        assert!(check.allowed);
+        assert_eq!(check.daily_remaining_value, DEFAULT_DAILY_LIMIT);
+    }
+
+    // -----------------------------------------------------------------------
+    // Weekly count limit enforcement
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_weekly_count_limit_exceeded() {
+        let (env, client, admin) = setup();
+        let user = Address::generate(&env);
+
+        // Set tight weekly count limit (3 transactions per week)
+        let limits = UserLimits {
+            daily_value: 1_000_000_000_000,
+            weekly_value: 5_000_000_000_000,
+            monthly_value: 15_000_000_000_000,
+            daily_count: 1000,
+            weekly_count: 3,
+            monthly_count: 300,
+        };
+        client.update_user_limit(&admin, &user, &limits);
+
+        // Consume across two different days to avoid daily count limit
+        client.consume_limit(&user, &1);
+        env.ledger().set_timestamp(1_000_000 + DAY_SECS + 1);
+        client.consume_limit(&user, &1);
+        env.ledger().set_timestamp(1_000_000 + 2 * DAY_SECS + 1);
+        client.consume_limit(&user, &1);
+
+        // Fourth transaction this week must be rejected on count
+        env.ledger().set_timestamp(1_000_000 + 3 * DAY_SECS + 1);
+        let result = client.consume_limit(&user, &1);
+        assert_eq!(
+            result,
+            ConsumeResult::Rejected(RateLimitError::WeeklyCountLimitExceeded as u32)
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // check_limit reflects reset after window advance
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_check_limit_reflects_window_reset() {
+        let (env, client, _admin) = setup();
+        let user = Address::generate(&env);
+
+        // Consume some of the daily limit
+        let consumed = 500_000_000i128;
+        client.consume_limit(&user, &consumed);
+
+        // Before reset: remaining is reduced
+        let check_before = client.check_limit(&user, &1);
+        assert_eq!(
+            check_before.daily_remaining_value,
+            DEFAULT_DAILY_LIMIT - consumed
+        );
+
+        // Advance past one full day
+        env.ledger().set_timestamp(1_000_000 + DAY_SECS + 1);
+
+        // After reset: full limit is available again
+        let check_after = client.check_limit(&user, &1);
+        assert!(check_after.allowed);
+        assert_eq!(check_after.daily_remaining_value, DEFAULT_DAILY_LIMIT);
+    }
+
+    // -----------------------------------------------------------------------
+    // Global limit accumulates across distinct users
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_global_limit_accumulates_across_users() {
+        let (env, client, admin) = setup();
+
+        // Set global daily limit equal to exactly 2× a single large transfer
+        let single_transfer = 500_000_000i128;
+        let gl = GlobalLimits {
+            daily_value: single_transfer * 2,
+            weekly_value: single_transfer * 10,
+        };
+        client.update_global_limit(&admin, &gl);
+
+        let user_a = Address::generate(&env);
+        let user_b = Address::generate(&env);
+        let user_c = Address::generate(&env);
+
+        // Two users fill the global daily pool
+        let r1 = client.try_consume_limit(&user_a, &single_transfer);
+        assert!(r1.is_ok());
+        let r2 = client.try_consume_limit(&user_b, &single_transfer);
+        assert!(r2.is_ok());
+
+        // Third user is blocked — global pool exhausted
+        let result = client.consume_limit(&user_c, &1);
+        assert_eq!(
+            result,
+            ConsumeResult::Rejected(RateLimitError::GlobalDailyLimitExceeded as u32)
+        );
+    }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -40,6 +40,7 @@ const ExportScheduler = lazy(() => import("./pages/ExportScheduler"));
 const AssetComparison = lazy(() => import("./pages/AssetComparison"));
 const MetricsSidebarPage = lazy(() => import("./pages/MetricsSidebar"));
 const CrossChainVerification = lazy(() => import("./pages/CrossChainVerification"));
+const FreshnessMonitoring = lazy(() => import("./pages/FreshnessMonitoring"));
 
 function NotificationInitializer() {
   useNotifications();
@@ -96,6 +97,7 @@ function App() {
               <Route path="/asset-comparison" element={<AssetComparison />} />
               <Route path="/metrics-sidebar" element={<MetricsSidebarPage />} />
               <Route path="/cross-chain-verification" element={<CrossChainVerification />} />
+              <Route path="/freshness" element={<FreshnessMonitoring />} />
             </Route>
           </Routes>
         </Suspense>

--- a/frontend/src/components/MobileNav/navigation.ts
+++ b/frontend/src/components/MobileNav/navigation.ts
@@ -23,6 +23,7 @@ export const navGroups: NavGroup[] = [
       { to: "/transactions", label: "Transactions", description: "Recent bridge transfer activity" },
       { to: "/reconciliation", label: "Reconciliation", description: "Supply drift and reserve backing triage" },
       { to: "/cross-chain-verification", label: "State Verification", description: "Cryptographic cross-chain state proof validation" },
+      { to: "/freshness", label: "Freshness", description: "Data freshness and staleness status for monitored sources" },
       { to: "/analytics", label: "Analytics", description: "Trend analysis and health scoring" },
       { to: "/analytics/metric-builder", label: "Metric Builder", description: "Create and save custom SQL metrics" },
       { to: "/data-provenance", label: "Provenance", description: "Trace metric lineage from source to destination" },

--- a/frontend/src/hooks/useFreshness.ts
+++ b/frontend/src/hooks/useFreshness.ts
@@ -1,0 +1,48 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  getFreshnessSnapshot,
+  getFreshnessSource,
+  getFreshnessSourceTrend,
+  getFreshnessAlerts,
+} from "../services/api";
+
+type QueryRefreshOptions = {
+  refetchInterval?: number | false;
+  refetchOnWindowFocus?: boolean;
+};
+
+export function useFreshnessSnapshot(options?: QueryRefreshOptions) {
+  return useQuery({
+    queryKey: ["freshness"],
+    queryFn: () => getFreshnessSnapshot(),
+    refetchInterval: options?.refetchInterval,
+    refetchOnWindowFocus: options?.refetchOnWindowFocus,
+  });
+}
+
+export function useFreshnessSource(source: string, options?: QueryRefreshOptions) {
+  return useQuery({
+    queryKey: ["freshness-source", source],
+    queryFn: () => getFreshnessSource(source),
+    enabled: !!source,
+    refetchInterval: options?.refetchInterval,
+    refetchOnWindowFocus: options?.refetchOnWindowFocus,
+  });
+}
+
+export function useFreshnessSourceTrend(source: string, options?: QueryRefreshOptions) {
+  return useQuery({
+    queryKey: ["freshness-trend", source],
+    queryFn: () => getFreshnessSourceTrend(source),
+    enabled: !!source,
+    refetchInterval: options?.refetchInterval,
+    refetchOnWindowFocus: options?.refetchOnWindowFocus,
+  });
+}
+
+export function useFreshnessAlerts() {
+  return useQuery({
+    queryKey: ["freshness-alerts"],
+    queryFn: getFreshnessAlerts,
+  });
+}

--- a/frontend/src/pages/FreshnessMonitoring.test.tsx
+++ b/frontend/src/pages/FreshnessMonitoring.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+import FreshnessMonitoring from "./FreshnessMonitoring";
+
+vi.mock("../hooks/useFreshness", () => ({
+  useFreshnessSnapshot: () => ({
+    data: {
+      sources: [
+        {
+          key: "stellar-horizon",
+          label: "Stellar Horizon",
+          status: "fresh",
+          lastUpdated: new Date(Date.now() - 5000).toISOString(),
+          expectedIntervalMs: 30000,
+          trend: "stable",
+        },
+        {
+          key: "circle-usdc",
+          label: "Circle USDC",
+          status: "stale",
+          lastUpdated: new Date(Date.now() - 600000).toISOString(),
+          expectedIntervalMs: 60000,
+          trend: "degrading",
+        },
+      ],
+      staleSources: 1,
+      freshSources: 1,
+      timestamp: new Date().toISOString(),
+    },
+    isLoading: false,
+    refetch: vi.fn(),
+  }),
+  useFreshnessAlerts: () => ({
+    data: {
+      alerts: [
+        {
+          source: "circle-usdc",
+          label: "Circle USDC",
+          severity: "warning",
+          message: "No update in 10 minutes",
+          since: new Date().toISOString(),
+        },
+      ],
+      timestamp: new Date().toISOString(),
+    },
+  }),
+}));
+
+vi.mock("../hooks/useRefreshControls", () => ({
+  useRefreshControls: () => ({
+    preferences: {
+      autoRefreshEnabled: false,
+      refreshIntervalMs: 30000,
+      refreshOnFocus: false,
+      selectedTargetIds: [],
+    },
+    setAutoRefreshEnabled: vi.fn(),
+    setRefreshIntervalMs: vi.fn(),
+    setRefreshOnFocus: vi.fn(),
+    setSelectedTargetIds: vi.fn(),
+    refreshNow: vi.fn(),
+    cancelRefresh: vi.fn(),
+    isRefreshing: false,
+    lastUpdatedAt: null,
+  }),
+}));
+
+vi.mock("../components/RefreshControls", () => ({
+  default: () => null,
+}));
+
+describe("FreshnessMonitoring", () => {
+  function renderPage() {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <FreshnessMonitoring />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  }
+
+  it("renders the page heading", () => {
+    renderPage();
+    expect(screen.getByRole("heading", { name: "Data Freshness" })).toBeInTheDocument();
+  });
+
+  it("shows the summary counts", () => {
+    renderPage();
+    expect(screen.getByText("Total Sources")).toBeInTheDocument();
+    expect(screen.getAllByText("Fresh").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Stale").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders a row for each data source", () => {
+    renderPage();
+    expect(screen.getByText("Stellar Horizon")).toBeInTheDocument();
+    expect(screen.getByText("Circle USDC")).toBeInTheDocument();
+  });
+
+  it("shows a Stale badge for the stale source", () => {
+    renderPage();
+    const staleElements = screen.getAllByText("Stale");
+    expect(staleElements.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows a Fresh badge for the fresh source", () => {
+    renderPage();
+    const freshElements = screen.getAllByText("Fresh");
+    expect(freshElements.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders freshness alerts when present", () => {
+    renderPage();
+    expect(screen.getByText(/Freshness Alerts/)).toBeInTheDocument();
+    expect(screen.getByText(/No update in 10 minutes/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/FreshnessMonitoring.tsx
+++ b/frontend/src/pages/FreshnessMonitoring.tsx
@@ -1,0 +1,194 @@
+import { useRefreshControls } from "../hooks/useRefreshControls";
+import { useFreshnessSnapshot, useFreshnessAlerts } from "../hooks/useFreshness";
+import RefreshControls from "../components/RefreshControls";
+import { SkeletonCard } from "../components/Skeleton";
+
+function StatusBadge({ status }: { status: "fresh" | "stale" | "unknown" }) {
+  if (status === "fresh") {
+    return (
+      <span className="inline-flex items-center rounded-full bg-green-900/30 px-2.5 py-0.5 text-xs font-medium text-green-400">
+        Fresh
+      </span>
+    );
+  }
+  if (status === "stale") {
+    return (
+      <span className="inline-flex items-center rounded-full bg-amber-900/30 px-2.5 py-0.5 text-xs font-medium text-amber-400">
+        Stale
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center rounded-full bg-stellar-border px-2.5 py-0.5 text-xs font-medium text-stellar-text-secondary">
+      Unknown
+    </span>
+  );
+}
+
+function TrendIcon({ trend }: { trend?: string | null }) {
+  if (trend === "improving") return <span className="text-green-400" aria-label="Improving">↑</span>;
+  if (trend === "degrading") return <span className="text-amber-400" aria-label="Degrading">↓</span>;
+  return <span className="text-stellar-text-secondary" aria-label="Stable">→</span>;
+}
+
+function formatAge(lastUpdated: string | null): string {
+  if (!lastUpdated) return "—";
+  const ms = Date.now() - new Date(lastUpdated).getTime();
+  const secs = Math.floor(ms / 1000);
+  if (secs < 60) return `${secs}s ago`;
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+export default function FreshnessMonitoring() {
+  const refreshControls = useRefreshControls({
+    viewId: "freshness",
+    targets: [{ id: "freshness", label: "Freshness data", queryKey: ["freshness"] }],
+    defaultIntervalMs: 30_000,
+  });
+
+  const { data, isLoading, refetch } = useFreshnessSnapshot({
+    refetchInterval: refreshControls.preferences.autoRefreshEnabled
+      ? refreshControls.preferences.refreshIntervalMs
+      : false,
+    refetchOnWindowFocus: refreshControls.preferences.refreshOnFocus,
+  });
+
+  const { data: alertsData } = useFreshnessAlerts();
+
+  const sources = data?.sources ?? [];
+  const staleCount = data?.staleSources ?? 0;
+  const freshCount = data?.freshSources ?? 0;
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-3xl font-bold text-stellar-text-primary">Data Freshness</h1>
+        <p className="mt-2 text-stellar-text-secondary">
+          Monitor how recently each data source was updated and identify stale entries.
+        </p>
+      </div>
+
+      <RefreshControls
+        autoRefreshEnabled={refreshControls.preferences.autoRefreshEnabled}
+        onAutoRefreshEnabledChange={refreshControls.setAutoRefreshEnabled}
+        refreshIntervalMs={refreshControls.preferences.refreshIntervalMs}
+        onRefreshIntervalChange={refreshControls.setRefreshIntervalMs}
+        refreshOnFocus={refreshControls.preferences.refreshOnFocus}
+        onRefreshOnFocusChange={refreshControls.setRefreshOnFocus}
+        targets={[{ id: "freshness", label: "Freshness data", refetch }]}
+        selectedTargetIds={refreshControls.preferences.selectedTargetIds}
+        onSelectedTargetIdsChange={refreshControls.setSelectedTargetIds}
+        onRefresh={refreshControls.refreshNow}
+        onCancelRefresh={refreshControls.cancelRefresh}
+        isRefreshing={refreshControls.isRefreshing}
+        lastUpdatedAt={refreshControls.lastUpdatedAt}
+      />
+
+      {!isLoading && (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <div className="rounded-lg border border-stellar-border bg-stellar-card p-4">
+            <p className="text-sm text-stellar-text-secondary">Total Sources</p>
+            <p className="mt-1 text-2xl font-semibold text-stellar-text-primary">
+              {sources.length}
+            </p>
+          </div>
+          <div className="rounded-lg border border-green-800/40 bg-green-900/10 p-4">
+            <p className="text-sm text-stellar-text-secondary">Fresh</p>
+            <p className="mt-1 text-2xl font-semibold text-green-400">{freshCount}</p>
+          </div>
+          <div className="rounded-lg border border-amber-800/40 bg-amber-900/10 p-4">
+            <p className="text-sm text-stellar-text-secondary">Stale</p>
+            <p className="mt-1 text-2xl font-semibold text-amber-400">{staleCount}</p>
+          </div>
+        </div>
+      )}
+
+      {alertsData && alertsData.alerts.length > 0 && (
+        <div className="rounded-lg border border-amber-800/40 bg-amber-900/10 p-4">
+          <h2 className="text-sm font-semibold text-amber-400 mb-2">
+            Freshness Alerts ({alertsData.alerts.length})
+          </h2>
+          <ul className="space-y-1">
+            {alertsData.alerts.map((alert, i) => (
+              <li key={i} className="text-sm text-stellar-text-secondary">
+                <span className="font-medium text-amber-300">[{alert.severity.toUpperCase()}]</span>{" "}
+                {alert.label}: {alert.message}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <div className="rounded-lg border border-stellar-border bg-stellar-card">
+        <div className="px-6 py-4 border-b border-stellar-border">
+          <h2 className="text-lg font-semibold text-stellar-text-primary">Source Freshness Status</h2>
+        </div>
+
+        {isLoading ? (
+          <div className="p-6 space-y-4">
+            {[1, 2, 3].map((i) => (
+              <SkeletonCard key={i} rows={2} ariaLabel={`Loading source ${i}`} />
+            ))}
+          </div>
+        ) : sources.length === 0 ? (
+          <div className="px-6 py-8 text-center">
+            <p className="text-stellar-text-secondary">
+              No freshness data available. Staleness detection will populate this page once monitoring
+              is active.
+            </p>
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <caption className="sr-only">Data source freshness status</caption>
+              <thead>
+                <tr className="text-left text-stellar-text-secondary border-b border-stellar-border">
+                  <th scope="col" className="px-6 py-3">Source</th>
+                  <th scope="col" className="px-6 py-3">Status</th>
+                  <th scope="col" className="px-6 py-3">Last Updated</th>
+                  <th scope="col" className="px-6 py-3">Expected Interval</th>
+                  <th scope="col" className="px-6 py-3">Trend</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-stellar-border">
+                {sources.map((source) => (
+                  <tr
+                    key={source.key}
+                    className={
+                      source.status === "stale"
+                        ? "bg-amber-900/10"
+                        : "hover:bg-stellar-dark/40"
+                    }
+                  >
+                    <td className="px-6 py-4">
+                      <div className="font-medium text-stellar-text-primary">{source.label}</div>
+                      <div className="text-xs text-stellar-text-secondary">{source.key}</div>
+                    </td>
+                    <td className="px-6 py-4">
+                      <StatusBadge status={source.status} />
+                    </td>
+                    <td className="px-6 py-4 text-stellar-text-secondary">
+                      {formatAge(source.lastUpdated)}
+                    </td>
+                    <td className="px-6 py-4 text-stellar-text-secondary">
+                      {source.expectedIntervalMs > 0
+                        ? `${Math.round(source.expectedIntervalMs / 1000)}s`
+                        : "—"}
+                    </td>
+                    <td className="px-6 py-4">
+                      <TrendIcon trend={source.trend} />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -987,3 +987,72 @@ export function triggerCrossChainVerification(bridgeId: string): Promise<CrossCh
     { method: "POST" }
   );
 }
+
+export interface FreshnessSourceStatus {
+  key: string;
+  label: string;
+  status: "fresh" | "stale" | "unknown";
+  lastUpdated: string | null;
+  expectedIntervalMs: number;
+  trend?: "improving" | "stable" | "degrading" | null;
+  ageMs?: number | null;
+}
+
+export interface FreshnessSnapshot {
+  sources: FreshnessSourceStatus[];
+  staleSources: number;
+  freshSources: number;
+  timestamp: string;
+}
+
+export interface FreshnessSourceDetail extends FreshnessSourceStatus {
+  history?: Array<{ timestamp: string; ageMs: number }>;
+  recentIntervalsMs?: number[];
+}
+
+export interface FreshnessAlert {
+  source: string;
+  label: string;
+  severity: "warning" | "critical";
+  message: string;
+  since: string;
+}
+
+export function getFreshnessSnapshot(opts?: {
+  includeHistory?: boolean;
+  historyLimit?: number;
+}): Promise<FreshnessSnapshot> {
+  const params = new URLSearchParams();
+  if (opts?.includeHistory) params.set("includeHistory", "true");
+  if (opts?.historyLimit != null) params.set("historyLimit", String(opts.historyLimit));
+  const qs = params.toString();
+  return fetchApi<FreshnessSnapshot>(`/freshness${qs ? `?${qs}` : ""}`);
+}
+
+export function getFreshnessSource(
+  source: string,
+  opts?: { historyLimit?: number }
+): Promise<FreshnessSourceDetail> {
+  const params = new URLSearchParams();
+  if (opts?.historyLimit != null) params.set("historyLimit", String(opts.historyLimit));
+  const qs = params.toString();
+  return fetchApi<FreshnessSourceDetail>(
+    `/freshness/${encodeURIComponent(source)}${qs ? `?${qs}` : ""}`
+  );
+}
+
+export function getFreshnessSourceTrend(
+  source: string,
+  opts?: { historyLimit?: number }
+): Promise<FreshnessSourceDetail> {
+  const params = new URLSearchParams();
+  if (opts?.historyLimit != null) params.set("historyLimit", String(opts.historyLimit));
+  const qs = params.toString();
+  return fetchApi<FreshnessSourceDetail>(
+    `/freshness/${encodeURIComponent(source)}/trend${qs ? `?${qs}` : ""}`
+  );
+}
+
+export function getFreshnessAlerts(): Promise<{ alerts: FreshnessAlert[]; timestamp: string }> {
+  return fetchApi<{ alerts: FreshnessAlert[]; timestamp: string }>("/freshness/alerts");
+}


### PR DESCRIPTION
  Summary

  - Closes #680 — corrected FOBXX/BENJI Stellar issuer address from 46 to 56 characters
  (GBHNGLLIE3KWGKCHIKMHJ5HVZHYIK7WTBE4QF5PLAKL4CJGSEU7HZIW5), uncommented the asset entry, and added a
  validateIssuerAddress startup guard that throws at launch if any non-native issuer is malformed
  - Closes #695 — added /freshness frontend page consuming the existing freshness API endpoints; shows per-source
  staleness status with Fresh/Stale badges, last-updated age, expected interval, trend direction, and amber
  highlighting for stale rows; includes auto-refresh via useRefreshControls, loading skeleton, empty state, and 6 page
  tests
  - Closes #719 — added 5 inline tests to rate_limiter.rs inside the existing #[cfg(test)] mod tests block covering:
  per-user isolation, rejected-consume non-recording, weekly count limit, window reset reflected in check_limit, and
  global limit accumulation across multiple users
  - Closes #720 — added backend/tests/api/alerts.test.ts with 18 tests covering all registered alert API routes: list
  rules, create rule, get rule, update rule, delete rule, alert history (global + per-asset), stats, recent events,
  and rule-specific events; mocks AlertService and authMiddleware

  Test Plan

  - [ ] npm run test:backend — alerts.test.ts (18 tests) and config.test.ts (6 tests) pass
  - [ ] cargo test in contracts/soroban/ — new rate limiter tests pass alongside existing suite
  - [ ] npm run test:frontend — FreshnessMonitoring.test.tsx (6 tests) passes
  - [ ] Navigate to /freshness in dev server — page renders with source table, summary counts, and stale row
  highlighting
  - [ ] Confirm SUPPORTED_ASSETS includes FOBXX with a 56-character issuer at startup (no thrown error on boot)

  Closes #680, Closes #695, Closes #719, Closes #720
