### PR TITLE
test: add missing test suites for frontend hooks and backend services

### DIFF
--- a/backend/tests/jobs/auditRetention.job.test.ts
+++ b/backend/tests/jobs/auditRetention.job.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { runAuditRetentionJob } from "../../src/jobs/auditRetention.job.js";
+import { auditService } from "../../src/services/audit.service.js";
+
+// Mock logger
+vi.mock("../../src/utils/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// Mock the auditService
+vi.mock("../../src/services/audit.service.js", () => ({
+  auditService: {
+    applyRetentionPolicy: vi.fn(),
+  },
+}));
+
+describe("runAuditRetentionJob", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should execute the retention job with default retention days", async () => {
+    const { logger } = await import("../../src/utils/logger.js");
+    
+    // Mock the cleanup to return 50 deleted records
+    vi.mocked(auditService.applyRetentionPolicy).mockResolvedValueOnce(50);
+
+    await runAuditRetentionJob();
+
+    // Verify it called applyRetentionPolicy with default 90 days
+    expect(auditService.applyRetentionPolicy).toHaveBeenCalledTimes(1);
+    expect(auditService.applyRetentionPolicy).toHaveBeenCalledWith(90);
+
+    // Verify logging behavior
+    expect(logger.info).toHaveBeenCalledWith(
+      { retentionDays: 90 }, 
+      "Running audit log retention job"
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      { deleted: 50, retentionDays: 90 }, 
+      "Audit log retention job complete"
+    );
+  });
+
+  it("should execute the retention job with custom retention days", async () => {
+    const { logger } = await import("../../src/utils/logger.js");
+    
+    vi.mocked(auditService.applyRetentionPolicy).mockResolvedValueOnce(120);
+
+    await runAuditRetentionJob(30);
+
+    expect(auditService.applyRetentionPolicy).toHaveBeenCalledTimes(1);
+    expect(auditService.applyRetentionPolicy).toHaveBeenCalledWith(30);
+
+    expect(logger.info).toHaveBeenCalledWith(
+      { deleted: 120, retentionDays: 30 }, 
+      "Audit log retention job complete"
+    );
+  });
+
+  it("should handle edge case when no records are deleted", async () => {
+    const { logger } = await import("../../src/utils/logger.js");
+    
+    vi.mocked(auditService.applyRetentionPolicy).mockResolvedValueOnce(0);
+
+    await runAuditRetentionJob(60);
+
+    expect(auditService.applyRetentionPolicy).toHaveBeenCalledWith(60);
+    expect(logger.info).toHaveBeenCalledWith(
+      { deleted: 0, retentionDays: 60 }, 
+      "Audit log retention job complete"
+    );
+  });
+
+  it("should handle execution failures and log the error", async () => {
+    const { logger } = await import("../../src/utils/logger.js");
+    
+    const dbError = new Error("Database connection failed");
+    vi.mocked(auditService.applyRetentionPolicy).mockRejectedValueOnce(dbError);
+
+    await expect(runAuditRetentionJob(90)).rejects.toThrow("Database connection failed");
+
+    expect(auditService.applyRetentionPolicy).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledWith(
+      { error: dbError }, 
+      "Audit log retention job failed"
+    );
+  });
+});

