### PR TITLE
Feature/sdk workspaces ci typed wrappers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,60 @@ jobs:
           retention-days: 30
           if-no-files-found: warn
 
+  sdk:
+    name: SDK Build & Test
+    runs-on: ubuntu-latest
+    env:
+      COMMAND_LOG_DIR: ${{ runner.temp }}/bridge-watch-command-logs/sdk
+      COMMAND_LOG_ARCHIVE_DIR: ${{ runner.temp }}/bridge-watch-command-log-archives
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize command log archive
+        run: |
+          mkdir -p "$COMMAND_LOG_DIR"
+          printf 'label\tcommand\tlog_file\n' > "$COMMAND_LOG_DIR/COMMANDS.tsv"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: |
+          set -o pipefail
+          printf 'install-dependencies\tnpm ci\tnpm-ci.log\n' >> "$COMMAND_LOG_DIR/COMMANDS.tsv"
+          npm ci 2>&1 | tee "$COMMAND_LOG_DIR/npm-ci.log"
+
+      - name: Build SDK
+        run: |
+          set -o pipefail
+          printf 'build-sdk\tnpm --workspace=sdk run build\tsdk-build.log\n' >> "$COMMAND_LOG_DIR/COMMANDS.tsv"
+          npm --workspace=sdk run build 2>&1 | tee "$COMMAND_LOG_DIR/sdk-build.log"
+
+      - name: Test SDK
+        run: |
+          set -o pipefail
+          printf 'test-sdk\tnpm --workspace=sdk run test\tsdk-test.log\n' >> "$COMMAND_LOG_DIR/COMMANDS.tsv"
+          npm --workspace=sdk run test 2>&1 | tee "$COMMAND_LOG_DIR/sdk-test.log"
+
+      - name: Compress command logs
+        if: always()
+        id: archive-command-logs
+        run: bash scripts/archive-command-logs.sh
+
+      - name: Upload command log archive
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.COMMAND_LOG_ARCHIVE_NAME }}
+          path: ${{ env.COMMAND_LOG_ARCHIVE }}
+          retention-days: 30
+          if-no-files-found: warn
+
   frontend:
     name: Frontend Build
     runs-on: ubuntu-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "workspaces": [
         "backend",
-        "frontend"
+        "frontend",
+        "sdk"
       ],
       "devDependencies": {
         "@playwright/test": "^1.54.2",
@@ -806,6 +807,10 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@bridge-watch/contract-sdk": {
+      "resolved": "sdk",
+      "link": true
     },
     "node_modules/@discordjs/builders": {
       "version": "1.14.1",
@@ -7496,6 +7501,15 @@
         }
       }
     },
+    "node_modules/feaxios": {
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/feaxios/-/feaxios-0.0.23.tgz",
+      "integrity": "sha512-eghR0A21fvbkcQBgZuMfQhrXxJzC0GNUGC9fXhBge33D+mFDTwl0aJ35zoQQn575BhyjQitRc5N4f+L4cP708g==",
+      "license": "MIT",
+      "dependencies": {
+        "is-retry-allowed": "^3.0.0"
+      }
+    },
     "node_modules/fengari": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/fengari/-/fengari-0.1.5.tgz",
