### PR TITLE
test(backend): unit & route tests for maintenance, fragmentation, metrics & reconciliation

### DIFF
--- a/backend/tests/api/reconciliation.test.ts
+++ b/backend/tests/api/reconciliation.test.ts
@@ -1,0 +1,249 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { FastifyInstance } from "fastify";
+
+vi.hoisted(() => {
+  process.env.NODE_ENV = "test";
+  process.env.API_KEY_BOOTSTRAP_TOKEN = "bootstrap-secret";
+});
+
+import { buildServer } from "../../src/index.js";
+
+// The route does `new ReconciliationService()`, so mock the constructor to
+// return an object backed by shared spies.
+const reconMocks = vi.hoisted(() => ({
+  getDriftSummaries: vi.fn(),
+  listRuns: vi.fn(),
+  getMismatchDetail: vi.fn(),
+  updateTriageStatus: vi.fn(),
+  getLatestRun: vi.fn(),
+}));
+
+vi.mock("../../src/services/reconciliation.service.js", () => ({
+  ReconciliationService: vi.fn(() => ({
+    getDriftSummaries: reconMocks.getDriftSummaries,
+    listRuns: reconMocks.listRuns,
+    getMismatchDetail: reconMocks.getMismatchDetail,
+    updateTriageStatus: reconMocks.updateTriageStatus,
+    getLatestRun: reconMocks.getLatestRun,
+  })),
+}));
+
+const BASE = "/api/v1/reconciliation";
+const VALID_UUID = "11111111-1111-4111-8111-111111111111";
+
+describe("Reconciliation API", () => {
+  let server: FastifyInstance;
+
+  beforeAll(async () => {
+    server = await buildServer();
+  });
+
+  afterAll(async () => {
+    await server.close();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("GET /runs", () => {
+    it("returns the reconciliation runs", async () => {
+      const runs = [
+        { id: VALID_UUID, assetCode: "USDC", status: "completed", drift: "0" },
+      ];
+      reconMocks.listRuns.mockResolvedValueOnce(runs);
+
+      const response = await server.inject({ method: "GET", url: `${BASE}/runs` });
+
+      expect(response.statusCode).toBe(200);
+      expect(JSON.parse(response.body)).toEqual({ runs });
+      expect(reconMocks.listRuns).toHaveBeenCalledTimes(1);
+    });
+
+    it("forwards assetCode and limit query params to the service", async () => {
+      reconMocks.listRuns.mockResolvedValueOnce([]);
+
+      const response = await server.inject({
+        method: "GET",
+        url: `${BASE}/runs?assetCode=USDC&limit=10`,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(reconMocks.listRuns).toHaveBeenCalledWith(
+        expect.objectContaining({ assetCode: "USDC", limit: 10 }),
+      );
+    });
+
+    it("returns 400 for an invalid limit", async () => {
+      const response = await server.inject({
+        method: "GET",
+        url: `${BASE}/runs?limit=-5`,
+      });
+      expect(response.statusCode).toBe(400);
+      expect(reconMocks.listRuns).not.toHaveBeenCalled();
+    });
+
+    it("returns 500 when the service throws", async () => {
+      reconMocks.listRuns.mockRejectedValueOnce(new Error("db down"));
+
+      const response = await server.inject({ method: "GET", url: `${BASE}/runs` });
+
+      expect(response.statusCode).toBe(500);
+      expect(JSON.parse(response.body)).toHaveProperty("error");
+    });
+  });
+
+  describe("GET /drift-summaries", () => {
+    it("returns drift summary results", async () => {
+      const summaries = [
+        { assetCode: "USDC", bridge: "Circle", drift: "1200.5", direction: "surplus" },
+      ];
+      reconMocks.getDriftSummaries.mockResolvedValueOnce(summaries);
+
+      const response = await server.inject({
+        method: "GET",
+        url: `${BASE}/drift-summaries?assetCode=USDC&range=7d`,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(JSON.parse(response.body)).toEqual(summaries);
+      expect(reconMocks.getDriftSummaries).toHaveBeenCalledWith(
+        expect.objectContaining({ assetCode: "USDC", range: "7d" }),
+      );
+    });
+
+    it("returns 400 for an invalid range", async () => {
+      const response = await server.inject({
+        method: "GET",
+        url: `${BASE}/drift-summaries?range=99h`,
+      });
+      expect(response.statusCode).toBe(400);
+      expect(reconMocks.getDriftSummaries).not.toHaveBeenCalled();
+    });
+
+    it("returns 500 when the service throws", async () => {
+      reconMocks.getDriftSummaries.mockRejectedValueOnce(new Error("boom"));
+
+      const response = await server.inject({
+        method: "GET",
+        url: `${BASE}/drift-summaries`,
+      });
+      expect(response.statusCode).toBe(500);
+    });
+  });
+
+  describe("GET /latest/:assetCode", () => {
+    it("returns the latest run for an asset", async () => {
+      const run = { id: VALID_UUID, assetCode: "USDC", status: "completed" };
+      reconMocks.getLatestRun.mockResolvedValueOnce(run);
+
+      const response = await server.inject({
+        method: "GET",
+        url: `${BASE}/latest/USDC`,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(JSON.parse(response.body)).toEqual({ run });
+      expect(reconMocks.getLatestRun).toHaveBeenCalledWith("USDC");
+    });
+
+    it("returns 404 when no run exists", async () => {
+      reconMocks.getLatestRun.mockResolvedValueOnce(null);
+
+      const response = await server.inject({
+        method: "GET",
+        url: `${BASE}/latest/EURC`,
+      });
+      expect(response.statusCode).toBe(404);
+    });
+
+    it("returns 500 when the service throws", async () => {
+      reconMocks.getLatestRun.mockRejectedValueOnce(new Error("nope"));
+
+      const response = await server.inject({
+        method: "GET",
+        url: `${BASE}/latest/USDC`,
+      });
+      expect(response.statusCode).toBe(500);
+    });
+  });
+
+  describe("GET /mismatches/:id", () => {
+    it("returns 400 for a non-UUID id", async () => {
+      const response = await server.inject({
+        method: "GET",
+        url: `${BASE}/mismatches/not-a-uuid`,
+      });
+      expect(response.statusCode).toBe(400);
+      expect(reconMocks.getMismatchDetail).not.toHaveBeenCalled();
+    });
+
+    it("returns 404 when the mismatch is not found", async () => {
+      reconMocks.getMismatchDetail.mockResolvedValueOnce(null);
+
+      const response = await server.inject({
+        method: "GET",
+        url: `${BASE}/mismatches/${VALID_UUID}`,
+      });
+      expect(response.statusCode).toBe(404);
+    });
+
+    it("returns the mismatch detail when found", async () => {
+      const detail = { id: VALID_UUID, assetCode: "USDC", expected: "100", actual: "98" };
+      reconMocks.getMismatchDetail.mockResolvedValueOnce(detail);
+
+      const response = await server.inject({
+        method: "GET",
+        url: `${BASE}/mismatches/${VALID_UUID}?range=24h`,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(JSON.parse(response.body)).toEqual(detail);
+      expect(reconMocks.getMismatchDetail).toHaveBeenCalledWith(
+        VALID_UUID,
+        expect.objectContaining({ range: "24h" }),
+      );
+    });
+  });
+
+  describe("PATCH /runs/:id/triage", () => {
+    it("updates the triage status of a run", async () => {
+      const run = { id: VALID_UUID, triageStatus: "investigating" };
+      reconMocks.updateTriageStatus.mockResolvedValueOnce(run);
+
+      const response = await server.inject({
+        method: "PATCH",
+        url: `${BASE}/runs/${VALID_UUID}/triage`,
+        payload: { status: "investigating", owner: "ops@bridgewatch" },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(JSON.parse(response.body)).toEqual({ run });
+      expect(reconMocks.updateTriageStatus).toHaveBeenCalledWith(
+        VALID_UUID,
+        expect.objectContaining({ status: "investigating", owner: "ops@bridgewatch" }),
+      );
+    });
+
+    it("returns 400 for an invalid status value", async () => {
+      const response = await server.inject({
+        method: "PATCH",
+        url: `${BASE}/runs/${VALID_UUID}/triage`,
+        payload: { status: "not-a-status" },
+      });
+      expect(response.statusCode).toBe(400);
+      expect(reconMocks.updateTriageStatus).not.toHaveBeenCalled();
+    });
+
+    it("returns 404 when the run does not exist", async () => {
+      reconMocks.updateTriageStatus.mockResolvedValueOnce(null);
+
+      const response = await server.inject({
+        method: "PATCH",
+        url: `${BASE}/runs/${VALID_UUID}/triage`,
+        payload: { status: "resolved" },
+      });
+      expect(response.statusCode).toBe(404);
+    });
+  });
+});

--- a/backend/tests/services/liquidityFragmentation.service.test.ts
+++ b/backend/tests/services/liquidityFragmentation.service.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { LiquidityFragmentationService } from "../../src/services/liquidityFragmentation.service.js";
+import { CacheService } from "../../src/utils/cache.js";
+
+const createQueryBuilder = (rows: any[] = []) => {
+  const builder: any = {
+    select: vi.fn(() => builder),
+    where: vi.fn(() => builder),
+    whereIn: vi.fn(() => builder),
+    groupBy: vi.fn(() => builder),
+    orderBy: vi.fn(() => builder),
+    having: vi.fn(() => builder),
+    then: (resolve: (value: any) => any) => resolve(rows),
+  };
+  return builder;
+};
+
+const mockKnex = vi.hoisted(() => {
+  const knex: any = vi.fn(() => undefined);
+  knex.raw = vi.fn((sql: string) => sql);
+  return knex;
+});
+
+vi.mock("../../src/database/connection.js", () => ({
+  getDatabase: () => mockKnex,
+}));
+
+// Bypass Redis: getOrSet simply runs the fetcher.
+vi.mock("../../src/utils/cache.js", () => ({
+  CacheService: {
+    getOrSet: vi.fn(),
+    invalidateByTag: vi.fn(),
+    invalidatePattern: vi.fn(),
+    generateKey: vi.fn((namespace, id) => `cache:${namespace}:${id}`),
+  },
+  CacheTTL: { ANALYTICS: 300, PRICES: 60, METADATA: 3600, LONG_LIVED: 86400 },
+}));
+
+vi.mock("../../src/utils/redis.js", () => ({
+  redis: { expire: vi.fn(), del: vi.fn(), keys: vi.fn().mockResolvedValue([]) },
+}));
+
+describe("LiquidityFragmentationService", () => {
+  let service: LiquidityFragmentationService;
+
+  beforeEach(() => {
+    service = new LiquidityFragmentationService();
+    vi.clearAllMocks();
+    mockKnex.mockImplementation(() => createQueryBuilder([]));
+    vi.mocked(CacheService.getOrSet).mockImplementation(
+      async (_key: string, fetcher: () => any) => fetcher(),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ── Pure scoring math (exercised through the private methods) ──────────────
+
+  describe("fragmentation scoring math", () => {
+    const calc = () => service as any;
+
+    it("computes the Herfindahl index as the sum of squared shares", () => {
+      expect(calc().calculateHerfindahlIndex([0.5, 0.5])).toBeCloseTo(0.5);
+      expect(calc().calculateHerfindahlIndex([1])).toBeCloseTo(1);
+    });
+
+    it("returns a Gini coefficient of 0 for perfectly even liquidity", () => {
+      expect(calc().calculateGiniCoefficient([5, 5, 5])).toBeCloseTo(0);
+    });
+
+    it("returns 0 Gini for an empty distribution", () => {
+      expect(calc().calculateGiniCoefficient([])).toBe(0);
+    });
+
+    it("returns a positive Gini for skewed liquidity", () => {
+      expect(calc().calculateGiniCoefficient([0, 10])).toBeGreaterThan(0);
+    });
+
+    it("blends Herfindahl, Gini and DEX diversity into a rounded score", () => {
+      // herfindahl 0.5 -> 50, gini 0.3 -> 30, diversity 2/5 -> 40
+      // 50*0.4 + 30*0.4 + 40*0.2 = 40
+      expect(calc().calculateFragmentationScore(0.5, 0.3, 2)).toBe(40);
+    });
+
+    it("treats zero liquidity as maximum price impact", () => {
+      expect(calc().estimatePriceImpact(100, 0)).toBe(1);
+    });
+
+    it("caps price impact at 0.99", () => {
+      expect(calc().estimatePriceImpact(1_000_000, 1)).toBe(0.99);
+    });
+
+    it("rewards balanced, deep liquidity with higher confidence", () => {
+      const balanced = calc().calculateConfidence(100_000, 100_000);
+      const imbalanced = calc().calculateConfidence(1_000, 100_000);
+      expect(balanced).toBeGreaterThan(imbalanced);
+      expect(calc().calculateConfidence(0, 0)).toBe(0);
+    });
+  });
+
+  // ── getFragmentationMetrics ────────────────────────────────────────────────
+
+  describe("getFragmentationMetrics", () => {
+    it("returns null when there is no liquidity data", async () => {
+      mockKnex.mockImplementation(() => createQueryBuilder([]));
+      expect(await service.getFragmentationMetrics("USDC")).toBeNull();
+    });
+
+    it("returns null when total liquidity is below the threshold", async () => {
+      mockKnex.mockImplementation(() =>
+        createQueryBuilder([{ dex: "SDEX", avg_liquidity: "50" }]),
+      );
+      expect(await service.getFragmentationMetrics("USDC")).toBeNull();
+    });
+
+    it("computes metrics across multiple DEXes", async () => {
+      mockKnex.mockImplementation(() =>
+        createQueryBuilder([
+          { dex: "SDEX", avg_liquidity: "6000" },
+          { dex: "Phoenix", avg_liquidity: "4000" },
+        ]),
+      );
+
+      const metrics = await service.getFragmentationMetrics("USDC");
+      expect(metrics).not.toBeNull();
+      expect(metrics!.symbol).toBe("USDC");
+      expect(metrics!.totalLiquidity).toBe(10000);
+      expect(metrics!.dexCount).toBe(2);
+      expect(metrics!.concentrationRatio).toBeCloseTo(0.6);
+      expect(typeof metrics!.fragmentationScore).toBe("number");
+      expect(metrics!.herfindahlIndex).toBeGreaterThan(0);
+    });
+
+    it("uses the cache layer", async () => {
+      mockKnex.mockImplementation(() =>
+        createQueryBuilder([{ dex: "SDEX", avg_liquidity: "6000" }]),
+      );
+      await service.getFragmentationMetrics("USDC");
+      expect(CacheService.getOrSet).toHaveBeenCalledWith(
+        "cache:fragmentation:metrics:USDC",
+        expect.any(Function),
+        expect.objectContaining({ tags: ["fragmentation"] }),
+      );
+    });
+  });
+
+  // ── getDexLiquidityDistribution ────────────────────────────────────────────
+
+  describe("getDexLiquidityDistribution", () => {
+    it("returns ranked shares that reflect each DEX's portion of liquidity", async () => {
+      mockKnex.mockImplementation(() =>
+        createQueryBuilder([
+          { dex: "SDEX", avg_liquidity: "6000" },
+          { dex: "Phoenix", avg_liquidity: "4000" },
+        ]),
+      );
+
+      const distribution = await service.getDexLiquidityDistribution("USDC");
+      expect(distribution).toHaveLength(2);
+      expect(distribution[0]).toMatchObject({ dex: "SDEX", liquidity: 6000, rank: 1 });
+      expect(distribution[0].share).toBeCloseTo(60);
+      expect(distribution[1]).toMatchObject({ dex: "Phoenix", liquidity: 4000, rank: 2 });
+      expect(distribution[1].share).toBeCloseTo(40);
+    });
+
+    it("returns an empty distribution when there is no data", async () => {
+      mockKnex.mockImplementation(() => createQueryBuilder([]));
+      expect(await service.getDexLiquidityDistribution("USDC")).toEqual([]);
+    });
+  });
+
+  // ── detectArbitrageOpportunities ───────────────────────────────────────────
+
+  describe("detectArbitrageOpportunities", () => {
+    it("returns no opportunities when a pair has fewer than two DEXes", async () => {
+      mockKnex.mockImplementation(() =>
+        createQueryBuilder([
+          { dex: "SDEX", bid_depth: "100", ask_depth: "100", tvl_usd: "10000" },
+        ]),
+      );
+      const opportunities = await service.detectArbitrageOpportunities(["USDC/XLM"]);
+      expect(opportunities).toEqual([]);
+    });
+  });
+});

--- a/backend/tests/services/maintenance.service.test.ts
+++ b/backend/tests/services/maintenance.service.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { MaintenanceService } from "../../src/services/maintenance.service.js";
+
+// Every db() call records its builder so tests can assert on insert/update args.
+let builders: any[] = [];
+
+const createQueryBuilder = (rows: any[] = [], firstRow?: any) => {
+  const builder: any = {
+    insert: vi.fn(() => builder),
+    where: vi.fn(() => builder),
+    orWhere: vi.fn(() => builder),
+    andWhere: vi.fn(() => builder),
+    orderBy: vi.fn(() => builder),
+    limit: vi.fn(() => builder),
+    update: vi.fn(async () => 1),
+    first: vi.fn(async () => firstRow ?? rows[0]),
+    then: (resolve: (value: any) => any) => resolve(rows),
+  };
+  builders.push(builder);
+  return builder;
+};
+
+const mockKnex = vi.hoisted(() => vi.fn());
+
+vi.mock("../../src/database/connection", () => ({
+  getDatabase: () => mockKnex,
+}));
+
+const baseWindow = {
+  title: "DB upgrade",
+  description: "Primary DB version bump",
+  scope: "global" as const,
+  scope_identifier: null,
+  start_time: new Date("2030-01-01T00:00:00Z"),
+  end_time: new Date("2030-01-01T02:00:00Z"),
+  suppress_alerts: true,
+  alert_types_suppressed: ["depeg", "reserve_drift"],
+  created_by: "ops@bridgewatch",
+  timezone: "UTC",
+};
+
+describe("MaintenanceService", () => {
+  let service: MaintenanceService;
+
+  beforeEach(() => {
+    service = new MaintenanceService();
+    builders = [];
+    mockKnex.mockReset();
+    mockKnex.mockImplementation(() => createQueryBuilder([]));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("createWindow", () => {
+    it("creates a scheduled window with a generated id and writes an audit log", async () => {
+      const result = await service.createWindow(baseWindow);
+
+      expect(result.id).toMatch(/^[0-9a-f]{32}$/);
+      expect(result.status).toBe("scheduled");
+      expect(result.approved_by).toBeNull();
+      // alert_types_suppressed is returned as the original array, not the JSON string
+      expect(result.alert_types_suppressed).toEqual(["depeg", "reserve_drift"]);
+
+      expect(mockKnex).toHaveBeenCalledWith("maintenance_windows");
+      expect(mockKnex).toHaveBeenCalledWith("maintenance_audit_logs");
+
+      const insertCall = builders.find((b) => b.insert.mock.calls.length > 0);
+      expect(insertCall.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: "scheduled",
+          alert_types_suppressed: JSON.stringify(baseWindow.alert_types_suppressed),
+        }),
+      );
+    });
+
+    it("rethrows when the insert fails", async () => {
+      mockKnex.mockImplementation(() => {
+        throw new Error("insert failed");
+      });
+      await expect(service.createWindow(baseWindow)).rejects.toThrow("insert failed");
+    });
+  });
+
+  describe("getWindow", () => {
+    it("returns the window with a parsed alert_types_suppressed array", async () => {
+      mockKnex.mockImplementation(() =>
+        createQueryBuilder([], {
+          id: "w1",
+          title: "x",
+          alert_types_suppressed: JSON.stringify(["depeg"]),
+        }),
+      );
+
+      const window = await service.getWindow("w1");
+      expect(window?.id).toBe("w1");
+      expect(window?.alert_types_suppressed).toEqual(["depeg"]);
+    });
+
+    it("returns null when the window does not exist", async () => {
+      mockKnex.mockImplementation(() => createQueryBuilder([], undefined));
+      expect(await service.getWindow("missing")).toBeNull();
+    });
+
+    it("returns null when the query throws", async () => {
+      mockKnex.mockImplementation(() => {
+        throw new Error("db down");
+      });
+      expect(await service.getWindow("w1")).toBeNull();
+    });
+  });
+
+  describe("shouldSuppressAlert", () => {
+    it("suppresses when an active window covers the alert type", async () => {
+      mockKnex.mockImplementation(() =>
+        createQueryBuilder([
+          { id: "w1", alert_types_suppressed: JSON.stringify(["depeg"]) },
+        ]),
+      );
+      expect(await service.shouldSuppressAlert("depeg")).toBe(true);
+    });
+
+    it("suppresses every alert type for a wildcard window", async () => {
+      mockKnex.mockImplementation(() =>
+        createQueryBuilder([
+          { id: "w1", alert_types_suppressed: JSON.stringify(["*"]) },
+        ]),
+      );
+      expect(await service.shouldSuppressAlert("anything")).toBe(true);
+    });
+
+    it("does not suppress an unrelated alert type", async () => {
+      mockKnex.mockImplementation(() =>
+        createQueryBuilder([
+          { id: "w1", alert_types_suppressed: JSON.stringify(["reserve_drift"]) },
+        ]),
+      );
+      expect(await service.shouldSuppressAlert("depeg")).toBe(false);
+    });
+
+    it("scopes the query when a scope is provided", async () => {
+      mockKnex.mockImplementation(() => createQueryBuilder([]));
+      expect(
+        await service.shouldSuppressAlert("depeg", {
+          type: "bridge",
+          identifier: "circle-usdc",
+        }),
+      ).toBe(false);
+    });
+
+    it("returns false when the check throws", async () => {
+      mockKnex.mockImplementation(() => {
+        throw new Error("boom");
+      });
+      expect(await service.shouldSuppressAlert("depeg")).toBe(false);
+    });
+  });
+
+  describe("getActiveWindows / getUpcomingWindows", () => {
+    it("returns active windows with parsed suppression arrays", async () => {
+      mockKnex.mockImplementation(() =>
+        createQueryBuilder([
+          { id: "w1", alert_types_suppressed: JSON.stringify(["*"]) },
+          { id: "w2", alert_types_suppressed: null },
+        ]),
+      );
+      const windows = await service.getActiveWindows();
+      expect(windows).toHaveLength(2);
+      expect(windows[0].alert_types_suppressed).toEqual(["*"]);
+      expect(windows[1].alert_types_suppressed).toEqual([]);
+    });
+
+    it("returns [] when active-window lookup throws", async () => {
+      mockKnex.mockImplementation(() => {
+        throw new Error("nope");
+      });
+      expect(await service.getActiveWindows()).toEqual([]);
+    });
+
+    it("applies the limit to upcoming windows", async () => {
+      mockKnex.mockImplementation(() =>
+        createQueryBuilder([
+          { id: "w1", alert_types_suppressed: JSON.stringify([]) },
+        ]),
+      );
+      const windows = await service.getUpcomingWindows(5);
+      expect(windows).toHaveLength(1);
+      const limited = builders.find((b) => b.limit.mock.calls.length > 0);
+      expect(limited.limit).toHaveBeenCalledWith(5);
+    });
+  });
+
+  describe("approveWindow / cancelWindow", () => {
+    it("approves a window and records the approver", async () => {
+      await service.approveWindow("w1", "lead@bridgewatch");
+      const updated = builders.find((b) => b.update.mock.calls.length > 0);
+      expect(updated.update).toHaveBeenCalledWith(
+        expect.objectContaining({ approved_by: "lead@bridgewatch" }),
+      );
+    });
+
+    it("cancels a window by setting status=cancelled", async () => {
+      await service.cancelWindow("w1", "ops@bridgewatch");
+      const updated = builders.find((b) => b.update.mock.calls.length > 0);
+      expect(updated.update).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "cancelled" }),
+      );
+    });
+  });
+
+  describe("processWindowTransitions", () => {
+    it("starts scheduled windows whose start time has passed", async () => {
+      // First db() call (the to-start SELECT) yields one scheduled window;
+      // every later call (updates, audit insert, to-complete SELECT) is empty.
+      mockKnex.mockImplementationOnce(() =>
+        createQueryBuilder([{ id: "w1" }]),
+      );
+
+      await service.processWindowTransitions();
+
+      const startedUpdate = builders.some((b) =>
+        b.update.mock.calls.some((c: any[]) => c[0]?.status === "active"),
+      );
+      expect(startedUpdate).toBe(true);
+    });
+
+    it("swallows errors and does not throw", async () => {
+      mockKnex.mockImplementation(() => {
+        throw new Error("transition failed");
+      });
+      await expect(service.processWindowTransitions()).resolves.toBeUndefined();
+    });
+  });
+
+  describe("getAllWindows", () => {
+    it("returns mapped windows and applies status/scope filters", async () => {
+      mockKnex.mockImplementation(() =>
+        createQueryBuilder([
+          { id: "w1", alert_types_suppressed: JSON.stringify(["depeg"]) },
+        ]),
+      );
+
+      const windows = await service.getAllWindows({
+        status: "active",
+        scope: "global",
+      });
+
+      expect(windows).toHaveLength(1);
+      expect(windows[0].alert_types_suppressed).toEqual(["depeg"]);
+      const builder = builders.find((b) => b.where.mock.calls.length > 0);
+      expect(builder.where).toHaveBeenCalledWith("status", "active");
+      expect(builder.where).toHaveBeenCalledWith("scope", "global");
+    });
+  });
+});

--- a/backend/tests/services/metrics.service.test.ts
+++ b/backend/tests/services/metrics.service.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  MetricsService,
+  getMetricsService,
+} from "../../src/services/metrics.service.js";
+
+/** Find a single sample from a getMetricsJSON() entry by metricName + labels. */
+const findSample = (
+  json: any[],
+  name: string,
+  match: (labels: Record<string, unknown>) => boolean,
+  metricName?: string,
+) => {
+  const metric = json.find((m) => m.name === name);
+  if (!metric) return undefined;
+  return metric.values.find(
+    (v: any) =>
+      (metricName ? v.metricName === metricName : true) && match(v.labels ?? {}),
+  );
+};
+
+describe("MetricsService", () => {
+  let metrics: MetricsService;
+
+  beforeEach(() => {
+    // Each instance owns its own prom-client Registry, so tests stay isolated.
+    metrics = new MetricsService();
+  });
+
+  describe("getMetricsService (singleton)", () => {
+    it("returns the same instance on repeated calls", () => {
+      expect(getMetricsService()).toBe(getMetricsService());
+    });
+  });
+
+  describe("registration & exposure", () => {
+    it("exposes registered counters/gauges/histograms in Prometheus text", async () => {
+      const text = await metrics.getMetrics();
+      expect(text).toContain("http_requests_total");
+      expect(text).toContain("bridge_health_score");
+      expect(text).toContain("db_query_duration_seconds");
+      expect(text).toContain("queue_jobs_completed_total");
+    });
+
+    it("exposes metrics as JSON with names and metric types", async () => {
+      const json = await metrics.getMetricsJSON();
+      const byName = Object.fromEntries(json.map((m: any) => [m.name, m.type]));
+      expect(byName["http_requests_total"]).toBe("counter");
+      expect(byName["bridge_health_score"]).toBe("gauge");
+      expect(byName["http_request_duration_seconds"]).toBe("histogram");
+    });
+
+    it("registers default Node.js process metrics", async () => {
+      const text = await metrics.getMetrics();
+      expect(text).toMatch(/nodejs_eventloop_lag_seconds|process_cpu_user_seconds_total/);
+    });
+
+    it("getRegistry returns a usable registry", () => {
+      const registry = metrics.getRegistry();
+      expect(registry).toBeDefined();
+      expect(typeof registry.metrics).toBe("function");
+    });
+  });
+
+  describe("recordHttpRequest", () => {
+    it("increments the request counter with method/route/status labels", async () => {
+      metrics.recordHttpRequest("GET", "/api/v1/health", 200, 0.012);
+
+      const json = await metrics.getMetricsJSON();
+      const sample = findSample(
+        json,
+        "http_requests_total",
+        (l) =>
+          l.method === "GET" &&
+          l.route === "/api/v1/health" &&
+          String(l.status_code) === "200",
+      );
+      expect(sample?.value).toBe(1);
+    });
+
+    it("observes the request-duration histogram", async () => {
+      metrics.recordHttpRequest("GET", "/price", 200, 0.5);
+
+      const json = await metrics.getMetricsJSON();
+      const count = findSample(
+        json,
+        "http_request_duration_seconds",
+        (l) => l.route === "/price",
+        "http_request_duration_seconds_count",
+      );
+      expect(count?.value).toBe(1);
+    });
+
+    it("records request and response sizes only when provided", async () => {
+      metrics.recordHttpRequest("POST", "/ingest", 201, 0.1, 2048, 4096);
+
+      const json = await metrics.getMetricsJSON();
+      const reqCount = findSample(
+        json,
+        "http_request_size_bytes",
+        (l) => l.route === "/ingest",
+        "http_request_size_bytes_count",
+      );
+      const resCount = findSample(
+        json,
+        "http_response_size_bytes",
+        (l) => l.route === "/ingest",
+        "http_response_size_bytes_count",
+      );
+      expect(reqCount?.value).toBe(1);
+      expect(resCount?.value).toBe(1);
+    });
+
+    it("omits size histograms when sizes are not passed", async () => {
+      metrics.recordHttpRequest("GET", "/nosize", 200, 0.01);
+
+      const json = await metrics.getMetricsJSON();
+      const reqCount = findSample(
+        json,
+        "http_request_size_bytes",
+        (l) => l.route === "/nosize",
+        "http_request_size_bytes_count",
+      );
+      expect(reqCount).toBeUndefined();
+    });
+  });
+
+  describe("recordDbQuery", () => {
+    it("counts queries and observes duration", async () => {
+      metrics.recordDbQuery("select", "bridges", 0.02);
+
+      const json = await metrics.getMetricsJSON();
+      const total = findSample(
+        json,
+        "db_queries_total",
+        (l) => l.operation === "select" && l.table === "bridges",
+      );
+      expect(total?.value).toBe(1);
+    });
+
+    it("increments the error counter when an error is supplied", async () => {
+      metrics.recordDbQuery("insert", "alerts", 0.05, { type: "unique_violation" });
+
+      const json = await metrics.getMetricsJSON();
+      const errors = findSample(
+        json,
+        "db_query_errors_total",
+        (l) =>
+          l.operation === "insert" &&
+          l.table === "alerts" &&
+          l.error_type === "unique_violation",
+      );
+      expect(errors?.value).toBe(1);
+    });
+  });
+
+  describe("recordQueueJob", () => {
+    it("increments the completed counter on success", async () => {
+      metrics.recordQueueJob("verifications", "verify", 12, true);
+
+      const json = await metrics.getMetricsJSON();
+      const completed = findSample(
+        json,
+        "queue_jobs_completed_total",
+        (l) => l.queue_name === "verifications" && l.job_type === "verify",
+      );
+      expect(completed?.value).toBe(1);
+    });
+
+    it("increments the failed counter with an error type on failure", async () => {
+      metrics.recordQueueJob("verifications", "verify", 8, false, "timeout");
+
+      const json = await metrics.getMetricsJSON();
+      const failed = findSample(
+        json,
+        "queue_jobs_failed_total",
+        (l) => l.job_type === "verify" && l.error_type === "timeout",
+      );
+      expect(failed?.value).toBe(1);
+    });
+
+    it("defaults the failure error type to 'unknown'", async () => {
+      metrics.recordQueueJob("q", "j", 1, false);
+
+      const json = await metrics.getMetricsJSON();
+      const failed = findSample(
+        json,
+        "queue_jobs_failed_total",
+        (l) => l.job_type === "j" && l.error_type === "unknown",
+      );
+      expect(failed?.value).toBe(1);
+    });
+  });
+
+  describe("recordBridgeVerification", () => {
+    it("counts the verification and the success branch", async () => {
+      metrics.recordBridgeVerification("b1", "Circle", "USDC", true);
+
+      const json = await metrics.getMetricsJSON();
+      const total = findSample(
+        json,
+        "bridge_verifications_total",
+        (l) => l.bridge_id === "b1" && l.asset === "USDC",
+      );
+      const success = findSample(
+        json,
+        "bridge_verification_success_total",
+        (l) => l.bridge_id === "b1",
+      );
+      expect(total?.value).toBe(1);
+      expect(success?.value).toBe(1);
+    });
+
+    it("records the failure branch with a reason", async () => {
+      metrics.recordBridgeVerification("b2", "Allbridge", "USDC", false, "reserve_drift");
+
+      const json = await metrics.getMetricsJSON();
+      const failure = findSample(
+        json,
+        "bridge_verification_failure_total",
+        (l) => l.bridge_id === "b2" && l.reason === "reserve_drift",
+      );
+      expect(failure?.value).toBe(1);
+    });
+  });
+
+  describe("reset", () => {
+    it("clears recorded metric values", async () => {
+      metrics.recordHttpRequest("GET", "/reset-me", 200, 0.01);
+      metrics.reset();
+
+      const json = await metrics.getMetricsJSON();
+      const sample = findSample(
+        json,
+        "http_requests_total",
+        (l) => l.route === "/reset-me",
+      );
+      expect(sample).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds the missing backend test coverage requested across four Stellar Wave issues. All four files run under the unit vitest config (`vitest.unit.config.ts`).

### #703 — `maintenance.service.ts`
`tests/services/maintenance.service.test.ts` — window creation (generated id, scheduled status, audit log), active-window / time-overlap checks, alert suppression (incl. wildcard and scope), approve/cancel, scheduled→active transitions, and filtered listing. Error paths covered.

### #704 — `liquidityFragmentation.service.ts`
`tests/services/liquidityFragmentation.service.test.ts` — fragmentation scoring math (Herfindahl index, Gini coefficient, blended fragmentation score, price impact, confidence), `getFragmentationMetrics` (no-data / below-threshold / multi-DEX), DEX liquidity distribution, and the arbitrage no-op path. Cache layer is mocked to run the fetcher.

### #705 — `metrics.service.ts`
`tests/services/metrics.service.test.ts` — Prometheus registration & exposure (text + JSON), default Node.js metrics, singleton accessor, and counter/gauge/histogram recording with correct labels (`recordHttpRequest`, `recordDbQuery`, `recordQueueJob`, `recordBridgeVerification`), plus `reset()`.

### #724 — `api/routes/reconciliation.ts`
`tests/api/reconciliation.test.ts` — Fastify `inject` route tests for `/runs`, `/latest/:assetCode`, `/drift-summaries`, `/mismatches/:id` and `PATCH /runs/:id/triage`: happy paths, query/param validation (400), not-found (404) and service-error (500) cases. `ReconciliationService` is mocked at the module boundary.

## Test plan
- [x] `tests/services/metrics.service.test.ts` — 17 passing
- [x] `tests/services/maintenance.service.test.ts` — 18 passing
- [x] `tests/services/liquidityFragmentation.service.test.ts` — 15 passing
- [x] `tests/api/reconciliation.test.ts` — 16 passing
- [x] All four run green together under `vitest.unit.config.ts` (66 tests)

### Out of scope
The full unit suite has 26 pre-existing failures in 11 unrelated files (e.g. `tagSync.service`, `incident.service`, `sourceDecommission.service`, `api/smoke`, several workers/jobs). They fail in isolation on `main` without these new files and are not touched by this PR.

Closes #703
Closes #704
Closes #705
Closes #724