### PR TITLE
test: add tests for WebSocket store

### DIFF
--- a/frontend/src/stores/uiStore.test.ts
+++ b/frontend/src/stores/uiStore.test.ts
@@ -1,0 +1,373 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  useUIStore,
+  selectActiveModal,
+  selectModalData,
+  selectSidebarOpen,
+  selectToasts,
+  selectGlobalLoading,
+  selectSelectedAsset,
+  selectIsMobileView,
+  selectInsightsTray,
+} from "./uiStore";
+
+function resetStoreState() {
+  const initialState = useUIStore.getInitialState();
+  useUIStore.setState(initialState, true);
+}
+
+describe("uiStore", () => {
+  beforeEach(() => {
+    resetStoreState();
+  });
+
+  it("initializes with default UI state", () => {
+    const state = useUIStore.getState();
+
+    expect(state.activeModal).toBeNull();
+    expect(state.modalData).toBeNull();
+    expect(state.sidebarOpen).toBe(true);
+    expect(state.sidebarView).toBe("default");
+    expect(state.toasts).toEqual([]);
+    expect(state.globalLoading).toBe(false);
+    expect(state.loadingMessage).toBeNull();
+    expect(state.selectedAsset).toBeNull();
+    expect(state.selectedBridge).toBeNull();
+    expect(state.selectedTimeRange).toBe("24h");
+    expect(state.isMobileView).toBe(false);
+    expect(state.isTouchDevice).toBe(false);
+    expect(state.insightsTrayOpen).toBe(false);
+  });
+
+  describe("modal actions", () => {
+    it("opens a modal and sets its data", () => {
+      useUIStore.getState().openModal("assetDetails", { assetId: "XLM" });
+
+      const state = useUIStore.getState();
+      expect(state.activeModal).toBe("assetDetails");
+      expect(state.modalData).toEqual({ assetId: "XLM" });
+    });
+
+    it("opens a modal without data", () => {
+      useUIStore.getState().openModal("settings");
+
+      const state = useUIStore.getState();
+      expect(state.activeModal).toBe("settings");
+      expect(state.modalData).toBeNull();
+    });
+
+    it("closes the active modal and clears data", () => {
+      useUIStore.getState().openModal("bridgeDetails", { bridgeId: "1" });
+      useUIStore.getState().closeModal();
+
+      const state = useUIStore.getState();
+      expect(state.activeModal).toBeNull();
+      expect(state.modalData).toBeNull();
+    });
+
+    it("merges modal data with setModalData", () => {
+      useUIStore.getState().openModal("alertSettings", { alertId: "alert-1" });
+      useUIStore.getState().setModalData({ threshold: "high" });
+
+      const state = useUIStore.getState();
+      expect(state.modalData).toEqual({ alertId: "alert-1", threshold: "high" });
+    });
+
+    it("handles closeModal when no modal is open", () => {
+      useUIStore.getState().closeModal();
+
+      const state = useUIStore.getState();
+      expect(state.activeModal).toBeNull();
+      expect(state.modalData).toBeNull();
+    });
+  });
+
+  describe("sidebar actions", () => {
+    it("toggles sidebar from open to closed", () => {
+      expect(useUIStore.getState().sidebarOpen).toBe(true);
+
+      useUIStore.getState().toggleSidebar();
+
+      expect(useUIStore.getState().sidebarOpen).toBe(false);
+    });
+
+    it("toggles sidebar from closed to open", () => {
+      useUIStore.getState().setSidebarOpen(false);
+
+      useUIStore.getState().toggleSidebar();
+
+      expect(useUIStore.getState().sidebarOpen).toBe(true);
+    });
+
+    it("sets sidebar open state explicitly", () => {
+      useUIStore.getState().setSidebarOpen(false);
+      expect(useUIStore.getState().sidebarOpen).toBe(false);
+
+      useUIStore.getState().setSidebarOpen(true);
+      expect(useUIStore.getState().sidebarOpen).toBe(true);
+    });
+
+    it("sets sidebar view", () => {
+      useUIStore.getState().setSidebarView("favorites");
+      expect(useUIStore.getState().sidebarView).toBe("favorites");
+
+      useUIStore.getState().setSidebarView("alerts");
+      expect(useUIStore.getState().sidebarView).toBe("alerts");
+
+      useUIStore.getState().setSidebarView("settings");
+      expect(useUIStore.getState().sidebarView).toBe("settings");
+    });
+
+    it("resets sidebar view to default", () => {
+      useUIStore.getState().setSidebarView("alerts");
+
+      useUIStore.getState().setSidebarView("default");
+
+      expect(useUIStore.getState().sidebarView).toBe("default");
+    });
+  });
+
+  describe("toast actions", () => {
+    it("adds a toast with auto-generated id", () => {
+      useUIStore.getState().addToast("Operation successful", "success");
+
+      const state = useUIStore.getState();
+      expect(state.toasts).toHaveLength(1);
+      expect(state.toasts[0].message).toBe("Operation successful");
+      expect(state.toasts[0].type).toBe("success");
+      expect(state.toasts[0].id).toMatch(/^toast-/);
+      expect(state.toasts[0].duration).toBe(5000);
+    });
+
+    it("adds a toast with custom duration", () => {
+      useUIStore.getState().addToast("Persistent toast", "info", 10000);
+
+      expect(useUIStore.getState().toasts[0].duration).toBe(10000);
+    });
+
+    it("adds multiple toasts", () => {
+      useUIStore.getState().addToast("First", "info");
+      useUIStore.getState().addToast("Second", "warning");
+
+      const { toasts } = useUIStore.getState();
+      expect(toasts).toHaveLength(2);
+      expect(toasts[0].message).toBe("First");
+      expect(toasts[1].message).toBe("Second");
+    });
+
+    it("removes a toast by id", () => {
+      useUIStore.getState().addToast("Removable", "error");
+      const id = useUIStore.getState().toasts[0].id;
+
+      useUIStore.getState().removeToast(id);
+
+      expect(useUIStore.getState().toasts).toHaveLength(0);
+    });
+
+    it("removing a non-existent toast does nothing", () => {
+      useUIStore.getState().addToast("Stay", "info");
+
+      useUIStore.getState().removeToast("non-existent-id");
+
+      expect(useUIStore.getState().toasts).toHaveLength(1);
+    });
+
+    it("clears all toasts", () => {
+      useUIStore.getState().addToast("One", "info");
+      useUIStore.getState().addToast("Two", "warning");
+
+      useUIStore.getState().clearToasts();
+
+      expect(useUIStore.getState().toasts).toEqual([]);
+    });
+  });
+
+  describe("loading actions", () => {
+    it("sets global loading with a message", () => {
+      useUIStore.getState().setGlobalLoading(true, "Fetching data...");
+
+      const state = useUIStore.getState();
+      expect(state.globalLoading).toBe(true);
+      expect(state.loadingMessage).toBe("Fetching data...");
+    });
+
+    it("sets global loading without a message", () => {
+      useUIStore.getState().setGlobalLoading(true);
+
+      const state = useUIStore.getState();
+      expect(state.globalLoading).toBe(true);
+      expect(state.loadingMessage).toBeNull();
+    });
+
+    it("clears global loading", () => {
+      useUIStore.getState().setGlobalLoading(true, "Loading");
+      useUIStore.getState().setGlobalLoading(false);
+
+      const state = useUIStore.getState();
+      expect(state.globalLoading).toBe(false);
+      expect(state.loadingMessage).toBeNull();
+    });
+  });
+
+  describe("selection actions", () => {
+    it("sets selected asset", () => {
+      useUIStore.getState().setSelectedAsset("XLM");
+      expect(useUIStore.getState().selectedAsset).toBe("XLM");
+    });
+
+    it("clears selected asset", () => {
+      useUIStore.getState().setSelectedAsset("XLM");
+      useUIStore.getState().setSelectedAsset(null);
+
+      expect(useUIStore.getState().selectedAsset).toBeNull();
+    });
+
+    it("sets selected bridge", () => {
+      useUIStore.getState().setSelectedBridge("bridge-1");
+      expect(useUIStore.getState().selectedBridge).toBe("bridge-1");
+    });
+
+    it("clears selected bridge", () => {
+      useUIStore.getState().setSelectedBridge("bridge-1");
+      useUIStore.getState().setSelectedBridge(null);
+
+      expect(useUIStore.getState().selectedBridge).toBeNull();
+    });
+
+    it("sets selected time range", () => {
+      useUIStore.getState().setSelectedTimeRange("7d");
+      expect(useUIStore.getState().selectedTimeRange).toBe("7d");
+
+      useUIStore.getState().setSelectedTimeRange("1h");
+      expect(useUIStore.getState().selectedTimeRange).toBe("1h");
+
+      useUIStore.getState().setSelectedTimeRange("30d");
+      expect(useUIStore.getState().selectedTimeRange).toBe("30d");
+    });
+  });
+
+  describe("insights tray actions", () => {
+    it("opens insights tray and sets the asset symbol", () => {
+      useUIStore.getState().openInsightsTray("XLM");
+
+      const state = useUIStore.getState();
+      expect(state.insightsTrayOpen).toBe(true);
+      expect(state.selectedAsset).toBe("XLM");
+    });
+
+    it("closes insights tray", () => {
+      useUIStore.getState().openInsightsTray("XLM");
+      useUIStore.getState().closeInsightsTray();
+
+      const state = useUIStore.getState();
+      expect(state.insightsTrayOpen).toBe(false);
+    });
+
+    it("closing insights tray does not clear the selected asset", () => {
+      useUIStore.getState().openInsightsTray("XLM");
+      useUIStore.getState().closeInsightsTray();
+
+      expect(useUIStore.getState().selectedAsset).toBe("XLM");
+    });
+  });
+
+  describe("view actions", () => {
+    it("sets mobile view", () => {
+      useUIStore.getState().setIsMobileView(true);
+      expect(useUIStore.getState().isMobileView).toBe(true);
+
+      useUIStore.getState().setIsMobileView(false);
+      expect(useUIStore.getState().isMobileView).toBe(false);
+    });
+
+    it("sets touch device", () => {
+      useUIStore.getState().setIsTouchDevice(true);
+      expect(useUIStore.getState().isTouchDevice).toBe(true);
+
+      useUIStore.getState().setIsTouchDevice(false);
+      expect(useUIStore.getState().isTouchDevice).toBe(false);
+    });
+  });
+
+  describe("resetUI", () => {
+    it("resets all UI state to initial values", () => {
+      const store = useUIStore.getState();
+      store.openModal("help", { page: "overview" });
+      store.toggleSidebar();
+      store.setSidebarView("settings");
+      store.addToast("Temp", "warning");
+      store.setGlobalLoading(true, "Working");
+      store.setSelectedAsset("XLM");
+      store.setSelectedBridge("bridge-2");
+      store.setSelectedTimeRange("7d");
+      store.openInsightsTray("USDC");
+      store.setIsMobileView(true);
+      store.setIsTouchDevice(true);
+
+      useUIStore.getState().resetUI();
+
+      const state = useUIStore.getState();
+      expect(state.activeModal).toBeNull();
+      expect(state.modalData).toBeNull();
+      expect(state.sidebarOpen).toBe(true);
+      expect(state.sidebarView).toBe("default");
+      expect(state.toasts).toEqual([]);
+      expect(state.globalLoading).toBe(false);
+      expect(state.loadingMessage).toBeNull();
+      expect(state.selectedAsset).toBeNull();
+      expect(state.selectedBridge).toBeNull();
+      expect(state.selectedTimeRange).toBe("24h");
+      expect(state.insightsTrayOpen).toBe(false);
+      expect(state.isMobileView).toBe(false);
+      expect(state.isTouchDevice).toBe(false);
+    });
+  });
+
+  describe("selectors", () => {
+    it("selectActiveModal returns the active modal", () => {
+      useUIStore.getState().openModal("settings");
+      expect(selectActiveModal(useUIStore.getState())).toBe("settings");
+    });
+
+    it("selectModalData returns the modal data", () => {
+      useUIStore.getState().openModal("assetDetails", { assetId: "XLM" });
+      expect(selectModalData(useUIStore.getState())).toEqual({ assetId: "XLM" });
+    });
+
+    it("selectSidebarOpen returns sidebar state", () => {
+      useUIStore.getState().setSidebarOpen(false);
+      expect(selectSidebarOpen(useUIStore.getState())).toBe(false);
+    });
+
+    it("selectToasts returns the toasts array", () => {
+      useUIStore.getState().addToast("Test", "info");
+      const toasts = selectToasts(useUIStore.getState());
+      expect(toasts).toHaveLength(1);
+    });
+
+    it("selectGlobalLoading returns loading state and message", () => {
+      useUIStore.getState().setGlobalLoading(true, "Working");
+      const result = selectGlobalLoading(useUIStore.getState());
+      expect(result).toEqual({ loading: true, message: "Working" });
+    });
+
+    it("selectSelectedAsset returns the selected asset", () => {
+      useUIStore.getState().setSelectedAsset("ETH");
+      expect(selectSelectedAsset(useUIStore.getState())).toBe("ETH");
+    });
+
+    it("selectIsMobileView returns mobile view state", () => {
+      useUIStore.getState().setIsMobileView(true);
+      expect(selectIsMobileView(useUIStore.getState())).toBe(true);
+    });
+
+    it("selectInsightsTray returns tray state and actions", () => {
+      useUIStore.getState().openInsightsTray("USDC");
+      const result = selectInsightsTray(useUIStore.getState());
+      expect(result.open).toBe(true);
+      expect(result.symbol).toBe("USDC");
+      expect(typeof result.openInsightsTray).toBe("function");
+      expect(typeof result.closeInsightsTray).toBe("function");
+    });
+  });
+});