@@ -8654,6 +8668,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-retry-allowed": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-3.0.0.tgz",
+      "integrity": "sha512-9xH0xvoggby+u0uGF7cZXdrutWiBiaFG8ZT4YFPXL8NzkyAwX3AKGLeFQLvzDpM430+nDFBZ1LHkie/8ocL06A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-set": {
@@ -13860,6 +13886,95 @@
         "use-sync-external-store": {
           "optional": true
         }
+      }
+    },
+    "sdk": {
+      "name": "@bridge-watch/contract-sdk",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@stellar/stellar-sdk": "^14.2.0"
+      },
+      "devDependencies": {
+        "typescript": "^5.6.3",
+        "vitest": "^2.1.4"
+      }
+    },
+    "sdk/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "sdk/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "sdk/node_modules/@stellar/stellar-base": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-14.1.0.tgz",
+      "integrity": "sha512-A8kFli6QGy22SRF45IjgPAJfUNGjnI+R7g4DF5NZYVsD1kGf7B4ITyc4OPclLV9tqNI4/lXxafGEw0JEUbHixw==",
+      "deprecated": "This package is now rolled into @stellar/stellar-sdk. Please use @stellar/stellar-sdk to continue receiving updates and support.",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/curves": "^1.9.6",
+        "@stellar/js-xdr": "^3.1.2",
+        "base32.js": "^0.1.0",
+        "bignumber.js": "^9.3.1",
+        "buffer": "^6.0.3",
+        "sha.js": "^2.4.12"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "sdk/node_modules/@stellar/stellar-sdk": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-14.6.1.tgz",
+      "integrity": "sha512-A1rQWDLdUasXkMXnYSuhgep+3ZZzyuXJKdt5/KAIc0gkmSp906HTvUpbT4pu+bVr41tu0+J4Ugz9J4BQAGGytg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stellar/stellar-base": "^14.1.0",
+        "axios": "^1.13.3",
+        "bignumber.js": "^9.3.1",
+        "commander": "^14.0.2",
+        "eventsource": "^2.0.2",
+        "feaxios": "^0.0.23",
+        "randombytes": "^2.1.0",
+        "toml": "^3.0.0",
+        "urijs": "^1.19.1"
+      },
+      "bin": {
+        "stellar-js": "bin/stellar-js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "sdk/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "private": true,
   "workspaces": [
     "backend",
-    "frontend"
+    "frontend",
+    "sdk"
   ],
   "scripts": {
     "dev": "npm run dev --workspaces --if-present",
@@ -14,8 +15,10 @@
     "build": "npm run build --workspaces --if-present",
     "build:backend": "npm run build --workspace=backend",
     "build:frontend": "npm run build --workspace=frontend",
+    "build:sdk": "npm run build --workspace=sdk",
     "test": "npm run test --workspaces --if-present",
     "test:backend": "npm run test --workspace=backend",
+    "test:sdk": "npm run test --workspace=sdk",
     "test:load": "k6 run load-tests/scenarios/api-load.js -e PROFILE=smoke -e BASE_URL=http://127.0.0.1:3001",
     "test:load:report": "node load-tests/scripts/generate-report.mjs load-tests/results/summary.json load-tests/results/report.md",
     "test:e2e": "playwright test",

--- a/sdk/examples/basic-usage.ts
+++ b/sdk/examples/basic-usage.ts
@@ -1,8 +1,8 @@
-import { Networks, xdr } from "@stellar/stellar-sdk";
-import { BridgeWatchContractSdk } from "../src/client";
+import { Networks } from "@stellar/stellar-sdk";
+import { TypedBridgeWatchContractSdk } from "../src/contract";
 
 async function run() {
-  const sdk = new BridgeWatchContractSdk({
+  const sdk = new TypedBridgeWatchContractSdk({
     rpcUrl: "https://soroban-testnet.stellar.org",
     contractId: "CCONTRACTID",
     networkPassphrase: Networks.TESTNET,
@@ -10,12 +10,32 @@ async function run() {
 
   await sdk.connect();
 
-  const query = await sdk.queryMethod({
-    method: "get_health",
-    args: [xdr.ScVal.scvString("USDC")],
-  });
+  // Typed query — returns structured AssetHealth | null
+  const health = await sdk.getContractHealth("USDC");
+  console.log("Health:", health);
 
-  console.log("Query result", query.result?.retval?.toXDR("base64"));
+  // Typed query — returns structured GlobalPauseState
+  const pauseStatus = await sdk.getPauseStatus();
+  console.log("Paused:", pauseStatus.is_paused);
+
+  // Typed query — returns string[]
+  const assets = await sdk.getMonitoredAssets();
+  console.log("Monitored assets:", assets);
+
+  // Typed query — returns boolean
+  const paused = await sdk.isPaused();
+  console.log("Globally paused:", paused);
+
+  // Typed invoke — submit health data (requires a funded Stellar keypair)
+  // const result = await sdk.submitHealth({
+  //   caller: "GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI",
+  //   asset_code: "USDC",
+  //   health_score: 85,
+  //   liquidity_score: 90,
+  //   price_stability_score: 80,
+  //   bridge_uptime_score: 95,
+  // });
+  // console.log("Submit result:", result);
 }
 
 run().catch((error) => {

--- a/sdk/src/contract.test.ts
+++ b/sdk/src/contract.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import * as StellarSdk from "@stellar/stellar-sdk";
+import { TypedBridgeWatchContractSdk } from "./contract";
+import type {
+  AssetHealth,
+  PriceRecord,
+  HealthWeights,
+  HealthScoreResult,
+  AggregatedHealth,
+  HealthSource,
+  EventReplayPage,
+} from "./contract";
+import type { BridgeWatchSdkConfig } from "./types";
+
+// Valid Stellar testnet public key for address tests
+const TEST_CALLER = "GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI";
+
+const testConfig: BridgeWatchSdkConfig = {
+  rpcUrl: "https://testnet.sorobanrpc.com",
+  contractId: "CCONTRACT123",
+  networkPassphrase: StellarSdk.Networks.TESTNET,
+};
+
+// ============================================================
+// ScVal parsing unit tests
+// ============================================================
+
+describe("ScVal utility helpers", () => {
+  it("scvVoid is void", () => {
+    const val = StellarSdk.xdr.ScVal.scvVoid();
+    expect(val.switch().name).toBe("scvVoid");
+  });
+
+  it("scvU32 creates a valid u32 ScVal", () => {
+    const val = StellarSdk.xdr.ScVal.scvU32(85);
+    expect(val.u32()).toBe(85);
+  });
+
+  it("scvString creates a valid string ScVal", () => {
+    const val = StellarSdk.xdr.ScVal.scvString("USDC");
+    expect(typeof val.str()).toBe("string");
+  });
+
+  it("scvI128 creates a valid i128 ScVal from bigint", () => {
+    const parts = new StellarSdk.xdr.Int128Parts({
+      lo: StellarSdk.xdr.Uint64.fromString("1000000"),
+      hi: StellarSdk.xdr.Int64.fromString("0"),
+    });
+    const val = StellarSdk.xdr.ScVal.scvI128(parts);
+    expect(val.i128()).toBeDefined();
+  });
+
+  it("scvMap creates a ScVal with map entries", () => {
+    const val = StellarSdk.xdr.ScVal.scvMap([
+      new StellarSdk.xdr.ScMapEntry({
+        key: StellarSdk.xdr.ScVal.scvString("name"),
+        val: StellarSdk.xdr.ScVal.scvString("test"),
+      }),
+    ]);
+    expect(val.map()).toHaveLength(1);
+  });
+
+  it("scvVec creates a ScVal with vec entries", () => {
+    const val = StellarSdk.xdr.ScVal.scvVec([
+      StellarSdk.xdr.ScVal.scvU32(1),
+      StellarSdk.xdr.ScVal.scvU32(2),
+    ]);
+    const items = val.vec();
+    expect(items).toHaveLength(2);
+  });
+});
+
+// ============================================================
+// TypedBridgeWatchContractSdk integration tests
+// ============================================================
+
+describe("TypedBridgeWatchContractSdk query wrappers", () => {
+  let sdk: TypedBridgeWatchContractSdk;
+  let queryMethodSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    sdk = new TypedBridgeWatchContractSdk(testConfig);
+    queryMethodSpy = vi
+      .spyOn(sdk, "queryMethod" as keyof typeof sdk)
+      .mockResolvedValue({} as never);
+  });
+
+  it("getContractHealth calls queryMethod with get_health", async () => {
+    await sdk.getContractHealth("USDC");
+    expect(queryMethodSpy).toHaveBeenCalledWith({
+      method: "get_health",
+      args: [expect.any(Object)],
+    });
+  });
+
+  it("getPrice calls queryMethod with get_price", async () => {
+    await sdk.getPrice("USDC");
+    expect(queryMethodSpy).toHaveBeenCalledWith({
+      method: "get_price",
+      args: [expect.any(Object)],
+    });
+  });
+
+  it("getHealthWeights calls queryMethod with get_health_weights", async () => {
+    await sdk.getHealthWeights().catch(() => {});
+    expect(queryMethodSpy).toHaveBeenCalledWith({
+      method: "get_health_weights",
+      args: undefined,
+    });
+  });
+
+  it("getHealthSources calls queryMethod with get_health_sources", async () => {
+    await sdk.getHealthSources().catch(() => {});
+    expect(queryMethodSpy).toHaveBeenCalledWith({
+      method: "get_health_sources",
+      args: undefined,
+    });
+  });
+
+  it("calculateHealthScore calls queryMethod with calculate_health_score", async () => {
+    await sdk.calculateHealthScore(90, 80, 95).catch(() => {});
+    expect(queryMethodSpy).toHaveBeenCalledWith({
+      method: "calculate_health_score",
+      args: [expect.any(Object), expect.any(Object), expect.any(Object)],
+    });
+  });
+
+  it("getAggregatedHealth calls queryMethod with get_aggregated_health", async () => {
+    await sdk.getAggregatedHealth("USDC");
+    expect(queryMethodSpy).toHaveBeenCalledWith({
+      method: "get_aggregated_health",
+      args: [expect.any(Object)],
+    });
+  });
+
+  it("getHealthScoreResult calls queryMethod with get_health_score_result", async () => {
+    await sdk.getHealthScoreResult("USDC");
+    expect(queryMethodSpy).toHaveBeenCalledWith({
+      method: "get_health_score_result",
+      args: [expect.any(Object)],
+    });
+  });
+
+  it("getSignatureThreshold calls queryMethod with get_signature_threshold", async () => {
+    await sdk.getSignatureThreshold().catch(() => {});
+    expect(queryMethodSpy).toHaveBeenCalledWith({
+      method: "get_signature_threshold",
+      args: undefined,
+    });
+  });
+
+  it("getReplaySchemaVersion calls queryMethod with get_replay_schema_version", async () => {
+    await sdk.getReplaySchemaVersion().catch(() => {});
+    expect(queryMethodSpy).toHaveBeenCalledWith({
+      method: "get_replay_schema_version",
+      args: undefined,
+    });
+  });
+
+  it("getReplayEvents calls queryMethod with get_replay_events", async () => {
+    await sdk.getReplayEvents(0, 10).catch(() => {});
+    expect(queryMethodSpy).toHaveBeenCalledWith({
+      method: "get_replay_events",
+      args: [expect.any(Object), expect.any(Object)],
+    });
+  });
+
+  it("getReplayLogSize calls queryMethod with get_replay_log_size", async () => {
+    await sdk.getReplayLogSize().catch(() => {});
+    expect(queryMethodSpy).toHaveBeenCalledWith({
+      method: "get_replay_log_size",
+      args: undefined,
+    });
+  });
+});
+
+describe("TypedBridgeWatchContractSdk invoke wrappers", () => {
+  let sdk: TypedBridgeWatchContractSdk;
+  let invokeAndSendSpy: ReturnType<typeof vi.spyOn>;
+  let buildInvokeTransactionSpy: ReturnType<typeof vi.spyOn>;
+  let simulateTransactionSpy: ReturnType<typeof vi.spyOn>;
+  let sendTransactionSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    sdk = new TypedBridgeWatchContractSdk(testConfig);
+    invokeAndSendSpy = vi
+      .spyOn(sdk, "invokeAndSend" as keyof typeof sdk)
+      .mockResolvedValue({ status: "SUCCESS" } as never);
+    buildInvokeTransactionSpy = vi
+      .spyOn(sdk, "buildInvokeTransaction" as keyof typeof sdk)
+      .mockResolvedValue({} as never);
+    simulateTransactionSpy = vi
+      .spyOn(sdk, "simulateTransaction" as keyof typeof sdk)
+      .mockResolvedValue({} as never);
+    sendTransactionSpy = vi
+      .spyOn(sdk, "sendTransaction" as keyof typeof sdk)
+      .mockResolvedValue({ status: "SUCCESS" } as never);
+  });
+
+  it("submitHealth calls invokeAndSend with submit_health method", async () => {
+    await sdk.submitHealth({
+      caller: TEST_CALLER,
+      asset_code: "USDC",
+      health_score: 85,
+      liquidity_score: 90,
+      price_stability_score: 80,
+      bridge_uptime_score: 95,
+    });
+    expect(invokeAndSendSpy).toHaveBeenCalled();
+    const arg = invokeAndSendSpy.mock.calls[0][0];
+    expect(arg.method).toBe("submit_health");
+    expect(arg.sourcePublicKey).toBe(TEST_CALLER);
+  });
+
+  it("submitHealthBatch calls invokeAndSend with submit_health_batch method", async () => {
+    await sdk.submitHealthBatch(TEST_CALLER, [
+      {
+        asset_code: "USDC",
+        health_score: 85,
+        liquidity_score: 90,
+        price_stability_score: 80,
+        bridge_uptime_score: 95,
+      },
+    ]);
+    expect(invokeAndSendSpy).toHaveBeenCalled();
+    const arg = invokeAndSendSpy.mock.calls[0][0];
+    expect(arg.method).toBe("submit_health_batch");
+    expect(arg.sourcePublicKey).toBe(TEST_CALLER);
+  });
+
+  it("submitPrice calls invokeAndSend with submit_price method", async () => {
+    await sdk.submitPrice({
+      caller: TEST_CALLER,
+      asset_code: "USDC",
+      price: 1000000n,
+      source: "oracle-1",
+    });
+    expect(invokeAndSendSpy).toHaveBeenCalled();
+    const arg = invokeAndSendSpy.mock.calls[0][0];
+    expect(arg.method).toBe("submit_price");
+    expect(arg.sourcePublicKey).toBe(TEST_CALLER);
+  });
+
+  it("buildSubmitHealthTransaction calls buildInvokeTransaction", async () => {
+    await sdk.buildSubmitHealthTransaction({
+      caller: TEST_CALLER,
+      asset_code: "USDC",
+      health_score: 85,
+      liquidity_score: 90,
+      price_stability_score: 80,
+      bridge_uptime_score: 95,
+    });
+    expect(buildInvokeTransactionSpy).toHaveBeenCalled();
+    const arg = buildInvokeTransactionSpy.mock.calls[0][0];
+    expect(arg.method).toBe("submit_health");
+  });
+
+  it("buildSubmitHealthBatchTransaction calls buildInvokeTransaction", async () => {
+    await sdk.buildSubmitHealthBatchTransaction(TEST_CALLER, [
+      {
+        asset_code: "USDC",
+        health_score: 85,
+        liquidity_score: 90,
+        price_stability_score: 80,
+        bridge_uptime_score: 95,
+      },
+    ]);
+    expect(buildInvokeTransactionSpy).toHaveBeenCalled();
+    const arg = buildInvokeTransactionSpy.mock.calls[0][0];
+    expect(arg.method).toBe("submit_health_batch");
+  });
+
+  it("buildSubmitPriceTransaction calls buildInvokeTransaction", async () => {
+    await sdk.buildSubmitPriceTransaction({
+      caller: TEST_CALLER,
+      asset_code: "USDC",
+      price: 1000000n,
+      source: "oracle-1",
+    });
+    expect(buildInvokeTransactionSpy).toHaveBeenCalled();
+    const arg = buildInvokeTransactionSpy.mock.calls[0][0];
+    expect(arg.method).toBe("submit_price");
+  });
+});

--- a/sdk/src/contract.test.ts
+++ b/sdk/src/contract.test.ts
@@ -282,3 +282,130 @@ describe("TypedBridgeWatchContractSdk invoke wrappers", () => {
     expect(arg.method).toBe("submit_price");
   });
 });
+
+describe("TypedBridgeWatchContractSdk status & pause wrappers", () => {
+  let sdk: TypedBridgeWatchContractSdk;
+  let queryMethodSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    sdk = new TypedBridgeWatchContractSdk(testConfig);
+    queryMethodSpy = vi
+      .spyOn(sdk, "queryMethod" as keyof typeof sdk)
+      .mockResolvedValue({} as never);
+  });
+
+  it("getContractStatus calls queryMethod with get_contract_status", async () => {
+    await sdk.getContractStatus();
+    expect(queryMethodSpy).toHaveBeenCalledWith({
+      method: "get_contract_status",
+      args: undefined,
+    });
+  });
+
+  it("getAssetStatusRollup calls queryMethod with get_asset_status_rollup", async () => {
+    await sdk.getAssetStatusRollup("USDC");
+    expect(queryMethodSpy).toHaveBeenCalledWith({
+      method: "get_asset_status_rollup",
+      args: [expect.any(Object)],
+    });
+  });
+
+  it("getBridgeStatusRollup calls queryMethod with get_bridge_status_rollup", async () => {
+    await sdk.getBridgeStatusRollup("bridge-1");
+    expect(queryMethodSpy).toHaveBeenCalledWith({
+      method: "get_bridge_status_rollup",
+      args: [expect.any(Object)],
+    });
+  });
+
+  it("isPaused calls queryMethod with is_paused", async () => {
+    await sdk.isPaused().catch(() => {});
+    expect(queryMethodSpy).toHaveBeenCalledWith({
+      method: "is_paused",
+      args: undefined,
+    });
+  });
+
+  it("isAssetPaused calls queryMethod with is_asset_paused", async () => {
+    await sdk.isAssetPaused("USDC").catch(() => {});
+    expect(queryMethodSpy).toHaveBeenCalledWith({
+      method: "is_asset_paused",
+      args: [expect.any(Object)],
+    });
+  });
+
+  it("getPauseStatus calls queryMethod with get_pause_status", async () => {
+    await sdk.getPauseStatus().catch(() => {});
+    expect(queryMethodSpy).toHaveBeenCalledWith({
+      method: "get_pause_status",
+      args: undefined,
+    });
+  });
+
+  it("getPauseHistory calls queryMethod with get_pause_history", async () => {
+    await sdk.getPauseHistory();
+    expect(queryMethodSpy).toHaveBeenCalledWith({
+      method: "get_pause_history",
+      args: undefined,
+    });
+  });
+
+  it("getMonitoredAssets calls queryMethod with get_monitored_assets", async () => {
+    await sdk.getMonitoredAssets();
+    expect(queryMethodSpy).toHaveBeenCalledWith({
+      method: "get_monitored_assets",
+      args: undefined,
+    });
+  });
+
+  it("getConfig calls queryMethod with get_config", async () => {
+    await sdk.getConfig("Threshold", "min_health").catch(() => {});
+    expect(queryMethodSpy).toHaveBeenCalledWith({
+      method: "get_config",
+      args: [expect.any(Object), expect.any(Object)],
+    });
+  });
+});
+
+describe("TypedBridgeWatchContractSdk setHealthWeights", () => {
+  let sdk: TypedBridgeWatchContractSdk;
+  let invokeAndSendSpy: ReturnType<typeof vi.spyOn>;
+  let buildInvokeTransactionSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    sdk = new TypedBridgeWatchContractSdk(testConfig);
+    invokeAndSendSpy = vi
+      .spyOn(sdk, "invokeAndSend" as keyof typeof sdk)
+      .mockResolvedValue({ status: "SUCCESS" } as never);
+    buildInvokeTransactionSpy = vi
+      .spyOn(sdk, "buildInvokeTransaction" as keyof typeof sdk)
+      .mockResolvedValue({} as never);
+  });
+
+  it("setHealthWeights calls invokeAndSend with set_health_weights method", async () => {
+    await sdk.setHealthWeights({
+      caller: TEST_CALLER,
+      liquidity_weight: 30,
+      price_stability_weight: 40,
+      bridge_uptime_weight: 30,
+      version: 2,
+    });
+    expect(invokeAndSendSpy).toHaveBeenCalled();
+    const arg = invokeAndSendSpy.mock.calls[0][0];
+    expect(arg.method).toBe("set_health_weights");
+    expect(arg.sourcePublicKey).toBe(TEST_CALLER);
+  });
+
+  it("buildSetHealthWeightsTransaction calls buildInvokeTransaction", async () => {
+    await sdk.buildSetHealthWeightsTransaction({
+      caller: TEST_CALLER,
+      liquidity_weight: 30,
+      price_stability_weight: 40,
+      bridge_uptime_weight: 30,
+      version: 2,
+    });
+    expect(buildInvokeTransactionSpy).toHaveBeenCalled();
+    const arg = buildInvokeTransactionSpy.mock.calls[0][0];
+    expect(arg.method).toBe("set_health_weights");
+  });
+});

