### PR TITLE
feat: implement alert dedup severity, price history, telegram role authz, and DEX XLM/USD

### DIFF
--- a/backend/src/database/migrations/042_admin_accounts_telegram_chat_id.ts
+++ b/backend/src/database/migrations/042_admin_accounts_telegram_chat_id.ts
@@ -1,0 +1,13 @@
+import type { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable("admin_accounts", (table) => {
+    table.string("telegram_chat_id").nullable().unique();
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable("admin_accounts", (table) => {
+    table.dropColumn("telegram_chat_id");
+  });
+}

--- a/backend/src/services/__tests__/alertDeduplication.service.unit.ts
+++ b/backend/src/services/__tests__/alertDeduplication.service.unit.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockUpdateSeverity = vi.fn().mockResolvedValue(null);
+const mockUpdateStatus = vi.fn().mockResolvedValue(null);
+const mockCreate = vi.fn();
+const mockFirst = vi.fn();
+const mockMapRow = vi.fn((r: any) => r);
+
+vi.mock("../incident.service.js", () => ({
+  IncidentService: vi.fn().mockImplementation(() => ({
+    updateIncidentSeverity: mockUpdateSeverity,
+    updateIncidentStatus: mockUpdateStatus,
+    createIncident: mockCreate,
+    mapDatabaseRow: mockMapRow,
+  })),
+}));
+
+vi.mock("../../database/connection.js", () => ({
+  getDatabase: () => ({
+    __esModule: true,
+    // knex-style chainable query builder stub
+    ...(() => {
+      const q: any = {};
+      ["where", "andWhere", "orderBy"].forEach((m) => {
+        q[m] = () => q;
+      });
+      q.first = mockFirst;
+      return (table: string) => q;
+    })(),
+  }),
+}));
+
+vi.mock("../../utils/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { AlertDeduplicationService } from "../alertDeduplication.service.js";
+import type { AlertEvent } from "../alert.service.js";
+
+function makeEvent(overrides: Partial<AlertEvent> = {}): AlertEvent {
+  return {
+    eventId: "evt-1",
+    ruleId: "rule-1",
+    assetCode: "USDC",
+    alertType: "price_deviation",
+    priority: "medium",
+    triggeredValue: 0.97,
+    threshold: 0.99,
+    metric: "price",
+    time: new Date(),
+    webhookDelivered: false,
+    onChainEventId: null,
+    lifecycleState: "open",
+    acknowledgedAt: null,
+    acknowledgedBy: null,
+    assignedAt: null,
+    assignedTo: null,
+    closedAt: null,
+    closedBy: null,
+    closureNote: null,
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+describe("AlertDeduplicationService", () => {
+  let svc: AlertDeduplicationService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (AlertDeduplicationService as any).instance = undefined;
+    svc = AlertDeduplicationService.getInstance();
+  });
+
+  describe("deduplicate — new incident creation", () => {
+    it("creates an incident with derived bridgeId when no match exists", async () => {
+      mockFirst.mockResolvedValue(null);
+      mockCreate.mockResolvedValue({ id: "inc-1", bridgeId: "bridge-usdc", severity: "medium" });
+
+      const event = makeEvent({ assetCode: "USDC", priority: "medium" });
+      const incident = await svc.deduplicate(event);
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ bridgeId: "bridge-usdc" })
+      );
+      expect(incident.bridgeId).toBe("bridge-usdc");
+    });
+
+    it("never passes 'unknown' as bridgeId", async () => {
+      mockFirst.mockResolvedValue(null);
+      mockCreate.mockResolvedValue({ id: "inc-2", bridgeId: "bridge-wbtc", severity: "low" });
+
+      await svc.deduplicate(makeEvent({ assetCode: "WBTC" }));
+
+      const call = mockCreate.mock.calls[0][0];
+      expect(call.bridgeId).not.toBe("unknown");
+    });
+  });
+
+  describe("deduplicate — existing incident merge", () => {
+    it("escalates severity and sets status to investigating when incoming priority is higher", async () => {
+      const existing = {
+        id: "inc-existing",
+        severity: "low",
+        status: "open",
+        assetCode: "USDC",
+        bridgeId: "bridge-usdc",
+      };
+      mockFirst.mockResolvedValue(existing);
+      mockMapRow.mockReturnValue(existing);
+
+      await svc.deduplicate(makeEvent({ priority: "high" }));
+
+      expect(mockUpdateSeverity).toHaveBeenCalledWith("inc-existing", "high");
+      expect(mockUpdateStatus).toHaveBeenCalledWith("inc-existing", "investigating");
+    });
+
+    it("does not update severity when incoming priority is not higher", async () => {
+      const existing = {
+        id: "inc-existing",
+        severity: "critical",
+        status: "open",
+        assetCode: "USDC",
+        bridgeId: "bridge-usdc",
+      };
+      mockFirst.mockResolvedValue(existing);
+      mockMapRow.mockReturnValue(existing);
+
+      await svc.deduplicate(makeEvent({ priority: "low" }));
+
+      expect(mockUpdateSeverity).not.toHaveBeenCalled();
+      expect(mockUpdateStatus).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("escalateSeverity", () => {
+    it("returns higher severity between current and incoming", () => {
+      const escalate = (svc as any).escalateSeverity.bind(svc);
+      expect(escalate("low", "high")).toBe("high");
+      expect(escalate("critical", "medium")).toBe("critical");
+      expect(escalate("medium", "medium")).toBe("medium");
+    });
+  });
+});

--- a/backend/src/services/__tests__/dexXlmUsd.source.unit.ts
+++ b/backend/src/services/__tests__/dexXlmUsd.source.unit.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockRedisGet = vi.fn();
+const mockRedisSet = vi.fn().mockResolvedValue("OK");
+
+vi.mock("../../utils/redis.js", () => ({
+  redis: { get: mockRedisGet, set: mockRedisSet },
+}));
+
+vi.mock("../../utils/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("../../utils/retry.js", () => ({
+  withRetry: vi.fn((fn: () => unknown) => fn()),
+}));
+
+vi.mock("../providerAllowlist.service.js", () => ({
+  providerAllowlistService: { isAllowed: vi.fn().mockResolvedValue(true) },
+}));
+
+// fetchJson is module-internal; we spy on globalThis.fetch instead
+const fetchMock = vi.fn();
+globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+// Helper to mock a successful fetch response
+function mockFetch(body: unknown) {
+  fetchMock.mockResolvedValueOnce({
+    ok: true,
+    json: async () => body,
+  });
+}
+
+// Helper to mock a failed fetch
+function mockFetchFail() {
+  fetchMock.mockRejectedValueOnce(new Error("network error"));
+}
+
+import { DexSource } from "../sources/dex.source.js";
+
+describe("DexSource.fetchXlmUsd", () => {
+  let svc: DexSource;
+  let fetchXlmUsd: () => Promise<number>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    svc = new DexSource();
+    fetchXlmUsd = (svc as any).fetchXlmUsd.bind(svc);
+  });
+
+  it("returns cached value when redis cache is warm", async () => {
+    mockRedisGet.mockResolvedValueOnce("0.15");
+    const price = await fetchXlmUsd();
+    expect(price).toBe(0.15);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fetches from Stellar DEX and caches the result", async () => {
+    mockRedisGet.mockResolvedValue(null);
+    // Stellar DEX order book: mid-price XLM/USDC = 7.5 → XLM/USD = 1/7.5 ≈ 0.1333
+    mockFetch({ bids: [{ price: "7.0" }], asks: [{ price: "8.0" }] });
+
+    const price = await fetchXlmUsd();
+    expect(price).toBeCloseTo(1 / 7.5, 5);
+    expect(mockRedisSet).toHaveBeenCalled();
+  });
+
+  it("falls back to Binance when Stellar DEX fetch fails", async () => {
+    mockRedisGet.mockResolvedValue(null);
+    mockFetchFail(); // Stellar DEX fails
+    mockFetch({ symbol: "XLMUSDT", price: "0.14" }); // Binance succeeds
+
+    const price = await fetchXlmUsd();
+    expect(price).toBe(0.14);
+  });
+
+  it("returns hardcoded fallback when both sources fail and no stale cache", async () => {
+    mockRedisGet.mockResolvedValue(null);
+    mockFetchFail(); // Stellar DEX fails
+    mockFetchFail(); // Binance fails
+
+    const price = await fetchXlmUsd();
+    expect(price).toBe(0.12);
+  });
+
+  it("returns stale cache when both live sources fail", async () => {
+    mockRedisGet
+      .mockResolvedValueOnce(null)       // primary cache miss
+      .mockResolvedValueOnce("0.13");    // stale cache hit
+    mockFetchFail(); // Stellar DEX fails
+    mockFetchFail(); // Binance fails
+
+    const price = await fetchXlmUsd();
+    expect(price).toBe(0.13);
+  });
+});

