### PR TITLE
feat: trigger price deviation alerts and persist aggregated prices to TimescaleDB

### DIFF
--- a/backend/src/workers/priceAggregator.worker.ts
+++ b/backend/src/workers/priceAggregator.worker.ts
@@ -9,6 +9,8 @@ import { PriceModel } from "../database/models/price.model.js";
 
 const QUEUE_NAME = "price-aggregator";
 
+const priceModel = new PriceModel();
+
 const connection = {
   host: config.REDIS_HOST,
   port: config.REDIS_PORT,
@@ -16,6 +18,22 @@ const connection = {
 };
 
 export const priceAggregatorQueue = new Queue(QUEUE_NAME, { connection });
+
+async function persistAggregatedPrice(aggregated: AggregatedPrice): Promise<void> {
+  try {
+    const now = new Date();
+    const records = aggregated.sources.map((src) => ({
+      time: now,
+      symbol: aggregated.symbol,
+      source: src.source,
+      price: src.price,
+      volume_24h: null as number | null,
+    }));
+    await priceModel.insertBatch(records);
+  } catch (err) {
+    logger.error({ err, symbol: aggregated.symbol }, "Failed to persist aggregated price");
+  }
+}
 
 /**
  * Worker that periodically aggregates prices from multiple sources:

--- a/backend/src/workers/priceAggregator.worker.ts
+++ b/backend/src/workers/priceAggregator.worker.ts
@@ -34,6 +34,30 @@ function buildDeviationAlert(symbol: string, deviation: { deviated: boolean; per
   };
 }
 
+async function routeDeviationAlert(symbol: string, deviation: { deviated: boolean; percentage: number }): Promise<void> {
+  const dedupEvent: Omit<AlertEvent, "eventId"> = {
+    ruleId: `price-aggregator-${symbol}`,
+    assetCode: symbol,
+    alertType: "price_deviation",
+    priority: deviation.percentage > (config.PRICE_DEVIATION_THRESHOLD ?? 0.02) * 2 ? "critical" : "high",
+    triggeredValue: deviation.percentage,
+    threshold: config.PRICE_DEVIATION_THRESHOLD ?? 0.02,
+    metric: "price_deviation_pct",
+    webhookDelivered: false,
+    onChainEventId: null,
+  };
+
+  const dedupResult = duplicateAlertCheckService.check(dedupEvent);
+
+  if (!dedupResult.isDuplicate || dedupResult.action !== "block") {
+    const alert = buildDeviationAlert(symbol, deviation);
+    await alertRoutingService.routeAlert(alert);
+    logger.info({ symbol, percentage: deviation.percentage }, "Price deviation alert routed");
+  } else {
+    logger.debug({ symbol, reason: dedupResult.reason }, "Price deviation alert suppressed by deduplication");
+  }
+}
+
 async function persistAggregatedPrice(aggregated: AggregatedPrice): Promise<void> {
   try {
     const now = new Date();

--- a/backend/src/workers/priceAggregator.worker.ts
+++ b/backend/src/workers/priceAggregator.worker.ts
@@ -19,6 +19,21 @@ const connection = {
 
 export const priceAggregatorQueue = new Queue(QUEUE_NAME, { connection });
 
+function buildDeviationAlert(symbol: string, deviation: { deviated: boolean; percentage: number }): RouteableAlert {
+  return {
+    eventTime: new Date(),
+    alertRuleId: `price-aggregator-${symbol}`,
+    ownerAddress: "system",
+    ruleName: "Price Deviation",
+    assetCode: symbol,
+    sourceType: "price_deviation",
+    severity: deviation.percentage > (config.PRICE_DEVIATION_THRESHOLD ?? 0.02) * 2 ? "critical" : "high",
+    triggeredValue: deviation.percentage,
+    threshold: config.PRICE_DEVIATION_THRESHOLD ?? 0.02,
+    metric: "price_deviation_pct",
+  };
+}
+
 async function persistAggregatedPrice(aggregated: AggregatedPrice): Promise<void> {
   try {
     const now = new Date();

--- a/backend/src/workers/priceAggregator.worker.ts
+++ b/backend/src/workers/priceAggregator.worker.ts
@@ -74,39 +74,43 @@ async function persistAggregatedPrice(aggregated: AggregatedPrice): Promise<void
   }
 }
 
+export async function processPriceAggregatorJob(job: { id?: string; data: { symbol: string } }) {
+  const priceService = new PriceService();
+  logger.info({ jobId: job.id, data: job.data }, "Processing price aggregation job");
+
+  const { symbol } = job.data;
+
+  const aggregatedPrice = await priceService.getAggregatedPrice(symbol);
+  const deviation = await priceService.checkDeviation(symbol);
+
+  if (deviation.deviated) {
+    logger.warn({ symbol, deviation: deviation.percentage }, "Price deviation detected");
+    await routeDeviationAlert(symbol, deviation);
+  }
+
+  if (aggregatedPrice) {
+    await persistAggregatedPrice(aggregatedPrice);
+  }
+
+  return { success: true, symbol, price: aggregatedPrice };
+}
+
 /**
  * Worker that periodically aggregates prices from multiple sources:
  * - Stellar DEX (SDEX + AMM pools)
  * - Circle API
  * - Coinbase API
  *
- * Computes VWAP and checks for price deviations exceeding thresholds.
+ * Computes VWAP, persists source prices to TimescaleDB, and triggers alerts
+ * when cross-source deviation exceeds the configured threshold.
  */
 export const priceAggregatorWorker = new Worker(
   QUEUE_NAME,
   async (job) => {
-    const priceService = new PriceService();
-    logger.info({ jobId: job.id, data: job.data }, "Processing price aggregation job");
-
-    const { symbol } = job.data;
-
     try {
-      const aggregatedPrice = await priceService.getAggregatedPrice(symbol);
-
-      // Check for deviation
-      const deviation = await priceService.checkDeviation(symbol);
-      if (deviation.deviated) {
-        logger.warn(
-          { symbol, deviation: deviation.percentage },
-          "Price deviation detected"
-        );
-        // TODO: Trigger price deviation alert
-      }
-
-      // TODO: Persist aggregated price to TimescaleDB
-      return { success: true, symbol, price: aggregatedPrice };
+      return await processPriceAggregatorJob(job);
     } catch (error) {
-      logger.error({ error, symbol }, "Price aggregation job failed");
+      logger.error({ error, symbol: job.data?.symbol }, "Price aggregation job failed");
       throw error;
     }
   },

--- a/backend/src/workers/priceAggregator.worker.ts
+++ b/backend/src/workers/priceAggregator.worker.ts
@@ -58,6 +58,11 @@ async function routeDeviationAlert(symbol: string, deviation: { deviated: boolea
   }
 }
 
+/**
+ * Batch-inserts one row per price source into the prices TimescaleDB hypertable.
+ * Columns: time (now), symbol, source, price, volume_24h (null — not returned by aggregation).
+ * Errors are swallowed so a DB outage never prevents the alert routing path from running.
+ */
 async function persistAggregatedPrice(aggregated: AggregatedPrice): Promise<void> {
   try {
     const now = new Date();

--- a/backend/src/workers/priceAggregator.worker.ts
+++ b/backend/src/workers/priceAggregator.worker.ts
@@ -1,7 +1,11 @@
 import { Worker, Queue } from "bullmq";
 import { config } from "../config/index.js";
-import { PriceService } from "../services/price.service.js";
+import { PriceService, type AggregatedPrice } from "../services/price.service.js";
 import { logger } from "../utils/logger.js";
+import { alertRoutingService, type RouteableAlert } from "../services/alertRouting.service.js";
+import { duplicateAlertCheckService } from "../services/duplicateAlertCheck.service.js";
+import type { AlertEvent } from "../services/alert.service.js";
+import { PriceModel } from "../database/models/price.model.js";
 
 const QUEUE_NAME = "price-aggregator";
 

--- a/backend/tests/workers/priceAggregator.worker.test.ts
+++ b/backend/tests/workers/priceAggregator.worker.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ─── Hoisted mocks ───────────────────────────────────────────────────────────
+const getAggregatedPriceMock = vi.hoisted(() => vi.fn());
+const checkDeviationMock = vi.hoisted(() => vi.fn().mockResolvedValue({ deviated: false, percentage: 0 }));
+const routeAlertMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const checkDedupMock = vi.hoisted(() =>
+  vi.fn().mockReturnValue({ isDuplicate: false, action: "allow" })
+);
+const insertBatchMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+vi.mock("../../src/services/price.service.js", () => ({
+  PriceService: class {
+    getAggregatedPrice = getAggregatedPriceMock;
+    checkDeviation = checkDeviationMock;
+  },
+}));
+
+vi.mock("../../src/services/alertRouting.service.js", () => ({
+  alertRoutingService: { routeAlert: routeAlertMock },
+}));
+
+vi.mock("../../src/services/duplicateAlertCheck.service.js", () => ({
+  duplicateAlertCheckService: { check: checkDedupMock },
+}));
+
+vi.mock("../../src/database/models/price.model.js", () => ({
+  PriceModel: class {
+    insertBatch = insertBatchMock;
+  },
+}));
+
+vi.mock("bullmq", () => ({
+  Worker: class {
+    on() {}
+  },
+  Queue: class {
+    add = vi.fn().mockResolvedValue({ id: "mock-job" });
+    on() {}
+  },
+}));
+
+vi.mock("../../src/config/index.js", () => ({
+  config: {
+    REDIS_HOST: "localhost",
+    REDIS_PORT: 6379,
+    PRICE_DEVIATION_THRESHOLD: 0.02,
+  },
+}));
+
+import { processPriceAggregatorJob } from "../../src/workers/priceAggregator.worker.js";
+
+const makeAggregated = (symbol: string, sources = [{ source: "sdex", price: 1.001, timestamp: new Date().toISOString() }]) => ({
+  symbol,
+  vwap: 1.0,
+  sources,
+  deviation: 0.001,
+  lastUpdated: new Date().toISOString(),
+});
+
+describe("priceAggregator.worker", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    checkDedupMock.mockReturnValue({ isDuplicate: false, action: "allow" });
+    checkDeviationMock.mockResolvedValue({ deviated: false, percentage: 0 });
+  });
+
+  describe("basic job execution", () => {
+    it("returns success with aggregated price", async () => {
+      getAggregatedPriceMock.mockResolvedValue(makeAggregated("USDC"));
+
+      const result = await processPriceAggregatorJob({ id: "job-1", data: { symbol: "USDC" } });
+
+      expect(result.success).toBe(true);
+      expect(result.symbol).toBe("USDC");
+    });
+
+    it("returns success even when aggregatedPrice is null", async () => {
+      getAggregatedPriceMock.mockResolvedValue(null);
+
+      const result = await processPriceAggregatorJob({ id: "job-2", data: { symbol: "USDC" } });
+
+      expect(result.success).toBe(true);
+      expect(result.price).toBeNull();
+    });
+  });
+
+  describe("price persistence", () => {
+    it("batch-inserts source prices into TimescaleDB when aggregatedPrice is present", async () => {
+      const sources = [
+        { source: "sdex", price: 1.001, timestamp: new Date().toISOString() },
+        { source: "circle", price: 1.0, timestamp: new Date().toISOString() },
+      ];
+      getAggregatedPriceMock.mockResolvedValue(makeAggregated("USDC", sources));
+
+      await processPriceAggregatorJob({ id: "job-3", data: { symbol: "USDC" } });
+
+      expect(insertBatchMock).toHaveBeenCalledOnce();
+      const records = insertBatchMock.mock.calls[0][0];
+      expect(records).toHaveLength(2);
+      expect(records[0]).toMatchObject({ symbol: "USDC", source: "sdex", price: 1.001 });
+      expect(records[1]).toMatchObject({ symbol: "USDC", source: "circle", price: 1.0 });
+    });
+
+    it("skips persistence when aggregatedPrice is null", async () => {
+      getAggregatedPriceMock.mockResolvedValue(null);
+
+      await processPriceAggregatorJob({ id: "job-4", data: { symbol: "USDC" } });
+
+      expect(insertBatchMock).not.toHaveBeenCalled();
+    });
+
+    it("continues and returns success when batch insert fails", async () => {
+      getAggregatedPriceMock.mockResolvedValue(makeAggregated("USDC"));
+      insertBatchMock.mockRejectedValueOnce(new Error("DB timeout"));
+
+      const result = await processPriceAggregatorJob({ id: "job-5", data: { symbol: "USDC" } });
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("deviation alerting", () => {
+    it("does not route alert when no deviation", async () => {
+      getAggregatedPriceMock.mockResolvedValue(makeAggregated("USDC"));
+      checkDeviationMock.mockResolvedValue({ deviated: false, percentage: 0 });
+
+      await processPriceAggregatorJob({ id: "job-6", data: { symbol: "USDC" } });
+
+      expect(routeAlertMock).not.toHaveBeenCalled();
+    });
+
+    it("routes alert when deviation is detected and not duplicate", async () => {
+      getAggregatedPriceMock.mockResolvedValue(makeAggregated("USDC"));
+      checkDeviationMock.mockResolvedValue({ deviated: true, percentage: 0.03 });
+
+      await processPriceAggregatorJob({ id: "job-7", data: { symbol: "USDC" } });
+
+      expect(routeAlertMock).toHaveBeenCalledOnce();
+      expect(routeAlertMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          assetCode: "USDC",
+          sourceType: "price_deviation",
+          triggeredValue: 0.03,
+        })
+      );
+    });
+
+    it("assigns critical severity when deviation exceeds 2x threshold", async () => {
+      getAggregatedPriceMock.mockResolvedValue(makeAggregated("USDC"));
+      checkDeviationMock.mockResolvedValue({ deviated: true, percentage: 0.05 });
+
+      await processPriceAggregatorJob({ id: "job-8", data: { symbol: "USDC" } });
+
+      expect(routeAlertMock).toHaveBeenCalledWith(
+        expect.objectContaining({ severity: "critical" })
+      );
+    });
+
+    it("assigns high severity when deviation is above threshold but below 2x", async () => {
+      getAggregatedPriceMock.mockResolvedValue(makeAggregated("USDC"));
+      checkDeviationMock.mockResolvedValue({ deviated: true, percentage: 0.03 });
+
+      await processPriceAggregatorJob({ id: "job-9", data: { symbol: "USDC" } });
+
+      expect(routeAlertMock).toHaveBeenCalledWith(
+        expect.objectContaining({ severity: "high" })
+      );
+    });
+  });
+
+  describe("deduplication", () => {
+    it("suppresses alert when dedup check blocks", async () => {
+      getAggregatedPriceMock.mockResolvedValue(makeAggregated("USDC"));
+      checkDeviationMock.mockResolvedValue({ deviated: true, percentage: 0.03 });
+      checkDedupMock.mockReturnValue({ isDuplicate: true, action: "block", reason: "within window" });
+
+      await processPriceAggregatorJob({ id: "job-10", data: { symbol: "USDC" } });
+
+      expect(routeAlertMock).not.toHaveBeenCalled();
+    });
+
+    it("allows alert when dedup action is escalate", async () => {
+      getAggregatedPriceMock.mockResolvedValue(makeAggregated("USDC"));
+      checkDeviationMock.mockResolvedValue({ deviated: true, percentage: 0.03 });
+      checkDedupMock.mockReturnValue({ isDuplicate: true, action: "escalate" });
+
+      await processPriceAggregatorJob({ id: "job-11", data: { symbol: "USDC" } });
+
+      expect(routeAlertMock).toHaveBeenCalledOnce();
+    });
+
+    it("passes consistent ruleId to dedup check and alertRuleId to alert routing", async () => {
+      getAggregatedPriceMock.mockResolvedValue(makeAggregated("EURC"));
+      checkDeviationMock.mockResolvedValue({ deviated: true, percentage: 0.03 });
+
+      await processPriceAggregatorJob({ id: "job-12", data: { symbol: "EURC" } });
+
+      const dedupCall = checkDedupMock.mock.calls[0][0];
+      const alertCall = routeAlertMock.mock.calls[0][0];
+      expect(dedupCall.ruleId).toBe("price-aggregator-EURC");
+      expect(alertCall.alertRuleId).toBe("price-aggregator-EURC");
+    });
+  });
+});

--- a/backend/tests/workers/priceAggregator.worker.test.ts
+++ b/backend/tests/workers/priceAggregator.worker.test.ts
@@ -178,6 +178,18 @@ describe("priceAggregator.worker", () => {
     });
   });
 
+  describe("alert and persistence in same job", () => {
+    it("both routes alert and persists prices when deviation detected", async () => {
+      getAggregatedPriceMock.mockResolvedValue(makeAggregated("USDC"));
+      checkDeviationMock.mockResolvedValue({ deviated: true, percentage: 0.03 });
+
+      await processPriceAggregatorJob({ id: "job-both", data: { symbol: "USDC" } });
+
+      expect(routeAlertMock).toHaveBeenCalledOnce();
+      expect(insertBatchMock).toHaveBeenCalledOnce();
+    });
+  });
+
   describe("deduplication", () => {
     it("suppresses alert when dedup check blocks", async () => {
       getAggregatedPriceMock.mockResolvedValue(makeAggregated("USDC"));

--- a/backend/tests/workers/priceAggregator.worker.test.ts
+++ b/backend/tests/workers/priceAggregator.worker.test.ts
@@ -222,5 +222,17 @@ describe("priceAggregator.worker", () => {
       expect(dedupCall.ruleId).toBe("price-aggregator-EURC");
       expect(alertCall.alertRuleId).toBe("price-aggregator-EURC");
     });
+
+    it("triggeredValue in dedup event and alert both equal the actual deviation percentage", async () => {
+      getAggregatedPriceMock.mockResolvedValue(makeAggregated("USDC"));
+      checkDeviationMock.mockResolvedValue({ deviated: true, percentage: 0.035 });
+
+      await processPriceAggregatorJob({ id: "job-13", data: { symbol: "USDC" } });
+
+      const dedupCall = checkDedupMock.mock.calls[0][0];
+      const alertCall = routeAlertMock.mock.calls[0][0];
+      expect(dedupCall.triggeredValue).toBeCloseTo(0.035);
+      expect(alertCall.triggeredValue).toBeCloseTo(0.035);
+    });
   });
 });

--- a/backend/tests/workers/priceAggregator.worker.test.ts
+++ b/backend/tests/workers/priceAggregator.worker.test.ts
@@ -102,6 +102,15 @@ describe("priceAggregator.worker", () => {
       expect(records[1]).toMatchObject({ symbol: "USDC", source: "circle", price: 1.0 });
     });
 
+    it("sets volume_24h to null on each persisted record", async () => {
+      getAggregatedPriceMock.mockResolvedValue(makeAggregated("USDC"));
+
+      await processPriceAggregatorJob({ id: "job-vol", data: { symbol: "USDC" } });
+
+      const records = insertBatchMock.mock.calls[0][0];
+      expect(records.every((r: any) => r.volume_24h === null)).toBe(true);
+    });
+
     it("skips persistence when aggregatedPrice is null", async () => {
       getAggregatedPriceMock.mockResolvedValue(null);
 


### PR DESCRIPTION
Closes #672

## What changed
- Imported `PriceModel`, `alertRoutingService`, and `duplicateAlertCheckService` into the price aggregator worker
- Added `buildDeviationAlert` — constructs a `RouteableAlert` with `critical` severity when deviation exceeds 2× the configured threshold, otherwise `high`
- Added `routeDeviationAlert` — runs a deduplication check per symbol before routing; blocked duplicates are suppressed, escalated/reviewed ones are allowed through
- Added `persistAggregatedPrice` — batch-inserts one row per price source into the `prices` TimescaleDB hypertable; errors are swallowed so a DB outage never blocks alert routing
- Extracted core logic into exported `processPriceAggregatorJob` for unit testability without spinning up the BullMQ worker

## Why
- Price deviation events were logged but never dispatched to the alert routing pipeline
- Aggregated VWAP and source prices were computed and then discarded — no historical price data was stored in TimescaleDB for trend queries

## How to test
- Run `vitest backend/tests/workers/priceAggregator.worker.test.ts` — 14 unit tests cover: basic success, null aggregatedPrice handling, batch insert correctness, volume_24h null, DB-failure resilience, no-alert when no deviation, alert routing on deviation, critical vs high severity thresholds, simultaneous alert + persist, dedup block/escalate, ruleId/alertRuleId consistency, triggeredValue propagation