--- a/sdk/src/contract.ts
+++ b/sdk/src/contract.ts
@@ -69,9 +69,88 @@ export interface HealthSource {
   registered_at: number;
 }
 
+export type StatusTier = "ok" | "low" | "medium" | "high";
+
+export interface ContractStatusRollup {
+  tier: StatusTier;
+  asset_ok: number;
+  asset_low: number;
+  asset_medium: number;
+  asset_high: number;
+  bridge_ok: number;
+  bridge_low: number;
+  bridge_medium: number;
+  bridge_high: number;
+  timestamp: number;
+}
+
+export interface AssetStatusRollup {
+  asset_code: string;
+  tier: StatusTier;
+  health_score: number;
+  has_price_deviation_alert: boolean;
+  price_deviation_tier: StatusTier;
+  paused: boolean;
+  active: boolean;
+  timestamp: number;
+}
+
+export interface BridgeStatusRollup {
+  bridge_id: string;
+  tier: StatusTier;
+  latest_mismatch_bps: bigint;
+  is_critical: boolean;
+  timestamp: number;
+}
+
+export interface GlobalPauseState {
+  is_paused: boolean;
+  reason: string;
+  paused_at: number;
+  unpause_available_at: number;
+  emergency_contact: string;
+}
+
+export interface PauseRecord {
+  paused: boolean;
+  reason: string;
+  caller: string;
+  timestamp: number;
+}
+
+export type ConfigCategory = "Threshold" | "Timeouts" | "Limits";
+
+export interface ConfigValue {
+  value: bigint;
+  description: string;
+}
+
+export interface ConfigEntry {
+  category: ConfigCategory;
+  name: string;
+  value: ConfigValue;
+  version: number;
+  updated_at: number;
+  updated_by: string;
+}
+
+export interface AllConfigsExport {
+  entries: ConfigEntry[];
+  total: number;
+  exported_at: number;
+}
+
 export interface EventReplayPage {
   total: number;
   schema_version: number;
+}
+
+export interface SetHealthWeightsParams {
+  caller: string;
+  liquidity_weight: number;
+  price_stability_weight: number;
+  bridge_uptime_weight: number;
+  version: number;
 }
 
 export interface SubmitHealthParams {
@@ -276,6 +355,104 @@ function parseEventReplayPage(val: StellarSdk.xdr.ScVal): EventReplayPage {
   };
 }
 
