### PR TITLE
feat: route liquidity dashboard page and add schema drift monitor page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,6 +34,8 @@ const AlertPlaybookViewer = lazy(() => import("./pages/AlertPlaybookViewer"));
 const DataProvenanceGraph = lazy(() => import("./pages/DataProvenanceGraph"));
 const AlertSimulationSandbox = lazy(() => import("./pages/AlertSimulationSandbox"));
 const LiquidityFragmentation = lazy(() => import("./pages/LiquidityFragmentation"));
+const LiquidityDashboard = lazy(() => import("./pages/LiquidityDashboard"));
+const SchemaDriftMonitor = lazy(() => import("./pages/SchemaDriftMonitor"));
 const OperationalAccessAudit = lazy(() => import("./pages/OperationalAccessAudit"));
 const BridgeHealthTimeline = lazy(() => import("./pages/BridgeHealthTimeline"));
 const ExportScheduler = lazy(() => import("./pages/ExportScheduler"));
@@ -92,6 +94,8 @@ function App() {
               <Route path="/data-provenance" element={<DataProvenanceGraph />} />
               <Route path="/alert-sandbox" element={<AlertSimulationSandbox />} />
               <Route path="/liquidity-fragmentation" element={<LiquidityFragmentation />} />
+              <Route path="/liquidity-dashboard" element={<LiquidityDashboard />} />
+              <Route path="/schema-drift" element={<SchemaDriftMonitor />} />
               <Route path="/bridge-health-timeline" element={<BridgeHealthTimeline />} />
               <Route path="/export-scheduler" element={<ExportScheduler />} />
               <Route path="/asset-comparison" element={<AssetComparison />} />

--- a/frontend/src/components/MobileNav/navigation.ts
+++ b/frontend/src/components/MobileNav/navigation.ts
@@ -24,6 +24,8 @@ export const navGroups: NavGroup[] = [
       { to: "/reconciliation", label: "Reconciliation", description: "Supply drift and reserve backing triage" },
       { to: "/cross-chain-verification", label: "State Verification", description: "Cryptographic cross-chain state proof validation" },
       { to: "/freshness", label: "Freshness", description: "Data freshness and staleness status for monitored sources" },
+      { to: "/liquidity-dashboard", label: "Liquidity", description: "Aggregated liquidity depth across SDEX, StellarX AMM, and Phoenix" },
+      { to: "/schema-drift", label: "Schema Drift", description: "Monitor field-level schema drift across upstream data sources" },
       { to: "/analytics", label: "Analytics", description: "Trend analysis and health scoring" },
       { to: "/analytics/metric-builder", label: "Metric Builder", description: "Create and save custom SQL metrics" },
       { to: "/data-provenance", label: "Provenance", description: "Trace metric lineage from source to destination" },

--- a/frontend/src/hooks/useSchemaDrift.ts
+++ b/frontend/src/hooks/useSchemaDrift.ts
@@ -1,0 +1,20 @@
+import { useQuery } from "@tanstack/react-query";
+import { getSchemaDriftReport } from "../services/api";
+import type { SchemaDriftReport } from "../services/api";
+
+export function useSchemaDrift(opts?: { refetchInterval?: number | false }) {
+  const { data, isLoading, error, refetch } = useQuery<SchemaDriftReport>({
+    queryKey: ["schema-drift-report"],
+    queryFn: getSchemaDriftReport,
+    refetchInterval: opts?.refetchInterval ?? 30_000,
+    staleTime: 15_000,
+  });
+
+  return {
+    summary: data?.summary ?? [],
+    recentIncidents: data?.recentIncidents ?? [],
+    isLoading,
+    error: error ? (error instanceof Error ? error.message : "Failed to load schema drift data") : null,
+    refetch,
+  };
+}

--- a/frontend/src/pages/LiquidityDashboard.test.tsx
+++ b/frontend/src/pages/LiquidityDashboard.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import LiquidityDashboard from "./LiquidityDashboard";
+
+vi.mock("../hooks/useLiquidity", () => ({
+  useLiquidity: () => ({
+    depth: {
+      pair: "USDC/XLM",
+      bids: [],
+      asks: [],
+      midPrice: 0.123456,
+      timestamp: new Date().toISOString(),
+    },
+    venues: [
+      { venue: "SDEX", totalLiquidity: 50000, bidDepth: 25000, askDepth: 25000, share: 50 },
+      { venue: "StellarX", totalLiquidity: 30000, bidDepth: 15000, askDepth: 15000, share: 30 },
+    ],
+    history: [],
+    isLoading: false,
+    error: null,
+    lastUpdated: new Date().toISOString(),
+    refetch: vi.fn(),
+  }),
+}));
+
+vi.mock("../hooks/useLocalStorageState", () => ({
+  useLocalStorageState: (key: string, defaultValue: unknown) => [defaultValue, vi.fn()],
+}));
+
+vi.mock("../components/liquidity", () => ({
+  LiquidityDepthChart: () => <div data-testid="depth-chart" />,
+  LiquidityByVenue: () => <div data-testid="venue-chart" />,
+  LiquidityTrend: () => <div data-testid="trend-chart" />,
+  PriceImpactCalculator: () => <div data-testid="price-impact" />,
+  PairSelector: () => <div data-testid="pair-selector" />,
+}));
+
+describe("LiquidityDashboard", () => {
+  function renderPage(path = "/liquidity-dashboard") {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[path]}>
+          <Routes>
+            <Route path="/liquidity-dashboard" element={<LiquidityDashboard />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  }
+
+  it("renders at the /liquidity-dashboard route", () => {
+    renderPage();
+    expect(screen.getByRole("heading", { name: "Liquidity" })).toBeInTheDocument();
+  });
+
+  it("shows summary stats cards", () => {
+    renderPage();
+    expect(screen.getByText("Total Liquidity")).toBeInTheDocument();
+    expect(screen.getByText("Mid Price")).toBeInTheDocument();
+    expect(screen.getByText("Bid Levels")).toBeInTheDocument();
+    expect(screen.getByText("Ask Levels")).toBeInTheDocument();
+  });
+
+  it("renders the venue table with data", () => {
+    renderPage();
+    expect(screen.getByText("SDEX")).toBeInTheDocument();
+    expect(screen.getByText("StellarX")).toBeInTheDocument();
+  });
+
+  it("renders the depth chart component", () => {
+    renderPage();
+    expect(screen.getByTestId("depth-chart")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/LiquidityDashboard.test.tsx
+++ b/frontend/src/pages/LiquidityDashboard.test.tsx
@@ -25,7 +25,7 @@ vi.mock("../hooks/useLiquidity", () => ({
 }));
 
 vi.mock("../hooks/useLocalStorageState", () => ({
-  useLocalStorageState: (key: string, defaultValue: unknown) => [defaultValue, vi.fn()],
+  useLocalStorageState: (_key: string, defaultValue: unknown) => [defaultValue, vi.fn()],
 }));
 
 vi.mock("../components/liquidity", () => ({

--- a/frontend/src/pages/SchemaDriftMonitor.test.tsx
+++ b/frontend/src/pages/SchemaDriftMonitor.test.tsx
@@ -1,0 +1,123 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+import SchemaDriftMonitor from "./SchemaDriftMonitor";
+
+const mockIncidents = [
+  {
+    id: "1",
+    source_name: "stellar-horizon",
+    drift_type: "REMOVAL" as const,
+    field_path: "ledger.base_fee",
+    expected_type: "number",
+    actual_type: null,
+    is_breaking: true,
+    detected_at: new Date(Date.now() - 5000).toISOString(),
+    is_resolved: false,
+  },
+  {
+    id: "2",
+    source_name: "circle-usdc",
+    drift_type: "ADDITION" as const,
+    field_path: "metadata.extra",
+    expected_type: null,
+    actual_type: "string",
+    is_breaking: false,
+    detected_at: new Date(Date.now() - 120000).toISOString(),
+    is_resolved: false,
+  },
+  {
+    id: "3",
+    source_name: "stellar-horizon",
+    drift_type: "TYPE_CHANGE" as const,
+    field_path: "ledger.sequence",
+    expected_type: "number",
+    actual_type: "string",
+    is_breaking: true,
+    detected_at: new Date(Date.now() - 60000).toISOString(),
+    is_resolved: false,
+  },
+];
+
+vi.mock("../hooks/useSchemaDrift", () => ({
+  useSchemaDrift: () => ({
+    summary: [
+      { source_name: "stellar-horizon", incident_count: 2, last_detected: new Date().toISOString() },
+      { source_name: "circle-usdc", incident_count: 1, last_detected: new Date().toISOString() },
+    ],
+    recentIncidents: mockIncidents,
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}));
+
+describe("SchemaDriftMonitor", () => {
+  function renderPage() {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <SchemaDriftMonitor />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  }
+
+  it("renders the page heading", () => {
+    renderPage();
+    expect(screen.getByRole("heading", { name: "Schema Drift Monitor" })).toBeInTheDocument();
+  });
+
+  it("shows summary stat cards", () => {
+    renderPage();
+    expect(screen.getByText("Total Incidents")).toBeInTheDocument();
+    expect(screen.getAllByText("Breaking").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Non-breaking").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows source summary table", () => {
+    renderPage();
+    expect(screen.getByText("Source Summary")).toBeInTheDocument();
+    expect(screen.getAllByText("stellar-horizon").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("circle-usdc").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders a row per drift incident", () => {
+    renderPage();
+    expect(screen.getByText("ledger.base_fee")).toBeInTheDocument();
+    expect(screen.getByText("metadata.extra")).toBeInTheDocument();
+    expect(screen.getByText("ledger.sequence")).toBeInTheDocument();
+  });
+
+  it("shows breaking and non-breaking severity badges", () => {
+    renderPage();
+    expect(screen.getAllByText("Breaking").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Non-breaking").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows drift type badges", () => {
+    renderPage();
+    expect(screen.getByText("REMOVAL")).toBeInTheDocument();
+    expect(screen.getByText("ADDITION")).toBeInTheDocument();
+    expect(screen.getByText("TYPE_CHANGE")).toBeInTheDocument();
+  });
+
+  it("filters incidents by source", async () => {
+    renderPage();
+    const select = screen.getByRole("combobox", { name: /filter by source/i });
+    fireEvent.change(select, { target: { value: "circle-usdc" } });
+    expect(screen.getByText("metadata.extra")).toBeInTheDocument();
+    expect(screen.queryByText("ledger.base_fee")).not.toBeInTheDocument();
+  });
+
+  it("filters incidents by drift type", async () => {
+    renderPage();
+    const select = screen.getByRole("combobox", { name: /filter by drift type/i });
+    fireEvent.change(select, { target: { value: "ADDITION" } });
+    expect(screen.getByText("metadata.extra")).toBeInTheDocument();
+    expect(screen.queryByText("ledger.base_fee")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/SchemaDriftMonitor.tsx
+++ b/frontend/src/pages/SchemaDriftMonitor.tsx
@@ -1,0 +1,237 @@
+import { useState, useMemo } from "react";
+import { useSchemaDrift } from "../hooks/useSchemaDrift";
+import { SkeletonCard } from "../components/Skeleton";
+import type { SchemaDriftIncident } from "../services/api";
+
+type DriftType = SchemaDriftIncident["drift_type"] | "ALL";
+
+const TIME_RANGES = [
+  { label: "All time", hours: 0 },
+  { label: "Last 1h", hours: 1 },
+  { label: "Last 24h", hours: 24 },
+  { label: "Last 7d", hours: 168 },
+];
+
+function SeverityBadge({ isBreaking }: { isBreaking: boolean }) {
+  if (isBreaking) {
+    return (
+      <span className="inline-flex items-center rounded-full bg-red-900/30 px-2.5 py-0.5 text-xs font-medium text-red-400">
+        Breaking
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center rounded-full bg-amber-900/30 px-2.5 py-0.5 text-xs font-medium text-amber-400">
+      Non-breaking
+    </span>
+  );
+}
+
+function DriftTypeBadge({ driftType }: { driftType: SchemaDriftIncident["drift_type"] }) {
+  const styles: Record<SchemaDriftIncident["drift_type"], string> = {
+    REMOVAL: "bg-red-900/20 text-red-300",
+    TYPE_CHANGE: "bg-orange-900/20 text-orange-300",
+    ADDITION: "bg-blue-900/20 text-blue-300",
+  };
+  return (
+    <span className={`inline-flex items-center rounded px-2 py-0.5 text-xs font-mono font-medium ${styles[driftType]}`}>
+      {driftType}
+    </span>
+  );
+}
+
+function formatDetectedAt(ts: string): string {
+  const ms = Date.now() - new Date(ts).getTime();
+  const secs = Math.floor(ms / 1000);
+  if (secs < 60) return `${secs}s ago`;
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+export default function SchemaDriftMonitor() {
+  const { summary, recentIncidents, isLoading, error } = useSchemaDrift();
+
+  const [sourceFilter, setSourceFilter] = useState<string>("ALL");
+  const [timeRange, setTimeRange] = useState<number>(0);
+  const [driftTypeFilter, setDriftTypeFilter] = useState<DriftType>("ALL");
+
+  const sources = useMemo(() => {
+    const names = Array.from(new Set(recentIncidents.map((i) => i.source_name)));
+    return ["ALL", ...names];
+  }, [recentIncidents]);
+
+  const filtered = useMemo(() => {
+    return recentIncidents.filter((incident) => {
+      if (sourceFilter !== "ALL" && incident.source_name !== sourceFilter) return false;
+      if (driftTypeFilter !== "ALL" && incident.drift_type !== driftTypeFilter) return false;
+      if (timeRange > 0) {
+        const cutoff = new Date(Date.now() - timeRange * 60 * 60 * 1000);
+        if (new Date(incident.detected_at) < cutoff) return false;
+      }
+      return true;
+    });
+  }, [recentIncidents, sourceFilter, driftTypeFilter, timeRange]);
+
+  const breakingCount = recentIncidents.filter((i) => i.is_breaking).length;
+  const nonBreakingCount = recentIncidents.length - breakingCount;
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-3xl font-bold text-stellar-text-primary">Schema Drift Monitor</h1>
+        <p className="mt-2 text-stellar-text-secondary">
+          Track schema changes across monitored data sources and identify breaking field-level drift.
+        </p>
+      </div>
+
+      {error && (
+        <div role="alert" className="rounded-lg border border-red-700 bg-red-900/20 px-4 py-3 text-sm text-red-300">
+          {error}
+        </div>
+      )}
+
+      {!isLoading && (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <div className="rounded-lg border border-stellar-border bg-stellar-card p-4">
+            <p className="text-sm text-stellar-text-secondary">Total Incidents</p>
+            <p className="mt-1 text-2xl font-semibold text-stellar-text-primary">
+              {recentIncidents.length}
+            </p>
+          </div>
+          <div className="rounded-lg border border-red-800/40 bg-red-900/10 p-4">
+            <p className="text-sm text-stellar-text-secondary">Breaking</p>
+            <p className="mt-1 text-2xl font-semibold text-red-400">{breakingCount}</p>
+          </div>
+          <div className="rounded-lg border border-amber-800/40 bg-amber-900/10 p-4">
+            <p className="text-sm text-stellar-text-secondary">Non-breaking</p>
+            <p className="mt-1 text-2xl font-semibold text-amber-400">{nonBreakingCount}</p>
+          </div>
+        </div>
+      )}
+
+      {!isLoading && summary.length > 0 && (
+        <div className="rounded-lg border border-stellar-border bg-stellar-card">
+          <div className="px-6 py-4 border-b border-stellar-border">
+            <h2 className="text-lg font-semibold text-stellar-text-primary">Source Summary</h2>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <caption className="sr-only">Schema drift summary by source</caption>
+              <thead>
+                <tr className="text-left text-stellar-text-secondary border-b border-stellar-border">
+                  <th scope="col" className="px-6 py-3">Source</th>
+                  <th scope="col" className="px-6 py-3">Incident Count</th>
+                  <th scope="col" className="px-6 py-3">Last Detected</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-stellar-border">
+                {summary.map((row) => (
+                  <tr key={row.source_name} className="hover:bg-stellar-dark/40">
+                    <td className="px-6 py-3 font-medium text-stellar-text-primary">{row.source_name}</td>
+                    <td className="px-6 py-3 text-stellar-text-secondary">{row.incident_count}</td>
+                    <td className="px-6 py-3 text-stellar-text-secondary">
+                      {row.last_detected ? formatDetectedAt(row.last_detected) : "—"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      <div className="rounded-lg border border-stellar-border bg-stellar-card">
+        <div className="px-6 py-4 border-b border-stellar-border">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <h2 className="text-lg font-semibold text-stellar-text-primary">Recent Drift Events</h2>
+            <div className="flex flex-wrap gap-2">
+              <select
+                aria-label="Filter by source"
+                value={sourceFilter}
+                onChange={(e) => setSourceFilter(e.target.value)}
+                className="rounded border border-stellar-border bg-stellar-dark px-2 py-1 text-xs text-stellar-text-secondary focus:outline-none focus:ring-1 focus:ring-stellar-blue"
+              >
+                {sources.map((s) => (
+                  <option key={s} value={s}>{s === "ALL" ? "All sources" : s}</option>
+                ))}
+              </select>
+
+              <select
+                aria-label="Filter by drift type"
+                value={driftTypeFilter}
+                onChange={(e) => setDriftTypeFilter(e.target.value as DriftType)}
+                className="rounded border border-stellar-border bg-stellar-dark px-2 py-1 text-xs text-stellar-text-secondary focus:outline-none focus:ring-1 focus:ring-stellar-blue"
+              >
+                <option value="ALL">All types</option>
+                <option value="ADDITION">Addition</option>
+                <option value="REMOVAL">Removal</option>
+                <option value="TYPE_CHANGE">Type change</option>
+              </select>
+
+              <select
+                aria-label="Filter by time range"
+                value={timeRange}
+                onChange={(e) => setTimeRange(Number(e.target.value))}
+                className="rounded border border-stellar-border bg-stellar-dark px-2 py-1 text-xs text-stellar-text-secondary focus:outline-none focus:ring-1 focus:ring-stellar-blue"
+              >
+                {TIME_RANGES.map((r) => (
+                  <option key={r.hours} value={r.hours}>{r.label}</option>
+                ))}
+              </select>
+            </div>
+          </div>
+        </div>
+
+        {isLoading ? (
+          <div className="p-6 space-y-4">
+            {[1, 2, 3].map((i) => (
+              <SkeletonCard key={i} rows={2} ariaLabel={`Loading drift event ${i}`} />
+            ))}
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className="px-6 py-8 text-center">
+            <p className="text-stellar-text-secondary">
+              No drift events found for the selected filters.
+            </p>
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <caption className="sr-only">Recent schema drift incidents</caption>
+              <thead>
+                <tr className="text-left text-stellar-text-secondary border-b border-stellar-border">
+                  <th scope="col" className="px-6 py-3">Source</th>
+                  <th scope="col" className="px-6 py-3">Type</th>
+                  <th scope="col" className="px-6 py-3">Field</th>
+                  <th scope="col" className="px-6 py-3">Expected</th>
+                  <th scope="col" className="px-6 py-3">Actual</th>
+                  <th scope="col" className="px-6 py-3">Severity</th>
+                  <th scope="col" className="px-6 py-3">Detected</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-stellar-border">
+                {filtered.map((incident) => (
+                  <tr
+                    key={incident.id}
+                    className={incident.is_breaking ? "bg-red-900/5 hover:bg-red-900/10" : "hover:bg-stellar-dark/40"}
+                  >
+                    <td className="px-6 py-3 font-medium text-stellar-text-primary">{incident.source_name}</td>
+                    <td className="px-6 py-3"><DriftTypeBadge driftType={incident.drift_type} /></td>
+                    <td className="px-6 py-3 font-mono text-xs text-stellar-text-secondary">{incident.field_path}</td>
+                    <td className="px-6 py-3 text-stellar-text-secondary">{incident.expected_type ?? "—"}</td>
+                    <td className="px-6 py-3 text-stellar-text-secondary">{incident.actual_type ?? "—"}</td>
+                    <td className="px-6 py-3"><SeverityBadge isBreaking={incident.is_breaking} /></td>
+                    <td className="px-6 py-3 text-stellar-text-secondary">{formatDetectedAt(incident.detected_at)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1056,3 +1056,30 @@ export function getFreshnessSourceTrend(
 export function getFreshnessAlerts(): Promise<{ alerts: FreshnessAlert[]; timestamp: string }> {
   return fetchApi<{ alerts: FreshnessAlert[]; timestamp: string }>("/freshness/alerts");
 }
+
+export interface SchemaDriftSummary {
+  source_name: string;
+  incident_count: number;
+  last_detected: string;
+}
+
+export interface SchemaDriftIncident {
+  id: string;
+  source_name: string;
+  drift_type: "ADDITION" | "REMOVAL" | "TYPE_CHANGE";
+  field_path: string;
+  expected_type?: string | null;
+  actual_type?: string | null;
+  is_breaking: boolean;
+  detected_at: string;
+  is_resolved?: boolean;
+}
+
+export interface SchemaDriftReport {
+  summary: SchemaDriftSummary[];
+  recentIncidents: SchemaDriftIncident[];
+}
+
+export function getSchemaDriftReport(): Promise<SchemaDriftReport> {
+  return fetchApi<SchemaDriftReport>("/schema-drift/report");
+}


### PR DESCRIPTION
## Summary

- **Closes #691** — Registers `LiquidityDashboard` at `/liquidity-dashboard` in `App.tsx` with lazy loading and adds a navigation entry under Monitoring
- **Closes #694** — Adds a new `SchemaDriftMonitor` page at `/schema-drift` that consumes the existing `GET /api/schema-drift/report` endpoint, with source and time-range filtering, severity badges, and drift type badges

## Changes

- `frontend/src/App.tsx` — lazy imports + routes for `LiquidityDashboard` and `SchemaDriftMonitor`
- `frontend/src/components/MobileNav/navigation.ts` — nav entries for both pages under Monitoring
- `frontend/src/services/api.ts` — `getSchemaDriftReport()` function with `SchemaDriftReport`, `SchemaDriftSummary`, `SchemaDriftIncident` types
- `frontend/src/hooks/useSchemaDrift.ts` — React Query hook for the drift report endpoint
- `frontend/src/pages/SchemaDriftMonitor.tsx` — new page listing drift events with severity, filtering by source, drift type, and time range
- `frontend/src/pages/LiquidityDashboard.test.tsx` — 4 tests confirming route renders and shows key UI
- `frontend/src/pages/SchemaDriftMonitor.test.tsx` — 8 tests covering heading, stat cards, source summary, incident table, badges, and filters

## Test plan

- [ ] All 12 new tests pass (`vitest run`)
- [ ] `/liquidity-dashboard` renders the Liquidity page with depth chart, venue table, and price impact calculator
- [ ] `/schema-drift` renders the Schema Drift Monitor with source summary and recent incidents table
- [ ] Source filter hides rows from other sources
- [ ] Drift type filter shows only matching incident types
- [ ] Time range filter removes incidents outside the selected window
- [ ] Both pages appear in the Monitoring nav group

Closes #691, Closes #694