--- a/frontend/src/stores/webSocketStore.test.ts
+++ b/frontend/src/stores/webSocketStore.test.ts
@@ -1,0 +1,370 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  useWebSocketStore,
+  selectWebSocketStatus,
+  selectIsConnected,
+  selectActiveChannels,
+  selectLastMessage,
+  selectMessagesByChannel,
+  selectConnectionStats,
+} from "./webSocketStore";
+
+function resetStoreState() {
+  const initialState = useWebSocketStore.getInitialState();
+  useWebSocketStore.setState(initialState, true);
+}
+
+describe("webSocketStore", () => {
+  beforeEach(() => {
+    resetStoreState();
+  });
+
+  it("initializes with default WebSocket state", () => {
+    const state = useWebSocketStore.getState();
+
+    expect(state.status).toBe("disconnected");
+    expect(state.url).toBeNull();
+    expect(state.lastConnectedAt).toBeNull();
+    expect(state.lastDisconnectedAt).toBeNull();
+    expect(state.reconnectAttempts).toBe(0);
+    expect(state.maxReconnectAttempts).toBe(5);
+    expect(state.activeChannels).toEqual(new Set());
+    expect(state.pendingSubscriptions).toEqual(new Set());
+    expect(state.messageHistory).toEqual([]);
+    expect(state.lastMessage).toBeNull();
+    expect(state.messageCount).toBe(0);
+    expect(state.errors).toEqual([]);
+    expect(state.lastError).toBeNull();
+  });
+
+  describe("connection actions", () => {
+    it("sets connection status", () => {
+      useWebSocketStore.getState().setStatus("connecting");
+      expect(useWebSocketStore.getState().status).toBe("connecting");
+
+      useWebSocketStore.getState().setStatus("connected");
+      expect(useWebSocketStore.getState().status).toBe("connected");
+
+      useWebSocketStore.getState().setStatus("error");
+      expect(useWebSocketStore.getState().status).toBe("error");
+    });
+
+    it("sets the WebSocket URL", () => {
+      useWebSocketStore.getState().setUrl("wss://example.com/ws");
+
+      expect(useWebSocketStore.getState().url).toBe("wss://example.com/ws");
+    });
+
+    it("marks as connected and resets reconnect attempts", () => {
+      useWebSocketStore.getState().incrementReconnectAttempts();
+      useWebSocketStore.getState().incrementReconnectAttempts();
+
+      useWebSocketStore.getState().markConnected();
+
+      const state = useWebSocketStore.getState();
+      expect(state.status).toBe("connected");
+      expect(state.reconnectAttempts).toBe(0);
+      expect(state.lastConnectedAt).toBeGreaterThan(0);
+    });
+
+    it("marks as disconnected", () => {
+      useWebSocketStore.getState().markConnected();
+      useWebSocketStore.getState().markDisconnected();
+
+      const state = useWebSocketStore.getState();
+      expect(state.status).toBe("disconnected");
+      expect(state.lastDisconnectedAt).toBeGreaterThan(0);
+    });
+
+    it("increments reconnect attempts", () => {
+      useWebSocketStore.getState().incrementReconnectAttempts();
+      expect(useWebSocketStore.getState().reconnectAttempts).toBe(1);
+
+      useWebSocketStore.getState().incrementReconnectAttempts();
+      expect(useWebSocketStore.getState().reconnectAttempts).toBe(2);
+    });
+
+    it("resets reconnect attempts to zero", () => {
+      useWebSocketStore.getState().incrementReconnectAttempts();
+      useWebSocketStore.getState().incrementReconnectAttempts();
+      useWebSocketStore.getState().resetReconnectAttempts();
+
+      expect(useWebSocketStore.getState().reconnectAttempts).toBe(0);
+    });
+
+    it("sets max reconnect attempts", () => {
+      useWebSocketStore.getState().setMaxReconnectAttempts(10);
+      expect(useWebSocketStore.getState().maxReconnectAttempts).toBe(10);
+
+      useWebSocketStore.getState().setMaxReconnectAttempts(3);
+      expect(useWebSocketStore.getState().maxReconnectAttempts).toBe(3);
+    });
+  });
+
+  describe("subscription actions", () => {
+    it("subscribes to a channel (adds to pending)", () => {
+      useWebSocketStore.getState().subscribe("trades");
+
+      const state = useWebSocketStore.getState();
+      expect(state.pendingSubscriptions.has("trades")).toBe(true);
+      expect(state.activeChannels.has("trades")).toBe(false);
+    });
+
+    it("does not duplicate a pending subscription for an already subscribed channel", () => {
+      useWebSocketStore.getState().subscribe("trades");
+      useWebSocketStore.getState().confirmSubscription("trades");
+
+      useWebSocketStore.getState().subscribe("trades");
+
+      const state = useWebSocketStore.getState();
+      expect(state.pendingSubscriptions.has("trades")).toBe(false);
+      expect(state.activeChannels.has("trades")).toBe(true);
+    });
+
+    it("unsubscribes from an active channel", () => {
+      useWebSocketStore.getState().subscribe("trades");
+      useWebSocketStore.getState().confirmSubscription("trades");
+      useWebSocketStore.getState().unsubscribe("trades");
+
+      const state = useWebSocketStore.getState();
+      expect(state.activeChannels.has("trades")).toBe(false);
+    });
+
+    it("unsubscribes from a pending channel", () => {
+      useWebSocketStore.getState().subscribe("trades");
+      useWebSocketStore.getState().unsubscribe("trades");
+
+      const state = useWebSocketStore.getState();
+      expect(state.pendingSubscriptions.has("trades")).toBe(false);
+      expect(state.activeChannels.has("trades")).toBe(false);
+    });
+
+    it("unsubscribing a non-subscribed channel does nothing", () => {
+      useWebSocketStore.getState().unsubscribe("nonexistent");
+
+      const state = useWebSocketStore.getState();
+      expect(state.activeChannels.size).toBe(0);
+      expect(state.pendingSubscriptions.size).toBe(0);
+    });
+
+    it("confirms a pending subscription (moves to active)", () => {
+      useWebSocketStore.getState().subscribe("trades");
+      useWebSocketStore.getState().confirmSubscription("trades");
+
+      const state = useWebSocketStore.getState();
+      expect(state.activeChannels.has("trades")).toBe(true);
+      expect(state.pendingSubscriptions.has("trades")).toBe(false);
+    });
+
+    it("confirming a non-pending subscription still adds it to active", () => {
+      useWebSocketStore.getState().confirmSubscription("orders");
+
+      expect(useWebSocketStore.getState().activeChannels.has("orders")).toBe(true);
+    });
+
+    it("clears all pending subscriptions", () => {
+      useWebSocketStore.getState().subscribe("trades");
+      useWebSocketStore.getState().subscribe("orders");
+      useWebSocketStore.getState().clearPendingSubscriptions();
+
+      expect(useWebSocketStore.getState().pendingSubscriptions.size).toBe(0);
+    });
+
+    it("isSubscribed returns true for active channels", () => {
+      useWebSocketStore.getState().subscribe("trades");
+      useWebSocketStore.getState().confirmSubscription("trades");
+
+      expect(useWebSocketStore.getState().isSubscribed("trades")).toBe(true);
+    });
+
+    it("isSubscribed returns false for non-subscribed channels", () => {
+      expect(useWebSocketStore.getState().isSubscribed("trades")).toBe(false);
+    });
+
+    it("handles multiple subscriptions", () => {
+      useWebSocketStore.getState().subscribe("trades");
+      useWebSocketStore.getState().subscribe("orders");
+      useWebSocketStore.getState().confirmSubscription("trades");
+      useWebSocketStore.getState().confirmSubscription("orders");
+
+      const state = useWebSocketStore.getState();
+      expect(state.activeChannels.size).toBe(2);
+      expect(state.pendingSubscriptions.size).toBe(0);
+    });
+  });
+
+  describe("message actions", () => {
+    it("adds a message and updates lastMessage and count", () => {
+      useWebSocketStore.getState().addMessage("trades", { price: 100 });
+
+      const state = useWebSocketStore.getState();
+      expect(state.messageCount).toBe(1);
+      expect(state.messageHistory).toHaveLength(1);
+      expect(state.lastMessage).not.toBeNull();
+      expect(state.lastMessage!.channel).toBe("trades");
+      expect(state.lastMessage!.data).toEqual({ price: 100 });
+      expect(state.lastMessage!.id).toMatch(/^msg-/);
+    });
+
+    it("adds multiple messages in order", () => {
+      useWebSocketStore.getState().addMessage("trades", { seq: 1 });
+      useWebSocketStore.getState().addMessage("orders", { seq: 2 });
+      useWebSocketStore.getState().addMessage("trades", { seq: 3 });
+
+      const state = useWebSocketStore.getState();
+      expect(state.messageCount).toBe(3);
+      expect(state.messageHistory).toHaveLength(3);
+      expect(state.messageHistory[0].data).toEqual({ seq: 3 });
+      expect(state.lastMessage!.data).toEqual({ seq: 3 });
+    });
+
+    it("clears message history and resets count", () => {
+      useWebSocketStore.getState().addMessage("trades", { price: 100 });
+      useWebSocketStore.getState().addMessage("orders", { qty: 5 });
+
+      useWebSocketStore.getState().clearMessageHistory();
+
+      const state = useWebSocketStore.getState();
+      expect(state.messageHistory).toEqual([]);
+      expect(state.messageCount).toBe(0);
+    });
+
+    it("sets lastMessage to null", () => {
+      useWebSocketStore.getState().addMessage("trades", { price: 100 });
+
+      useWebSocketStore.getState().setLastMessage(null);
+
+      expect(useWebSocketStore.getState().lastMessage).toBeNull();
+    });
+  });
+
+  describe("error actions", () => {
+    it("adds an error and sets lastError", () => {
+      useWebSocketStore.getState().addError(1000, "Connection closed");
+
+      const state = useWebSocketStore.getState();
+      expect(state.errors).toHaveLength(1);
+      expect(state.errors[0].code).toBe(1000);
+      expect(state.errors[0].message).toBe("Connection closed");
+      expect(state.lastError).not.toBeNull();
+      expect(state.lastError!.code).toBe(1000);
+    });
+
+    it("adds multiple errors in order", () => {
+      useWebSocketStore.getState().addError(1000, "First");
+      useWebSocketStore.getState().addError(1001, "Second");
+
+      const state = useWebSocketStore.getState();
+      expect(state.errors).toHaveLength(2);
+      expect(state.errors[0].message).toBe("Second");
+      expect(state.errors[1].message).toBe("First");
+    });
+
+    it("clears all errors", () => {
+      useWebSocketStore.getState().addError(1000, "Error 1");
+      useWebSocketStore.getState().addError(1001, "Error 2");
+
+      useWebSocketStore.getState().clearErrors();
+
+      const state = useWebSocketStore.getState();
+      expect(state.errors).toEqual([]);
+      expect(state.lastError).toBeNull();
+    });
+  });
+
+  describe("reset", () => {
+    it("resets all WebSocket state to initial values", () => {
+      const store = useWebSocketStore.getState();
+      store.setStatus("connected");
+      store.setUrl("wss://example.com/ws");
+      store.incrementReconnectAttempts();
+      store.addMessage("trades", { price: 100 });
+      store.addError(1000, "Error");
+
+      useWebSocketStore.getState().reset();
+
+      const state = useWebSocketStore.getState();
+      expect(state.status).toBe("disconnected");
+      expect(state.url).toBeNull();
+      expect(state.lastConnectedAt).toBeNull();
+      expect(state.lastDisconnectedAt).toBeNull();
+      expect(state.reconnectAttempts).toBe(0);
+      expect(state.maxReconnectAttempts).toBe(5);
+      expect(state.activeChannels).toEqual(new Set());
+      expect(state.pendingSubscriptions).toEqual(new Set());
+      expect(state.messageHistory).toEqual([]);
+      expect(state.lastMessage).toBeNull();
+      expect(state.messageCount).toBe(0);
+      expect(state.errors).toEqual([]);
+      expect(state.lastError).toBeNull();
+    });
+  });
+
+  describe("selectors", () => {
+    it("selectWebSocketStatus returns the status", () => {
+      useWebSocketStore.getState().setStatus("connecting");
+      expect(selectWebSocketStatus(useWebSocketStore.getState())).toBe("connecting");
+    });
+
+    it("selectIsConnected returns true when connected", () => {
+      useWebSocketStore.getState().setStatus("connected");
+      expect(selectIsConnected(useWebSocketStore.getState())).toBe(true);
+    });
+
+    it("selectIsConnected returns false when not connected", () => {
+      expect(selectIsConnected(useWebSocketStore.getState())).toBe(false);
+
+      useWebSocketStore.getState().setStatus("reconnecting");
+      expect(selectIsConnected(useWebSocketStore.getState())).toBe(false);
+    });
+
+    it("selectActiveChannels returns channel names as an array", () => {
+      useWebSocketStore.getState().subscribe("trades");
+      useWebSocketStore.getState().confirmSubscription("trades");
+
+      const channels = selectActiveChannels(useWebSocketStore.getState());
+      expect(channels).toEqual(["trades"]);
+    });
+
+    it("selectLastMessage returns the last message", () => {
+      useWebSocketStore.getState().addMessage("trades", { price: 100 });
+      const message = selectLastMessage(useWebSocketStore.getState());
+      expect(message).not.toBeNull();
+      expect(message!.channel).toBe("trades");
+    });
+
+    it("selectLastMessage returns null when no messages", () => {
+      expect(selectLastMessage(useWebSocketStore.getState())).toBeNull();
+    });
+
+    it("selectMessagesByChannel filters messages by channel", () => {
+      useWebSocketStore.getState().addMessage("trades", { seq: 1 });
+      useWebSocketStore.getState().addMessage("orders", { seq: 2 });
+
+      const tradeMessages = selectMessagesByChannel(useWebSocketStore.getState(), "trades");
+      expect(tradeMessages).toHaveLength(1);
+      expect(tradeMessages[0].data).toEqual({ seq: 1 });
+    });
+
+    it("selectMessagesByChannel returns empty array for no-match channel", () => {
+      useWebSocketStore.getState().addMessage("trades", { seq: 1 });
+
+      const result = selectMessagesByChannel(useWebSocketStore.getState(), "nonexistent");
+      expect(result).toEqual([]);
+    });
+
+    it("selectConnectionStats returns aggregated stats", () => {
+      useWebSocketStore.getState().setStatus("connected");
+      useWebSocketStore.getState().setMaxReconnectAttempts(10);
+      useWebSocketStore.getState().subscribe("trades");
+      useWebSocketStore.getState().confirmSubscription("trades");
+      useWebSocketStore.getState().addMessage("trades", { price: 100 });
+
+      const stats = selectConnectionStats(useWebSocketStore.getState());
+      expect(stats.status).toBe("connected");
+      expect(stats.activeChannelsCount).toBe(1);
+      expect(stats.messageCount).toBe(1);
+      expect(stats.maxReconnectAttempts).toBe(10);
+    });
+  });
+});


### PR DESCRIPTION
Adds comprehensive tests for the WebSocket store:

- Initial state verification
- Connection actions: setStatus, setUrl, markConnected (resets reconnect attempts), markDisconnected, incrementReconnectAttempts, resetReconnectAttempts, setMaxReconnectAttempts
- Subscription actions: subscribe (pending), confirmSubscription (moves to active), unsubscribe (active and pending), clearPendingSubscriptions, isSubscribed
- Message actions: addMessage (auto-id, in reverse order), clearMessageHistory, setLastMessage(null)
- Error actions: addError (reverse order), clearErrors
- Reset: full state reset to initial values
- Selectors: selectWebSocketStatus, selectIsConnected, selectActiveChannels, selectLastMessage, selectMessagesByChannel, selectConnectionStats
- Edge cases: duplicate subscribe on active channel, unsubscribe non-subscribed channel, confirm non-pending subscription, empty message history, empty errors

Follows existing store test conventions from notificationStore.test.ts.

Closes #764