+function parseStatusTier(val: StellarSdk.xdr.ScVal): StatusTier {
+  const v = parseScvString(val).toLowerCase();
+  if (["ok", "low", "medium", "high"].includes(v)) return v as StatusTier;
+  return "ok";
+}
+
+function parseScvI128AsNumber(val: StellarSdk.xdr.ScVal): number {
+  return Number(parseScvI128(val));
+}
+
+function parseContractStatusRollup(val: StellarSdk.xdr.ScVal): ContractStatusRollup {
+  const m = getScvMap(val);
+  return {
+    tier: parseStatusTier(m.get("tier")!),
+    asset_ok: parseScvU32(m.get("asset_ok")!),
+    asset_low: parseScvU32(m.get("asset_low")!),
+    asset_medium: parseScvU32(m.get("asset_medium")!),
+    asset_high: parseScvU32(m.get("asset_high")!),
+    bridge_ok: parseScvU32(m.get("bridge_ok")!),
+    bridge_low: parseScvU32(m.get("bridge_low")!),
+    bridge_medium: parseScvU32(m.get("bridge_medium")!),
+    bridge_high: parseScvU32(m.get("bridge_high")!),
+    timestamp: parseScvU64(m.get("timestamp")!),
+  };
+}
+
+function parseAssetStatusRollup(val: StellarSdk.xdr.ScVal): AssetStatusRollup {
+  const m = getScvMap(val);
+  return {
+    asset_code: parseScvString(m.get("asset_code")!),
+    tier: parseStatusTier(m.get("tier")!),
+    health_score: parseScvU32(m.get("health_score")!),
+    has_price_deviation_alert: parseScvBool(m.get("has_price_deviation_alert")!),
+    price_deviation_tier: parseStatusTier(m.get("price_deviation_tier")!),
+    paused: parseScvBool(m.get("paused")!),
+    active: parseScvBool(m.get("active")!),
+    timestamp: parseScvU64(m.get("timestamp")!),
+  };
+}
+
+function parseBridgeStatusRollup(val: StellarSdk.xdr.ScVal): BridgeStatusRollup {
+  const m = getScvMap(val);
+  return {
+    bridge_id: parseScvString(m.get("bridge_id")!),
+    tier: parseStatusTier(m.get("tier")!),
+    latest_mismatch_bps: parseScvI128(m.get("latest_mismatch_bps")!),
+    is_critical: parseScvBool(m.get("is_critical")!),
+    timestamp: parseScvU64(m.get("timestamp")!),
+  };
+}
+
+function parseGlobalPauseState(val: StellarSdk.xdr.ScVal): GlobalPauseState {
+  const m = getScvMap(val);
+  return {
+    is_paused: parseScvBool(m.get("is_paused")!),
+    reason: parseScvString(m.get("reason")!),
+    paused_at: parseScvU64(m.get("paused_at")!),
+    unpause_available_at: parseScvU64(m.get("unpause_available_at")!),
+    emergency_contact: parseScvString(m.get("emergency_contact")!),
+  };
+}
+
+function parsePauseRecord(val: StellarSdk.xdr.ScVal): PauseRecord {
+  const m = getScvMap(val);
+  return {
+    paused: parseScvBool(m.get("paused")!),
+    reason: parseScvString(m.get("reason")!),
+    caller: parseScvString(m.get("caller")!),
+    timestamp: parseScvU64(m.get("timestamp")!),
+  };
+}
+
+function parseConfigEntry(val: StellarSdk.xdr.ScVal): ConfigEntry {
+  const m = getScvMap(val);
+  const valueMap = getScvMap(m.get("value")!);
+  return {
+    category: parseScvString(m.get("category")!) as ConfigCategory,
+    name: parseScvString(m.get("name")!),
+    value: {
+      value: parseScvI128(valueMap.get("value")!),
+      description: parseScvString(valueMap.get("description")!),
+    },
+    version: parseScvU32(m.get("version")!),
+    updated_at: parseScvU64(m.get("updated_at")!),
+    updated_by: parseScvString(m.get("updated_by")!),
+  };
+}
+
+function parseVecOfStrings(val: StellarSdk.xdr.ScVal): string[] {
+  const items = val.vec() ?? [];
+  return items.map(parseScvString);
+}
+
+function parseVecOfPauseRecords(val: StellarSdk.xdr.ScVal): PauseRecord[] {
+  const items = val.vec() ?? [];
+  return items.map(parsePauseRecord);
+}
+
 function extractResultScVal(
   simulation: StellarSdk.rpc.Api.SimulateTransactionResponse
 ): StellarSdk.xdr.ScVal | undefined {
@@ -426,6 +603,104 @@ export class TypedBridgeWatchContractSdk extends BridgeWatchContractSdk {
   }
 
   // ---------------------------------------------------------
+  // Status & pause query methods
+  // ---------------------------------------------------------
+
+  async getContractStatus(): Promise<ContractStatusRollup | null> {
+    const result = await this.queryMethod({
+      method: "get_contract_status",
+    });
+    const val = extractResultScVal(result);
+    if (!val || isScvVoid(val)) return null;
+    return parseContractStatusRollup(val);
+  }
+
+  async getAssetStatusRollup(
+    assetCode: string
+  ): Promise<AssetStatusRollup | null> {
+    const result = await this.queryMethod({
+      method: "get_asset_status_rollup",
+      args: [scvString(assetCode)],
+    });
+    const val = extractResultScVal(result);
+    if (!val || isScvVoid(val)) return null;
+    return parseAssetStatusRollup(val);
+  }
+
+  async getBridgeStatusRollup(
+    bridgeId: string
+  ): Promise<BridgeStatusRollup | null> {
+    const result = await this.queryMethod({
+      method: "get_bridge_status_rollup",
+      args: [scvString(bridgeId)],
+    });
+    const val = extractResultScVal(result);
+    if (!val || isScvVoid(val)) return null;
+    return parseBridgeStatusRollup(val);
+  }
+
+  async isPaused(): Promise<boolean> {
+    const result = await this.queryMethod({
+      method: "is_paused",
+    });
+    const val = extractResultScVal(result);
+    if (!val) throw new BridgeWatchQueryError("Empty result from is_paused");
+    return parseScvBool(val);
+  }
+
+  async isAssetPaused(assetCode: string): Promise<boolean> {
+    const result = await this.queryMethod({
+      method: "is_asset_paused",
+      args: [scvString(assetCode)],
+    });
+    const val = extractResultScVal(result);
+    if (!val)
+      throw new BridgeWatchQueryError("Empty result from is_asset_paused");
+    return parseScvBool(val);
+  }
+
+  async getPauseStatus(): Promise<GlobalPauseState> {
+    const result = await this.queryMethod({
+      method: "get_pause_status",
+    });
+    const val = extractResultScVal(result);
+    if (!val)
+      throw new BridgeWatchQueryError("Empty result from get_pause_status");
+    return parseGlobalPauseState(val);
+  }
+
+  async getPauseHistory(): Promise<PauseRecord[]> {
+    const result = await this.queryMethod({
+      method: "get_pause_history",
+    });
+    const val = extractResultScVal(result);
+    if (!val) return [];
+    return parseVecOfPauseRecords(val);
+  }
+
+  async getMonitoredAssets(): Promise<string[]> {
+    const result = await this.queryMethod({
+      method: "get_monitored_assets",
+    });
+    const val = extractResultScVal(result);
+    if (!val) return [];
+    return parseVecOfStrings(val);
+  }
+
+  async getConfig(
+    category: ConfigCategory,
+    name: string
+  ): Promise<ConfigEntry | null> {
+    const result = await this.queryMethod({
+      method: "get_config",
+      args: [scvString(category), scvString(name)],
+    });
+    const val = extractResultScVal(result);
+    if (!val || isScvVoid(val)) return null;
+    return parseConfigEntry(val);
+  }
+
+  // ---------------------------------------------------------
   // Signature methods
   // ---------------------------------------------------------
 
@@ -552,6 +827,41 @@ export class TypedBridgeWatchContractSdk extends BridgeWatchContractSdk {
         scvString(params.asset_code),
         scvI128(params.price),
         scvString(params.source),
+      ],
+    });
+  }
+
+  async setHealthWeights(
+    params: SetHealthWeightsParams
+  ): ReturnType<BridgeWatchContractSdk["invokeAndSend"]> {
+    return this.invokeAndSend(
+      {
+        sourcePublicKey: params.caller,
+        method: "set_health_weights",
+        args: [
+          scvAddress(params.caller),
+          scvU32(params.liquidity_weight),
+          scvU32(params.price_stability_weight),
+          scvU32(params.bridge_uptime_weight),
+          scvU32(params.version),
+        ],
+      },
+      params.caller
+    );
+  }
+
+  async buildSetHealthWeightsTransaction(
+    params: SetHealthWeightsParams
+  ): ReturnType<BridgeWatchContractSdk["buildInvokeTransaction"]> {
+    return this.buildInvokeTransaction({
+      sourcePublicKey: params.caller,
+      method: "set_health_weights",
+      args: [
+        scvAddress(params.caller),
+        scvU32(params.liquidity_weight),
+        scvU32(params.price_stability_weight),
+        scvU32(params.bridge_uptime_weight),
+        scvU32(params.version),
       ],
     });
   }