--- a/backend/src/services/__tests__/priceHistorical.service.unit.ts
+++ b/backend/src/services/__tests__/priceHistorical.service.unit.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockGetTimeBucketed = vi.fn();
+
+vi.mock("../../database/models/price.model.js", () => ({
+  PriceModel: vi.fn().mockImplementation(() => ({
+    getTimeBucketed: mockGetTimeBucketed,
+  })),
+}));
+
+// Stub out heavy dependencies that PriceService transitively imports
+vi.mock("../../utils/stellar.js", () => ({
+  getOrderBook: vi.fn(),
+  getLiquidityPools: vi.fn(),
+  HorizonTimeoutError: class HorizonTimeoutError extends Error {},
+  HorizonClientError: class HorizonClientError extends Error {},
+}));
+
+vi.mock("../../utils/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("../../utils/cache.js", () => ({
+  CacheService: vi.fn().mockImplementation(() => ({ get: vi.fn(), set: vi.fn() })),
+}));
+
+vi.mock("../sources/circle.source.js", () => ({
+  CircleSource: vi.fn().mockImplementation(() => ({})),
+}));
+
+vi.mock("../../config/index.js", () => ({
+  config: { PRICE_DEVIATION_THRESHOLD: 0.02 },
+  SUPPORTED_ASSETS: [{ code: "USDC", issuer: "GA5Z" }],
+}));
+
+import { PriceService } from "../price.service.js";
+
+describe("PriceService.getHistoricalPrices", () => {
+  let svc: PriceService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    svc = new PriceService();
+  });
+
+  it("queries with 5-minute bucket for 1h interval", async () => {
+    mockGetTimeBucketed.mockResolvedValue([]);
+    await svc.getHistoricalPrices("USDC", "1h");
+    expect(mockGetTimeBucketed).toHaveBeenCalledWith("USDC", "5 minutes", expect.any(Date));
+    const startArg: Date = mockGetTimeBucketed.mock.calls[0][2];
+    expect(Date.now() - startArg.getTime()).toBeCloseTo(60 * 60 * 1000, -3);
+  });
+
+  it("queries with 1-hour bucket for 1d interval", async () => {
+    mockGetTimeBucketed.mockResolvedValue([]);
+    await svc.getHistoricalPrices("USDC", "1d");
+    expect(mockGetTimeBucketed).toHaveBeenCalledWith("USDC", "1 hour", expect.any(Date));
+  });
+
+  it("queries with 6-hour bucket for 7d interval", async () => {
+    mockGetTimeBucketed.mockResolvedValue([]);
+    await svc.getHistoricalPrices("USDC", "7d");
+    expect(mockGetTimeBucketed).toHaveBeenCalledWith("USDC", "6 hours", expect.any(Date));
+  });
+
+  it("queries with 1-day bucket for 30d interval", async () => {
+    mockGetTimeBucketed.mockResolvedValue([]);
+    await svc.getHistoricalPrices("USDC", "30d");
+    expect(mockGetTimeBucketed).toHaveBeenCalledWith("USDC", "1 day", expect.any(Date));
+  });
+
+  it("maps rows to { timestamp, price } shape", async () => {
+    const bucket = new Date("2024-01-01T00:00:00Z");
+    mockGetTimeBucketed.mockResolvedValue([{ bucket, avg_price: "1.0002" }]);
+
+    const result = await svc.getHistoricalPrices("USDC", "1d");
+
+    expect(result).toEqual([{ timestamp: bucket.toISOString(), price: 1.0002 }]);
+  });
+
+  it("returns empty array when no rows found", async () => {
+    mockGetTimeBucketed.mockResolvedValue([]);
+    const result = await svc.getHistoricalPrices("USDC", "1h");
+    expect(result).toEqual([]);
+  });
+
+  it("uppercases the symbol before querying", async () => {
+    mockGetTimeBucketed.mockResolvedValue([]);
+    await svc.getHistoricalPrices("usdc", "1h");
+    expect(mockGetTimeBucketed).toHaveBeenCalledWith("USDC", expect.any(String), expect.any(Date));
+  });
+});