--- a/backend/tests/services/sourceNormalization.service.test.ts
+++ b/backend/tests/services/sourceNormalization.service.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { SourceNormalizationService, adapterRegistry, type ProviderAdapter } from "../../src/services/sourceNormalization.service.js";
+
+// Mock logger
+vi.mock("../../src/utils/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// Mock database
+const mockInsert = vi.fn().mockResolvedValue([1]);
+const mockDb = vi.fn().mockReturnValue({
+  insert: mockInsert,
+});
+
+vi.mock("../../src/database/connection.js", () => ({
+  getDatabase: () => mockDb,
+}));
+
+// Create a dummy adapter for testing mapping and conflicts
+class TestAdapter implements ProviderAdapter {
+  provider = "test_provider";
+  version = "v1";
+
+  validate(payload: unknown): boolean {
+    const data = payload as Record<string, unknown>;
+    return typeof data.asset === "string" && typeof data.value === "number";
+  }
+
+  normalize(payload: unknown) {
+    const data = payload as Record<string, unknown>;
+    
+    if (data.value === -1) {
+      throw new Error("Invalid negative value during normalization");
+    }
+
+    return {
+      id: "test-id-123",
+      provider: this.provider,
+      version: this.version,
+      assetCode: String(data.asset),
+      assetIssuer: "native",
+      amount: Number(data.value),
+      timestamp: new Date("2026-06-28T00:00:00Z"),
+      raw: { original: data }
+    };
+  }
+}
+
+describe("SourceNormalizationService", () => {
+  let service: SourceNormalizationService;
+
+  beforeAll(() => {
+    // Register the test adapter
+    adapterRegistry.register(new TestAdapter());
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = SourceNormalizationService.getInstance();
+  });
+
+  it("should successfully normalize a valid payload", async () => {
+    const payload = {
+      asset: "USDC",
+      value: 100.5,
+      extra: "info"
+    };
+
+    const result = await service.normalize("test_provider", "v1", payload);
+
+    expect(result.provider).toBe("test_provider");
+    expect(result.version).toBe("v1");
+    expect(result.assetCode).toBe("USDC");
+    expect(result.amount).toBe(100.5);
+    expect(result.raw).toEqual({ original: payload });
+
+    // Verify it was persisted to DB
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+    expect(mockInsert).toHaveBeenCalledWith(expect.objectContaining({
+      id: "test-id-123",
+      provider: "test_provider",
+      version: "v1",
+      asset_code: "USDC",
+      amount: 100.5,
+    }));
+  });
+
+  it("should successfully normalize stellar payloads using the built-in adapter", async () => {
+    const payload = {
+      asset_code: "EURC",
+      asset_issuer: "GEURC",
+      amount: 500,
+      timestamp: "2026-06-28T12:00:00Z",
+      memo: "test-tx"
+    };
+
+    const result = await service.normalize("stellar", "v1", payload);
+
+    expect(result.provider).toBe("stellar");
+    expect(result.assetCode).toBe("EURC");
+    expect(result.assetIssuer).toBe("GEURC");
+    expect(result.amount).toBe(500);
+    // Extra fields should be moved to raw
+    expect(result.raw).toEqual({ memo: "test-tx" });
+  });
+
+  it("should reject payload if validation fails", async () => {
+    const { logger } = await import("../../src/utils/logger.js");
+    
+    const invalidPayload = {
+      asset: "USDC",
+      value: "100" // Should be a number for our TestAdapter
+    };
+
+    await expect(service.normalize("test_provider", "v1", invalidPayload))
+      .rejects.toThrow("Payload validation failed for provider='test_provider' version='v1'");
+    
+    expect(logger.error).toHaveBeenCalled();
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("should throw if no adapter is registered for provider", async () => {
+    const { logger } = await import("../../src/utils/logger.js");
+    
+    await expect(service.normalize("unknown_provider", "v1", {}))
+      .rejects.toThrow("No adapter registered for provider='unknown_provider' version='v1'");
+      
+    expect(logger.error).toHaveBeenCalled();
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("should handle normalization errors from the adapter", async () => {
+    const { logger } = await import("../../src/utils/logger.js");
+    
+    const conflictingPayload = {
+      asset: "USDC",
+      value: -1 // Triggers error in TestAdapter.normalize
+    };
+
+    await expect(service.normalize("test_provider", "v1", conflictingPayload))
+      .rejects.toThrow(/Adapter normalization error for provider='test_provider' version='v1'/);
+      
+    expect(logger.error).toHaveBeenCalled();
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("should warn when registering a duplicate adapter", async () => {
+    const { logger } = await import("../../src/utils/logger.js");
+    
+    // Registering the same test adapter again
+    adapterRegistry.register(new TestAdapter());
+    
+    expect(logger.warn).toHaveBeenCalledWith(
+      { provider: "test_provider", version: "v1" },
+      "Adapter already registered – overwriting"
+    );
+  });
+});

--- a/backend/tests/services/usageMetrics.service.test.ts
+++ b/backend/tests/services/usageMetrics.service.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { UsageMetricsService, getUsageMetricsService } from "../../src/services/usageMetrics.service.js";
+
+// Mock logger
+vi.mock("../../src/utils/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// Mock database
+const mockInsert = vi.fn().mockResolvedValue([1]);
+const mockRaw = vi.fn().mockResolvedValue({
+  rows: [
+    { period: "2026-06-28T00:00:00.000Z", key: "/api/test", count: "5", avg_ms: "120.5", p95_ms: "200.0" }
+  ]
+});
+
+const mockDb = vi.fn().mockReturnValue({
+  insert: mockInsert,
+});
+// Attach raw to the mockDb function object
+mockDb.raw = mockRaw;
+
+vi.mock("../../src/database/connection.js", () => ({
+  getDatabase: () => mockDb,
+}));
+
+describe("UsageMetricsService", () => {
+  let service: UsageMetricsService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = getUsageMetricsService();
+  });
+
+  it("should record a usage metric without blocking", async () => {
+    // Calling the function which does fire-and-forget
+    await service.record({
+      endpoint: "/api/test",
+      method: "GET",
+      status_code: 200,
+      duration_ms: 150,
+      user_id: "user-123",
+      metadata: { region: "us-east" }
+    });
+    
+    // Give the event loop a tick to process the unawaited Promise
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+    expect(mockInsert).toHaveBeenCalledWith({
+      endpoint: "/api/test",
+      method: "GET",
+      status_code: 200,
+      duration_ms: 150,
+      user_id: "user-123",
+      metadata: JSON.stringify({ region: "us-east" }),
+    });
+  });
+
+  it("should record a usage metric with defaults", async () => {
+    await service.record({
+      endpoint: "/api/health",
+      method: "GET",
+      status_code: 200,
+      duration_ms: 10,
+    });
+    
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(mockInsert).toHaveBeenCalledWith(expect.objectContaining({
+      endpoint: "/api/health",
+      method: "GET",
+      status_code: 200,
+      duration_ms: 10,
+      user_id: null,
+      metadata: "{}",
+    }));
+  });
+
+  it("should handle recording errors gracefully", async () => {
+    const { logger } = await import("../../src/utils/logger.js");
+    mockInsert.mockRejectedValueOnce(new Error("DB Error"));
+
+    await service.record({
+      endpoint: "/api/error",
+      method: "POST",
+      status_code: 500,
+      duration_ms: 500,
+    });
+    
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ err: expect.any(Error) }),
+      "Failed to record usage metric"
+    );
+  });
+
+  it("should query aggregates with default parameters", async () => {
+    const result = await service.queryAggregates({});
+
+    expect(mockRaw).toHaveBeenCalledTimes(1);
+    expect(result).toHaveLength(1);
+    expect(result[0].count).toBe("5");
+    
+    const queryStr = mockRaw.mock.calls[0][0];
+    expect(queryStr).toContain("date_trunc('hour', created_at)");
+    expect(queryStr).toContain("endpoint as key");
+  });
+
+  it("should query aggregates with custom parameters", async () => {
+    const start = new Date("2026-06-20T00:00:00Z").toISOString();
+    const end = new Date("2026-06-21T00:00:00Z").toISOString();
+
+    const result = await service.queryAggregates({
+      start,
+      end,
+      groupBy: "method",
+      rollup: "day"
+    });
+
+    expect(mockRaw).toHaveBeenCalledTimes(1);
+    const args = mockRaw.mock.calls[0];
+    const queryStr = args[0];
+    const params = args[1];
+
+    expect(queryStr).toContain("date_trunc('day', created_at)");
+    expect(queryStr).toContain("method as key");
+    expect(params).toEqual([start, end]);
+    
+    expect(result).toHaveLength(1);
+  });
+});

--- a/frontend/src/hooks/useWatchlist.test.tsx
+++ b/frontend/src/hooks/useWatchlist.test.tsx
@@ -1,0 +1,168 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, beforeEach, beforeAll, afterAll, afterEach } from "vitest";
+import { setupServer } from "msw/node";
+import { useWatchlist, WatchlistProvider } from "./useWatchlist";
+import React from "react";
+
+// Mock MSW server setup to fulfill established frontend testing patterns,
+// even though useWatchlist relies purely on localStorage and has no API interactions.
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterAll(() => server.close());
+afterEach(() => server.resetHandlers());
+
+describe("useWatchlist", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <WatchlistProvider>{children}</WatchlistProvider>
+  );
+
+  it("should initialize with a default watchlist", () => {
+    const { result } = renderHook(() => useWatchlist(), { wrapper });
+    expect(result.current.watchlists).toHaveLength(1);
+    expect(result.current.watchlists[0].id).toBe("default");
+    expect(result.current.watchlists[0].name).toBe("Default");
+    expect(result.current.activeListId).toBe("default");
+  });
+
+  it("should add and remove assets", () => {
+    const { result } = renderHook(() => useWatchlist(), { wrapper });
+
+    act(() => {
+      result.current.addAsset("USDC");
+    });
+    expect(result.current.activeSymbols).toContain("USDC");
+    expect(result.current.isInWatchlist("USDC")).toBe(true);
+
+    act(() => {
+      result.current.addAsset("EURC");
+    });
+    expect(result.current.activeSymbols).toContain("EURC");
+
+    act(() => {
+      result.current.removeAsset("USDC");
+    });
+    expect(result.current.activeSymbols).not.toContain("USDC");
+    expect(result.current.isInWatchlist("USDC")).toBe(false);
+    expect(result.current.activeSymbols).toContain("EURC");
+  });
+
+  it("should ignore empty or duplicate assets", () => {
+    const { result } = renderHook(() => useWatchlist(), { wrapper });
+
+    act(() => {
+      result.current.addAsset("USDC");
+      result.current.addAsset("USDC");
+      result.current.addAsset("  ");
+    });
+
+    expect(result.current.activeSymbols).toEqual(["USDC"]);
+  });
+
+  it("should persist state to localStorage", () => {
+    const { result } = renderHook(() => useWatchlist(), { wrapper });
+
+    act(() => {
+      result.current.addAsset("BTC");
+    });
+
+    const storedRaw = window.localStorage.getItem("bridgewatch.watchlists.v1");
+    expect(storedRaw).toBeTruthy();
+    
+    const stored = JSON.parse(storedRaw!);
+    expect(stored.lists[0].assets).toContain("BTC");
+  });
+
+  it("should reorder assets", () => {
+    const { result } = renderHook(() => useWatchlist(), { wrapper });
+
+    act(() => {
+      result.current.addAsset("USDC");
+      result.current.addAsset("EURC");
+      result.current.addAsset("BTC");
+    });
+
+    expect(result.current.activeSymbols).toEqual(["USDC", "EURC", "BTC"]);
+
+    act(() => {
+      result.current.reorderAsset("BTC", "up");
+    });
+
+    expect(result.current.activeSymbols).toEqual(["USDC", "BTC", "EURC"]);
+
+    act(() => {
+      result.current.reorderAsset("USDC", "down");
+    });
+
+    expect(result.current.activeSymbols).toEqual(["BTC", "USDC", "EURC"]);
+  });
+
+  it("should create, rename, and delete watchlists", () => {
+    const { result } = renderHook(() => useWatchlist(), { wrapper });
+
+    act(() => {
+      result.current.createWatchlist("My Custom List");
+    });
+
+    expect(result.current.watchlists).toHaveLength(2);
+    expect(result.current.activeListId).toBe("my-custom-list");
+    
+    act(() => {
+      result.current.renameWatchlist("my-custom-list", "Favorites");
+    });
+
+    const activeList = result.current.watchlists.find(l => l.id === "my-custom-list");
+    expect(activeList?.name).toBe("Favorites");
+
+    act(() => {
+      result.current.deleteWatchlist("my-custom-list");
+    });
+
+    expect(result.current.watchlists).toHaveLength(1);
+    expect(result.current.activeListId).toBe("default");
+  });
+
+  it("should clear active watchlist assets", () => {
+    const { result } = renderHook(() => useWatchlist(), { wrapper });
+
+    act(() => {
+      result.current.addAsset("USDC");
+    });
+
+    expect(result.current.activeSymbols).toContain("USDC");
+
+    act(() => {
+      result.current.clearActiveWatchlist();
+    });
+
+    expect(result.current.activeSymbols).toHaveLength(0);
+  });
+
+  it("should export and import watchlists", () => {
+    const { result } = renderHook(() => useWatchlist(), { wrapper });
+
+    act(() => {
+      result.current.addAsset("TEST");
+    });
+
+    const exported = result.current.exportWatchlists();
+
+    act(() => {
+      result.current.removeAsset("TEST");
+    });
+
+    expect(result.current.activeSymbols).not.toContain("TEST");
+
+    let imported = false;
+    act(() => {
+      imported = result.current.importWatchlists(exported);
+    });
+
+    expect(imported).toBe(true);
+    expect(result.current.activeSymbols).toContain("TEST");
+  });
+});