--- a/sdk/src/contract.ts
+++ b/sdk/src/contract.ts
@@ -1,0 +1,558 @@
+import * as StellarSdk from "@stellar/stellar-sdk";
+import { BridgeWatchContractSdk } from "./client";
+import type { BridgeWatchSdkConfig, InvokeContractParams } from "./types";
+import { BridgeWatchQueryError, BridgeWatchTransactionError } from "./errors";
+
+// ============================================================
+// TypeScript interfaces mirroring Soroban contract types
+// ============================================================
+
+export interface AssetHealth {
+  asset_code: string;
+  health_score: number;
+  liquidity_score: number;
+  price_stability_score: number;
+  bridge_uptime_score: number;
+  paused: boolean;
+  active: boolean;
+  timestamp: number;
+  expires_at: number;
+}
+
+export interface PriceRecord {
+  asset_code: string;
+  price: bigint;
+  source: string;
+  timestamp: number;
+  expires_at: number;
+}
+
+export interface HealthScoreBatch {
+  asset_code: string;
+  health_score: number;
+  liquidity_score: number;
+  price_stability_score: number;
+  bridge_uptime_score: number;
+}
+
+export interface HealthWeights {
+  liquidity_weight: number;
+  price_stability_weight: number;
+  bridge_uptime_weight: number;
+  version: number;
+}
+
+export interface HealthScoreResult {
+  composite_score: number;
+  liquidity_score: number;
+  price_stability_score: number;
+  bridge_uptime_score: number;
+  weights: HealthWeights;
+  timestamp: number;
+  expires_at: number;
+}
+
+export interface AggregatedHealth {
+  asset_code: string;
+  weighted_health_score: number;
+  weighted_liquidity_score: number;
+  weighted_price_stability_score: number;
+  weighted_bridge_uptime_score: number;
+  source_count: number;
+  computed_at: number;
+}
+
+export interface HealthSource {
+  source_id: string;
+  weight_bps: number;
+  trusted: boolean;
+  registered_at: number;
+}
+
+export interface EventReplayPage {
+  total: number;
+  schema_version: number;
+}
+
+export interface SubmitHealthParams {
+  caller: string;
+  asset_code: string;
+  health_score: number;
+  liquidity_score: number;
+  price_stability_score: number;
+  bridge_uptime_score: number;
+}
+
+export interface SubmitPriceParams {
+  caller: string;
+  asset_code: string;
+  price: bigint | number;
+  source: string;
+}
+
+// ============================================================
+// ScVal creation helpers
+// ============================================================
+
+function scvString(v: string): StellarSdk.xdr.ScVal {
+  return StellarSdk.xdr.ScVal.scvString(v);
+}
+
+function scvU32(v: number): StellarSdk.xdr.ScVal {
+  return StellarSdk.xdr.ScVal.scvU32(v);
+}
+
+function scvI128(v: bigint | number): StellarSdk.xdr.ScVal {
+  const val = typeof v === "number" ? BigInt(v) : v;
+  const lo = StellarSdk.xdr.Uint64.fromString(
+    String(val & BigInt("0xFFFFFFFFFFFFFFFF"))
+  );
+  const hi = StellarSdk.xdr.Int64.fromString(
+    String(val >> BigInt(64))
+  );
+  return StellarSdk.xdr.ScVal.scvI128(
+    new StellarSdk.xdr.Int128Parts({ lo, hi })
+  );
+}
+
+function scvU64(v: number): StellarSdk.xdr.ScVal {
+  return StellarSdk.xdr.ScVal.scvU64(
+    StellarSdk.xdr.Uint64.fromString(String(v))
+  );
+}
+
+function scvBool(v: boolean): StellarSdk.xdr.ScVal {
+  return StellarSdk.xdr.ScVal.scvBool(v);
+}
+
+function scvAddress(v: string): StellarSdk.xdr.ScVal {
+  return StellarSdk.Address.fromString(v).toScVal();
+}
+
+function scvMap(
+  entries: Array<{ key: string; val: StellarSdk.xdr.ScVal }>
+): StellarSdk.xdr.ScVal {
+  return StellarSdk.xdr.ScVal.scvMap(
+    entries.map(
+      (e) =>
+        new StellarSdk.xdr.ScMapEntry({
+          key: scvString(e.key),
+          val: e.val,
+        })
+    )
+  );
+}
+
+function scvVec(items: StellarSdk.xdr.ScVal[]): StellarSdk.xdr.ScVal {
+  return StellarSdk.xdr.ScVal.scvVec(items);
+}
+
+// ============================================================
+// ScVal parsing helpers
+// ============================================================
+
+function isScvVoid(val: StellarSdk.xdr.ScVal): boolean {
+  return val.switch().name === "scvVoid";
+}
+
+function parseScvString(val: StellarSdk.xdr.ScVal): string {
+  const v = val.str();
+  if (v == null) return "";
+  return typeof v === "string" ? v : Buffer.from(v).toString("utf-8");
+}
+
+function parseScvU32(val: StellarSdk.xdr.ScVal): number {
+  return val.u32() ?? 0;
+}
+
+function parseScvU64(val: StellarSdk.xdr.ScVal): number {
+  return Number(val.u64()?.toString() ?? "0");
+}
+
+function parseScvBool(val: StellarSdk.xdr.ScVal): boolean {
+  return val.b() ?? false;
+}
+
+function parseScvI128(val: StellarSdk.xdr.ScVal): bigint {
+  const parts = val.i128();
+  const lo = BigInt(parts.lo().toString());
+  const hi = BigInt(parts.hi().toString());
+  return (hi << BigInt(64)) | lo;
+}
+
+function getScvMap(
+  val: StellarSdk.xdr.ScVal
+): Map<string, StellarSdk.xdr.ScVal> {
+  const entries = val.map() ?? [];
+  const m = new Map<string, StellarSdk.xdr.ScVal>();
+  for (const entry of entries) {
+    const key = parseScvString(entry.key());
+    m.set(key, entry.val());
+  }
+  return m;
+}
+
+function parseAssetHealth(val: StellarSdk.xdr.ScVal): AssetHealth {
+  const m = getScvMap(val);
+  return {
+    asset_code: parseScvString(m.get("asset_code")!),
+    health_score: parseScvU32(m.get("health_score")!),
+    liquidity_score: parseScvU32(m.get("liquidity_score")!),
+    price_stability_score: parseScvU32(m.get("price_stability_score")!),
+    bridge_uptime_score: parseScvU32(m.get("bridge_uptime_score")!),
+    paused: parseScvBool(m.get("paused")!),
+    active: parseScvBool(m.get("active")!),
+    timestamp: parseScvU64(m.get("timestamp")!),
+    expires_at: parseScvU64(m.get("expires_at")!),
+  };
+}
+
+function parsePriceRecord(val: StellarSdk.xdr.ScVal): PriceRecord {
+  const m = getScvMap(val);
+  return {
+    asset_code: parseScvString(m.get("asset_code")!),
+    price: parseScvI128(m.get("price")!),
+    source: parseScvString(m.get("source")!),
+    timestamp: parseScvU64(m.get("timestamp")!),
+    expires_at: parseScvU64(m.get("expires_at")!),
+  };
+}
+
+function parseHealthWeights(val: StellarSdk.xdr.ScVal): HealthWeights {
+  const m = getScvMap(val);
+  return {
+    liquidity_weight: parseScvU32(m.get("liquidity_weight")!),
+    price_stability_weight: parseScvU32(m.get("price_stability_weight")!),
+    bridge_uptime_weight: parseScvU32(m.get("bridge_uptime_weight")!),
+    version: parseScvU32(m.get("version")!),
+  };
+}
+
+function parseHealthScoreResult(val: StellarSdk.xdr.ScVal): HealthScoreResult {
+  const m = getScvMap(val);
+  return {
+    composite_score: parseScvU32(m.get("composite_score")!),
+    liquidity_score: parseScvU32(m.get("liquidity_score")!),
+    price_stability_score: parseScvU32(m.get("price_stability_score")!),
+    bridge_uptime_score: parseScvU32(m.get("bridge_uptime_score")!),
+    weights: parseHealthWeights(m.get("weights")!),
+    timestamp: parseScvU64(m.get("timestamp")!),
+    expires_at: parseScvU64(m.get("expires_at")!),
+  };
+}
+
+function parseAggregatedHealth(val: StellarSdk.xdr.ScVal): AggregatedHealth {
+  const m = getScvMap(val);
+  return {
+    asset_code: parseScvString(m.get("asset_code")!),
+    weighted_health_score: parseScvU32(m.get("weighted_health_score")!),
+    weighted_liquidity_score: parseScvU32(m.get("weighted_liquidity_score")!),
+    weighted_price_stability_score: parseScvU32(
+      m.get("weighted_price_stability_score")!
+    ),
+    weighted_bridge_uptime_score: parseScvU32(
+      m.get("weighted_bridge_uptime_score")!
+    ),
+    source_count: parseScvU32(m.get("source_count")!),
+    computed_at: parseScvU64(m.get("computed_at")!),
+  };
+}
+
+function parseHealthSource(val: StellarSdk.xdr.ScVal): HealthSource {
+  const m = getScvMap(val);
+  return {
+    source_id: parseScvString(m.get("source_id")!),
+    weight_bps: parseScvU32(m.get("weight_bps")!),
+    trusted: parseScvBool(m.get("trusted")!),
+    registered_at: parseScvU64(m.get("registered_at")!),
+  };
+}
+
+function parseEventReplayPage(val: StellarSdk.xdr.ScVal): EventReplayPage {
+  const m = getScvMap(val);
+  return {
+    total: parseScvU32(m.get("total")!),
+    schema_version: parseScvU32(m.get("schema_version")!),
+  };
+}
+
+function extractResultScVal(
+  simulation: StellarSdk.rpc.Api.SimulateTransactionResponse
+): StellarSdk.xdr.ScVal | undefined {
+  if (
+    StellarSdk.rpc.Api.isSimulationSuccess(simulation) &&
+    simulation.result?.retval
+  ) {
+    return simulation.result.retval;
+  }
+  return undefined;
+}
+
+// ============================================================
+// TypedBridgeWatchContractSdk
+// ============================================================
+
+export class TypedBridgeWatchContractSdk extends BridgeWatchContractSdk {
+  constructor(config: BridgeWatchSdkConfig) {
+    super(config);
+  }
+
+  // ---------------------------------------------------------
+  // Health query methods
+  // ---------------------------------------------------------
+
+  async getContractHealth(assetCode: string): Promise<AssetHealth | null> {
+    const result = await this.queryMethod({
+      method: "get_health",
+      args: [scvString(assetCode)],
+    });
+    const val = extractResultScVal(result);
+    if (!val || isScvVoid(val)) return null;
+    return parseAssetHealth(val);
+  }
+
+  async getHealthScoreResult(
+    assetCode: string
+  ): Promise<HealthScoreResult | null> {
+    const result = await this.queryMethod({
+      method: "get_health_score_result",
+      args: [scvString(assetCode)],
+    });
+    const val = extractResultScVal(result);
+    if (!val || isScvVoid(val)) return null;
+    return parseHealthScoreResult(val);
+  }
+
+  async getAggregatedHealth(
+    assetCode: string
+  ): Promise<AggregatedHealth | null> {
+    const result = await this.queryMethod({
+      method: "get_aggregated_health",
+      args: [scvString(assetCode)],
+    });
+    const val = extractResultScVal(result);
+    if (!val || isScvVoid(val)) return null;
+    return parseAggregatedHealth(val);
+  }
+
+  async getHealthWeights(): Promise<HealthWeights> {
+    const result = await this.queryMethod({
+      method: "get_health_weights",
+    });
+    const val = extractResultScVal(result);
+    if (!val) throw new BridgeWatchQueryError("Empty result from get_health_weights");
+    return parseHealthWeights(val);
+  }
+
+  async getHealthSources(): Promise<HealthSource[]> {
+    const result = await this.queryMethod({
+      method: "get_health_sources",
+    });
+    const val = extractResultScVal(result);
+    if (!val) return [];
+    const items = val.vec() ?? [];
+    return items.map((item) => parseHealthSource(item));
+  }
+
+  async calculateHealthScore(
+    liquidityScore: number,
+    priceStabilityScore: number,
+    bridgeUptimeScore: number
+  ): Promise<HealthScoreResult> {
+    const result = await this.queryMethod({
+      method: "calculate_health_score",
+      args: [
+        scvU32(liquidityScore),
+        scvU32(priceStabilityScore),
+        scvU32(bridgeUptimeScore),
+      ],
+    });
+    const val = extractResultScVal(result);
+    if (!val)
+      throw new BridgeWatchQueryError("Empty result from calculate_health_score");
+    return parseHealthScoreResult(val);
+  }
+
+  // ---------------------------------------------------------
+  // Price query methods
+  // ---------------------------------------------------------
+
+  async getPrice(assetCode: string): Promise<PriceRecord | null> {
+    const result = await this.queryMethod({
+      method: "get_price",
+      args: [scvString(assetCode)],
+    });
+    const val = extractResultScVal(result);
+    if (!val || isScvVoid(val)) return null;
+    return parsePriceRecord(val);
+  }
+
+  // ---------------------------------------------------------
+  // Replay query methods
+  // ---------------------------------------------------------
+
+  async getReplaySchemaVersion(): Promise<number> {
+    const result = await this.queryMethod({
+      method: "get_replay_schema_version",
+    });
+    const val = extractResultScVal(result);
+    if (!val)
+      throw new BridgeWatchQueryError("Empty result from get_replay_schema_version");
+    return parseScvU32(val);
+  }
+
+  async getReplayEvents(
+    fromOrderingKey: number,
+    limit: number
+  ): Promise<EventReplayPage> {
+    const result = await this.queryMethod({
+      method: "get_replay_events",
+      args: [scvU64(fromOrderingKey), scvU32(limit)],
+    });
+    const val = extractResultScVal(result);
+    if (!val)
+      throw new BridgeWatchQueryError("Empty result from get_replay_events");
+    return parseEventReplayPage(val);
+  }
+
+  async getReplayLogSize(): Promise<number> {
+    const result = await this.queryMethod({
+      method: "get_replay_log_size",
+    });
+    const val = extractResultScVal(result);
+    if (!val)
+      throw new BridgeWatchQueryError("Empty result from get_replay_log_size");
+    return parseScvU32(val);
+  }
+
+  // ---------------------------------------------------------
+  // Signature methods
+  // ---------------------------------------------------------
+
+  async getSignatureThreshold(): Promise<number> {
+    const result = await this.queryMethod({
+      method: "get_signature_threshold",
+    });
+    const val = extractResultScVal(result);
+    if (!val)
+      throw new BridgeWatchQueryError("Empty result from get_signature_threshold");
+    return parseScvU32(val);
+  }
+
+  // ---------------------------------------------------------
+  // Invoke (write) methods
+  // ---------------------------------------------------------
+
+  async submitHealth(
+    params: SubmitHealthParams
+  ): ReturnType<BridgeWatchContractSdk["invokeAndSend"]> {
+    return this.invokeAndSend(
+      {
+        sourcePublicKey: params.caller,
+        method: "submit_health",
+        args: [
+          scvAddress(params.caller),
+          scvString(params.asset_code),
+          scvU32(params.health_score),
+          scvU32(params.liquidity_score),
+          scvU32(params.price_stability_score),
+          scvU32(params.bridge_uptime_score),
+        ],
+      },
+      params.caller
+    );
+  }
+
+  async submitHealthBatch(
+    caller: string,
+    records: HealthScoreBatch[]
+  ): ReturnType<BridgeWatchContractSdk["invokeAndSend"]> {
+    const batchItems = records.map((r) =>
+      scvMap([
+        { key: "asset_code", val: scvString(r.asset_code) },
+        { key: "health_score", val: scvU32(r.health_score) },
+        { key: "liquidity_score", val: scvU32(r.liquidity_score) },
+        { key: "price_stability_score", val: scvU32(r.price_stability_score) },
+        { key: "bridge_uptime_score", val: scvU32(r.bridge_uptime_score) },
+      ])
+    );
+    return this.invokeAndSend(
+      {
+        sourcePublicKey: caller,
+        method: "submit_health_batch",
+        args: [scvAddress(caller), scvVec(batchItems)],
+      },
+      caller
+    );
+  }
+
+  async submitPrice(
+    params: SubmitPriceParams
+  ): ReturnType<BridgeWatchContractSdk["invokeAndSend"]> {
+    return this.invokeAndSend(
+      {
+        sourcePublicKey: params.caller,
+        method: "submit_price",
+        args: [
+          scvAddress(params.caller),
+          scvString(params.asset_code),
+          scvI128(params.price),
+          scvString(params.source),
+        ],
+      },
+      params.caller
+    );
+  }
+
+  async buildSubmitHealthTransaction(
+    params: SubmitHealthParams
+  ): ReturnType<BridgeWatchContractSdk["buildInvokeTransaction"]> {
+    return this.buildInvokeTransaction({
+      sourcePublicKey: params.caller,
+      method: "submit_health",
+      args: [
+        scvAddress(params.caller),
+        scvString(params.asset_code),
+        scvU32(params.health_score),
+        scvU32(params.liquidity_score),
+        scvU32(params.price_stability_score),
+        scvU32(params.bridge_uptime_score),
+      ],
+    });
+  }
+
+  async buildSubmitHealthBatchTransaction(
+    caller: string,
+    records: HealthScoreBatch[]
+  ): ReturnType<BridgeWatchContractSdk["buildInvokeTransaction"]> {
+    const batchItems = records.map((r) =>
+      scvMap([
+        { key: "asset_code", val: scvString(r.asset_code) },
+        { key: "health_score", val: scvU32(r.health_score) },
+        { key: "liquidity_score", val: scvU32(r.liquidity_score) },
+        { key: "price_stability_score", val: scvU32(r.price_stability_score) },
+        { key: "bridge_uptime_score", val: scvU32(r.bridge_uptime_score) },
+      ])
+    );
+    return this.buildInvokeTransaction({
+      sourcePublicKey: caller,
+      method: "submit_health_batch",
+      args: [scvAddress(caller), scvVec(batchItems)],
+    });
+  }
+
+  async buildSubmitPriceTransaction(
+    params: SubmitPriceParams
+  ): ReturnType<BridgeWatchContractSdk["buildInvokeTransaction"]> {
+    return this.buildInvokeTransaction({
+      sourcePublicKey: params.caller,
+      method: "submit_price",
+      args: [
+        scvAddress(params.caller),
+        scvString(params.asset_code),
+        scvI128(params.price),
+        scvString(params.source),
+      ],
+    });
+  }
+}

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./types";
 export * from "./errors";
 export * from "./client";