--- a/backend/src/services/__tests__/telegramRoleAuthz.service.unit.ts
+++ b/backend/src/services/__tests__/telegramRoleAuthz.service.unit.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockDbFirst = vi.fn();
+const mockDb = vi.fn(() => ({
+  where: vi.fn().mockReturnThis(),
+  first: mockDbFirst,
+}));
+
+vi.mock("../../database/connection.js", () => ({
+  getDatabase: () => mockDb,
+}));
+
+vi.mock("../../utils/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("telegraf", () => ({
+  Telegraf: vi.fn().mockImplementation(() => ({
+    use: vi.fn(),
+    command: vi.fn(),
+    on: vi.fn(),
+    action: vi.fn(),
+    launch: vi.fn(),
+    stop: vi.fn(),
+    telegram: { setWebhook: vi.fn(), deleteWebhook: vi.fn() },
+  })),
+  Markup: { inlineKeyboard: vi.fn(() => ({})), button: { callback: vi.fn() } },
+  Context: class {},
+}));
+
+vi.mock("ioredis", () => ({
+  default: vi.fn().mockImplementation(() => ({
+    get: vi.fn(),
+    set: vi.fn(),
+    del: vi.fn(),
+  })),
+}));
+
+vi.mock("../formatters/telegram.formatter.js", () => ({
+  formatAlertMessage: vi.fn(() => "msg"),
+  escapeTelegramMarkdown: vi.fn((s: string) => s),
+}));
+
+vi.mock("../../config/index.js", () => ({
+  config: {
+    TELEGRAM_BOT_TOKEN: "test-token",
+    TELEGRAM_BOT_ENABLED: true,
+    TELEGRAM_ADMIN_CHAT_IDS: "9999",
+    TELEGRAM_WEBHOOK_URL: "",
+    REDIS_HOST: "localhost",
+    REDIS_PORT: 6379,
+    REDIS_PASSWORD: undefined,
+    TELEGRAM_RATE_LIMIT_OUTBOUND_GLOBAL_PER_SEC: 10,
+    TELEGRAM_RATE_LIMIT_OUTBOUND_PER_CHAT_PER_SEC: 1,
+  },
+}));
+
+import { TelegramBotService } from "../telegram.bot.service.js";
+
+describe("TelegramBotService.isAdminChat", () => {
+  let svc: TelegramBotService;
+  let isAdminChat: (chatId: string, userId?: string) => Promise<boolean>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    svc = new TelegramBotService();
+    isAdminChat = (svc as any).isAdminChat.bind(svc);
+  });
+
+  it("grants access to bootstrap admin chat IDs", async () => {
+    mockDbFirst.mockResolvedValue(null);
+    expect(await isAdminChat("9999")).toBe(true);
+  });
+
+  it("grants access when admin_accounts row has operator role", async () => {
+    mockDbFirst.mockResolvedValue({ roles: JSON.stringify(["operator"]), is_active: true });
+    expect(await isAdminChat("1234")).toBe(true);
+  });
+
+  it("grants access when admin_accounts row has super_admin role", async () => {
+    mockDbFirst.mockResolvedValue({ roles: ["super_admin"], is_active: true });
+    expect(await isAdminChat("5678")).toBe(true);
+  });
+
+  it("denies access when admin_accounts row has only auditor role", async () => {
+    mockDbFirst.mockResolvedValue({ roles: JSON.stringify(["auditor"]), is_active: true });
+    expect(await isAdminChat("1111")).toBe(false);
+  });
+
+  it("denies access when no matching admin_accounts row", async () => {
+    mockDbFirst.mockResolvedValue(null);
+    expect(await isAdminChat("0000")).toBe(false);
+  });
+
+  it("denies access and does not throw when db query fails", async () => {
+    mockDbFirst.mockRejectedValue(new Error("db error"));
+    await expect(isAdminChat("2222")).resolves.toBe(false);
+  });
+});

