### PR TITLE
feat(access-overview): replace in-memory stub with DB-backed listSummaries

### DIFF
--- a/backend/src/services/accessOverview.service.ts
+++ b/backend/src/services/accessOverview.service.ts
@@ -1,3 +1,5 @@
+import { getDatabase } from "../database/connection.js";
+
 export interface WorkspaceAccessSummary {
   workspaceId: string;
   workspaceName: string;
@@ -5,15 +7,40 @@ export interface WorkspaceAccessSummary {
 }
 
 export class AccessOverviewService {
-  // Lightweight in-memory stub; replace with DB queries or API calls as needed
-  private readonly summaries: WorkspaceAccessSummary[] = [];
-
   async listSummaries(): Promise<WorkspaceAccessSummary[]> {
-    return this.summaries.slice();
+    const db = getDatabase();
+
+    const bridges = await db("bridges")
+      .select("id", "name")
+      .where("is_active", true)
+      .orderBy("name");
+
+    const operators = await db("bridge_operators")
+      .select("bridge_id", "operator_address", "provider_name", "is_active")
+      .where("is_active", true);
+
+    const operatorsByBridgeName = new Map<string, { address: string; provider: string }[]>();
+    for (const op of operators) {
+      const list = operatorsByBridgeName.get(op.bridge_id) ?? [];
+      list.push({ address: op.operator_address, provider: op.provider_name });
+      operatorsByBridgeName.set(op.bridge_id, list);
+    }
+
+    return bridges.map((bridge) => {
+      const ops = operatorsByBridgeName.get(bridge.name) ?? [];
+      const roles: Record<string, string[]> = { operator: [] };
+      for (const op of ops) {
+        roles.operator.push(op.address);
+      }
+      return {
+        workspaceId: bridge.id,
+        workspaceName: bridge.name,
+        roles,
+      };
+    });
   }
 
   async addSummary(summary: WorkspaceAccessSummary) {
-    this.summaries.push(summary);
     return summary;
   }
 }

--- a/backend/tests/api/accessOverview.test.ts
+++ b/backend/tests/api/accessOverview.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { AccessOverviewService } from "../../src/services/accessOverview.service.js";
+import * as connection from "../../src/database/connection.js";
+
+function makeDb(bridges: object[], operators: object[]) {
+  const queryBuilder = (table: string) => {
+    const qb: any = {
+      select: () => qb,
+      where: () => qb,
+      orderBy: () => (table === "bridges" ? Promise.resolve(bridges) : Promise.resolve(operators)),
+    };
+    return qb;
+  };
+  return queryBuilder;
+}
+
+describe("AccessOverviewService.listSummaries", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns empty array when no bridges exist", async () => {
+    vi.spyOn(connection, "getDatabase").mockReturnValue(makeDb([], []) as any);
+    const svc = new AccessOverviewService();
+    const result = await svc.listSummaries();
+    expect(result).toEqual([]);
+  });
+
+  it("maps each bridge to a WorkspaceAccessSummary", async () => {
+    const bridges = [{ id: "bridge-uuid-1", name: "stellar-eth" }];
+    const operators = [
+      { bridge_id: "stellar-eth", operator_address: "0xABC", provider_name: "Prov1", is_active: true },
+      { bridge_id: "stellar-eth", operator_address: "0xDEF", provider_name: "Prov2", is_active: true },
+    ];
+    vi.spyOn(connection, "getDatabase").mockReturnValue(makeDb(bridges, operators) as any);
+    const svc = new AccessOverviewService();
+    const result = await svc.listSummaries();
+    expect(result).toHaveLength(1);
+    expect(result[0].workspaceId).toBe("bridge-uuid-1");
+    expect(result[0].workspaceName).toBe("stellar-eth");
+    expect(result[0].roles.operator).toContain("0xABC");
+    expect(result[0].roles.operator).toContain("0xDEF");
+  });
+
+  it("returns empty operator list for bridges with no operators", async () => {
+    const bridges = [{ id: "bridge-uuid-2", name: "stellar-btc" }];
+    vi.spyOn(connection, "getDatabase").mockReturnValue(makeDb(bridges, []) as any);
+    const svc = new AccessOverviewService();
+    const result = await svc.listSummaries();
+    expect(result[0].roles.operator).toEqual([]);
+  });
+
+  it("addSummary returns the passed summary unchanged", async () => {
+    const svc = new AccessOverviewService();
+    const summary = { workspaceId: "x", workspaceName: "y", roles: {} };
+    expect(await svc.addSummary(summary)).toEqual(summary);
+  });
+});


### PR DESCRIPTION
Closes #674
Closes #675
Closes #682
Closes #683

## Summary

- Replaced the in-memory stub in `AccessOverviewService.listSummaries` with Knex queries against the `bridges` and `bridge_operators` tables
- Each active bridge becomes a `WorkspaceAccessSummary` with its operators aggregated under `roles.operator`
- Added unit tests in `backend/tests/api/accessOverview.test.ts` covering empty state, multi-operator mapping, bridge with no operators, and `addSummary` passthrough

## Test plan

- [ ] `AccessOverviewService.listSummaries` returns DB-sourced summaries
- [ ] Empty operator list returned when a bridge has no active operators
- [ ] `addSummary` returns the summary unchanged