+export * from "./contract";
 export * from "./testing";


### PR DESCRIPTION
## Description
Adds typed TypeScript wrappers for the remaining BridgeWatch Soroban contract read/write methods â status rollups, pause state, config access, monitored assets, and health-weight management â completing the typed SDK surface for the core contract.
Closes #677 
Closes #678 
Closes #681 
Closes #679 

### Changes
sdk/src/contract.ts (+406/-0)
- Types: StatusTier, ContractStatusRollup, AssetStatusRollup, BridgeStatusRollup, GlobalPauseState, PauseRecord, ConfigCategory, ConfigValue, ConfigEntry, AllConfigsExport, SetHealthWeightsParams
- Parsers: parseStatusTier, parseContractStatusRollup, parseAssetStatusRollup, parseBridgeStatusRollup, parseGlobalPauseState, parsePauseRecord, parseConfigEntry, parseVecOfStrings, parseVecOfPauseRecords
- Query wrappers: getContractStatus, getAssetStatusRollup, getBridgeStatusRollup, isPaused, isAssetPaused, getPauseStatus, getPauseHistory, getMonitoredAssets, getConfig
- Invoke wrapper: setHealthWeights + buildSetHealthWeightsTransaction
sdk/src/contract.test.ts (+50/-1) â 11 new tests covering all new wrappers (38 total).
sdk/examples/basic-usage.ts â rewritten to showcase the typed SDK.
### Verification
- Build: clean