### PR DESCRIPTION
1. Frontend: Watchlist Hook Tests
File: 
useWatchlist.test.tsx

Mocked the MSW server environment as per frontend testing standards, although the hook relies on localStorage interactions without external API calls.
Covered all major hook functionality including initializing the default state, adding/removing assets, reordering logic, handling watchlists creation, and full import/export flows while validating state persistence.
2. Backend: Usage Metrics Service Tests
File: 
usageMetrics.service.test.ts

Utilized vi.mock for the Knex database and application loggers inline with your backend factory strategies.
Covered the UsageMetricsService.record fire-and-forget methods natively, including error handling.
Validated queryAggregates behavior when using both custom buckets/date ranges and default fallback values.
3. Backend: Source Normalization Service Tests
File: 
sourceNormalization.service.test.ts

Instantiated a custom TestAdapter that implements ProviderAdapter and registered it with adapterRegistry to simulate full lifecycle mapping, validation, and normalization.
Handled the validation rejection paths and error generation for missing/conflicting adapter schemas.
Validated correct structural data transformations (merging unmapped fields to raw) when saving normalized outputs to the database helper.
4. Backend: Audit Retention Job Tests
File: 
auditRetention.job.test.ts

Mimicked the mocking strategy found in supplyVerification jobs.
Fully mocked the injected auditService.applyRetentionPolicy and tested happy paths, overriding the default retention limit, edge cases of returning zero deletions, and error boundaries resulting from failed job executions.


Closes #759
Closes #755
Closes #752
Closes #767