--- a/backend/src/services/alertDeduplication.service.ts
+++ b/backend/src/services/alertDeduplication.service.ts
@@ -57,8 +57,8 @@ export class AlertDeduplicationService {
       // Escalate severity if needed.
       const newSeverity = this.escalateSeverity(matching.severity, event.priority);
       if (newSeverity !== matching.severity) {
-        await this.incidentService.updateIncidentStatus(matching.id, "investigating"); // placeholder for severity update
-        // In a full implementation we would update the severity field.
+        await this.incidentService.updateIncidentSeverity(matching.id, newSeverity as any);
+        await this.incidentService.updateIncidentStatus(matching.id, "investigating");
       }
       logger.info({ incidentId: matching.id, alertId: event.eventId }, "Alert deduplicated into existing incident");
       return matching;
@@ -66,7 +66,7 @@ export class AlertDeduplicationService {
 
     // No matching incident – create a new one.
     const payload = {
-      bridgeId: "unknown", // Bridge id may be derived elsewhere; placeholder.
+      bridgeId: `bridge-${event.assetCode.toLowerCase()}`,
       assetCode: event.assetCode,
       severity: event.priority as any, // map priority to severity directly.
       title: `Alert: ${event.alertType} on ${event.assetCode}`,

--- a/backend/src/services/incident.service.ts
+++ b/backend/src/services/incident.service.ts
@@ -210,6 +210,16 @@ export class IncidentService {
     return this.mapRow(row);
   }
 
+  async updateIncidentSeverity(id: string, severity: IncidentSeverity): Promise<BridgeIncident | null> {
+    const [row] = await this.db("bridge_incidents")
+      .where("id", id)
+      .update({ severity, updated_at: new Date() })
+      .returning("*");
+    if (!row) return null;
+    logger.info({ incidentId: id, severity }, "Bridge incident severity updated");
+    return this.mapRow(row);
+  }
+
   async markRead(incidentId: string, userSession: string): Promise<void> {
     await this.db("bridge_incident_reads")
       .insert({ incident_id: incidentId, user_session: userSession })

--- a/backend/src/services/price.service.ts
+++ b/backend/src/services/price.service.ts
@@ -9,6 +9,7 @@ import {
 } from "../utils/stellar.js";
 import * as StellarSdk from "@stellar/stellar-sdk";
 import { CircleSource } from "./sources/circle.source.js";
+import { PriceModel } from "../database/models/price.model.js";
 
 export class PriceFetchError extends Error {
   constructor(
@@ -358,7 +359,22 @@ export class PriceService {
     interval: "1h" | "1d" | "7d" | "30d"
   ): Promise<{ timestamp: string; price: number }[]> {
     logger.info({ symbol, interval }, "Fetching historical prices");
-    // TODO: Query TimescaleDB for time-bucketed price data
-    return [];
+
+    const intervalConfig: Record<"1h" | "1d" | "7d" | "30d", { bucket: string; lookbackMs: number }> = {
+      "1h":  { bucket: "5 minutes",  lookbackMs: 60 * 60 * 1000 },
+      "1d":  { bucket: "1 hour",     lookbackMs: 24 * 60 * 60 * 1000 },
+      "7d":  { bucket: "6 hours",    lookbackMs: 7 * 24 * 60 * 60 * 1000 },
+      "30d": { bucket: "1 day",      lookbackMs: 30 * 24 * 60 * 60 * 1000 },
+    };
+
+    const { bucket, lookbackMs } = intervalConfig[interval];
+    const startTime = new Date(Date.now() - lookbackMs);
+    const priceModel = new PriceModel();
+
+    const rows = await priceModel.getTimeBucketed(symbol.toUpperCase(), bucket, startTime);
+    return rows.map((r) => ({
+      timestamp: new Date(r.bucket).toISOString(),
+      price: Number(r.avg_price),
+    }));
   }
 }

--- a/backend/src/services/sources/dex.source.ts
+++ b/backend/src/services/sources/dex.source.ts
@@ -240,8 +240,7 @@ export class DexSource {
 
           if (!bid && !ask) return;
 
-          // Mid-price in XLM/asset; we approximate USD via a known XLM price
-          // For production: fetch XLM/USD separately. Here we use a placeholder.
+          // Mid-price in XLM/asset; convert to USD using live XLM/USD rate.
           const xlmUsd = await this.fetchXlmUsd();
           const midXlm = bid && ask ? (bid + ask) / 2 : bid || ask;
           const priceUsd = midXlm > 0 ? (1 / midXlm) * xlmUsd : 0;
@@ -263,34 +262,62 @@ export class DexSource {
     return results;
   }
 
-  /** Fetch XLM/USD price from Stellar DEX (XLM vs USDC) */
+  /** Fetch XLM/USD price — tries Stellar DEX order book first, then Binance, then a stale cache. */
   private async fetchXlmUsd(): Promise<number> {
     const cacheKey = "dex:xlm-usd";
     try {
       const cached = await redis.get(cacheKey);
       if (cached) return parseFloat(cached);
     } catch {
-      // ignore
+      // ignore cache errors
     }
 
+    // Primary: Stellar DEX XLM/USDC order book
     const usdc = STELLAR_ASSETS["USDC"];
-    const url = `${STELLAR_HORIZON}/order_book?selling_asset_type=native&buying_asset_type=credit_alphanum4&buying_asset_code=${usdc.code}&buying_asset_issuer=${usdc.issuer}&limit=1`;
+    const horizonUrl = `${STELLAR_HORIZON}/order_book?selling_asset_type=native&buying_asset_type=credit_alphanum4&buying_asset_code=${usdc.code}&buying_asset_issuer=${usdc.issuer}&limit=1`;
 
     try {
-      const book = await fetchJson<{ bids: { price: string }[]; asks: { price: string }[] }>(url);
+      const book = await fetchJson<{ bids: { price: string }[]; asks: { price: string }[] }>(horizonUrl);
       const bid = parseFloat(book.bids?.[0]?.price ?? "0");
       const ask = parseFloat(book.asks?.[0]?.price ?? "0");
       const mid = bid && ask ? (bid + ask) / 2 : bid || ask;
       if (mid > 0) {
         const xlmUsd = 1 / mid;
-        await redis.set(cacheKey, String(xlmUsd), "EX", 30).catch(() => undefined);
+        await Promise.all([
+          redis.set(cacheKey, String(xlmUsd), "EX", 30).catch(() => undefined),
+          redis.set(`${cacheKey}:stale`, String(xlmUsd), "EX", 3600).catch(() => undefined),
+        ]);
         return xlmUsd;
       }
     } catch {
-      // fallback
+      logger.warn("Stellar DEX XLM/USD fetch failed, falling back to Binance");
     }
 
-    return 0.12; // emergency fallback
+    // Secondary: Binance public ticker (no API key required)
+    try {
+      const binanceUrl = "https://api.binance.com/api/v3/ticker/price?symbol=XLMUSDT";
+      const ticker = await fetchJson<{ symbol: string; price: string }>(binanceUrl);
+      const price = parseFloat(ticker.price);
+      if (price > 0) {
+        await Promise.all([
+          redis.set(cacheKey, String(price), "EX", 30).catch(() => undefined),
+          redis.set(`${cacheKey}:stale`, String(price), "EX", 3600).catch(() => undefined),
+        ]);
+        return price;
+      }
+    } catch {
+      logger.warn("Binance XLM/USD fetch failed, using last known or emergency fallback");
+    }
+
+    // Last resort: stale cache without TTL check, then hardcoded fallback
+    try {
+      const stale = await redis.get(`${cacheKey}:stale`);
+      if (stale) return parseFloat(stale);
+    } catch {
+      // ignore
+    }
+
+    return 0.12; // emergency fallback — update if XLM price drifts significantly
   }
 
   // ---------------------------------------------------------------------------

--- a/backend/src/services/telegram.bot.service.ts
+++ b/backend/src/services/telegram.bot.service.ts
@@ -764,7 +764,24 @@ export class TelegramBotService {
       return true;
     }
 
-    // TODO: Check application role system here when available
+    // Check the application role system: operator or super_admin with a linked telegram_chat_id
+    try {
+      const row = await this.db("admin_accounts")
+        .where("telegram_chat_id", chatId)
+        .where("is_active", true)
+        .first();
+
+      if (row) {
+        const roles: string[] = Array.isArray(row.roles) ? row.roles : JSON.parse(row.roles ?? "[]");
+        if (roles.includes("operator") || roles.includes("super_admin")) {
+          logger.debug({ chatId }, "Admin access granted via application role system");
+          return true;
+        }
+      }
+    } catch (err) {
+      logger.warn({ chatId, err }, "Role system check failed, denying access");
+    }
+
     return false;
   }
 


### PR DESCRIPTION
## Summary

- Implements four placeholder/TODO resolutions across backend services with unit tests

## Changes

### closes #688 — Alert Deduplication Severity & Bridge Resolution
- `alertDeduplication.service.ts`: Replace `updateIncidentStatus("investigating")` placeholder with a real `updateIncidentSeverity` call that escalates to the higher priority; status is then set to `"investigating"` afterward
- `alertDeduplication.service.ts`: Replace hard-coded `bridgeId: "unknown"` with `bridgeId: bridge-<assetCode>` derived from the alert event (consistent with the pattern in `alert.service.ts`)
- `incident.service.ts`: Add `updateIncidentSeverity` method used by the above

### closes #685 — Historical Price Series TimescaleDB Query
- `price.service.ts`: Implement `getHistoricalPrices` using `PriceModel.getTimeBucketed` with per-interval bucket widths (`5 minutes` / `1 hour` / `6 hours` / `1 day`) and matching lookback windows

### closes #686 — Telegram Bot Role-Based Authorization
- `telegram.bot.service.ts`: Replace TODO in `isAdminChat` with a query against `admin_accounts` checking `telegram_chat_id` for `operator` or `super_admin` roles; fails closed on DB errors
- `migrations/042_admin_accounts_telegram_chat_id.ts`: Adds `telegram_chat_id` (nullable, unique) column to `admin_accounts`

### closes #687 — DEX XLM/USD Price Source
- `dex.source.ts`: Remove misleading "placeholder" comment — `fetchXlmUsd` already does a live fetch
- `dex.source.ts`: Add Binance public ticker as secondary fallback; also persist a 1-hour stale cache entry on successful fetches so the last-resort path can serve a recent value when both live sources are down, before falling back to the hardcoded `0.12` emergency value

## Tests

Unit tests added for all four changes:
- `__tests__/alertDeduplication.service.unit.ts`
- `__tests__/priceHistorical.service.unit.ts`
- `__tests__/telegramRoleAuthz.service.unit.ts`
- `__tests__/dexXlmUsd.source.unit.ts`

## Test plan

- [ ] Run `npm run test:unit` — all new unit tests pass
- [ ] Verify `getHistoricalPrices` returns correct shape against a TimescaleDB dev instance
- [ ] Register a `telegram_chat_id` on an `admin_accounts` row with `operator` role and confirm the Telegram `/pause` command is now accessible
- [ ] Confirm Stellar DEX and Binance XLM/USD fallback paths via log output in staging

Closes #685
Closes #686
Closes #687
Closes #688

🤖 Generated with [Claude Code](https://claude.com/claude-code)