### PR TITLE
test: add unit coverage for retry, provenance, pool, and notification templates

### DIFF
--- a/backend/tests/services/notificationTemplate.service.test.ts
+++ b/backend/tests/services/notificationTemplate.service.test.ts
@@ -1,0 +1,198 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  NotificationTemplateService,
+  type NotificationTemplate,
+} from "../../src/services/notificationTemplate.service.js";
+
+vi.mock("../../src/utils/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const dbMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../src/database/connection.js", () => ({
+  getDatabase: () => dbMock,
+}));
+
+type StoredRow = Record<string, any>;
+
+const tables = vi.hoisted(() => ({
+  notification_templates: [] as StoredRow[],
+  template_versions: [] as StoredRow[],
+}));
+
+function resetTables() {
+  tables.notification_templates.length = 0;
+  tables.template_versions.length = 0;
+}
+
+function createQuery(table: keyof typeof tables) {
+  let rows = tables[table];
+  const query = {
+    where: vi.fn((criteriaOrColumn: any, value?: any) => {
+      if (typeof criteriaOrColumn === "string") {
+        rows = rows.filter((row) => row[criteriaOrColumn] === value);
+      } else {
+        rows = rows.filter((row) =>
+          Object.entries(criteriaOrColumn).every(([key, expected]) => row[key] === expected),
+        );
+      }
+      return query;
+    }),
+    first: vi.fn(async () => rows[0] ?? null),
+    insert: vi.fn(async (row: StoredRow) => {
+      tables[table].push(row);
+      return [row.id];
+    }),
+    update: vi.fn(async (updates: StoredRow) => {
+      for (const row of rows) {
+        Object.assign(row, updates);
+      }
+      return rows.length;
+    }),
+    orderBy: vi.fn(async (column: string, direction: "asc" | "desc" = "asc") => {
+      const sorted = [...rows].sort((a, b) => {
+        const left = a[column] instanceof Date ? a[column].getTime() : a[column];
+        const right = b[column] instanceof Date ? b[column].getTime() : b[column];
+        return direction === "desc" ? right - left : left - right;
+      });
+      return sorted;
+    }),
+  };
+  return query;
+}
+
+function seedTemplate(overrides: Partial<NotificationTemplate> = {}) {
+  const template = {
+    id: "template-1",
+    name: "Bridge alert",
+    description: "Bridge alert template",
+    channel: "email",
+    subject: "Alert for {{asset}}",
+    body: "Hello {{user}}, {{asset}} is {{status}}.",
+    variables: JSON.stringify(["asset", "user", "status"]),
+    metadata: JSON.stringify({ severity: "high" }),
+    status: "approved",
+    version: 1,
+    created_by: "ops",
+    approved_by: "lead",
+    approved_at: new Date("2026-01-01T00:00:00.000Z"),
+    created_at: new Date("2026-01-01T00:00:00.000Z"),
+    updated_at: new Date("2026-01-01T00:00:00.000Z"),
+    ...overrides,
+  };
+  tables.notification_templates.push(template);
+  return template;
+}
+
+describe("NotificationTemplateService", () => {
+  let service: NotificationTemplateService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetTables();
+    dbMock.mockImplementation((table: keyof typeof tables) => createQuery(table));
+    service = new NotificationTemplateService();
+  });
+
+  it("creates templates with extracted unique variables and an initial version", async () => {
+    const template = await service.createTemplate({
+      name: "Depeg email",
+      description: "Depeg alert email",
+      channel: "email",
+      subject: "{{asset}} depeg alert",
+      body: "{{asset}} moved to {{price}} for {{asset}}",
+      variables: [],
+      metadata: { severity: "critical" },
+      created_by: "ops",
+    });
+
+    expect(template).toMatchObject({
+      name: "Depeg email",
+      channel: "email",
+      status: "draft",
+      version: 1,
+      variables: ["asset", "price"],
+      metadata: { severity: "critical" },
+    });
+    expect(tables.notification_templates).toHaveLength(1);
+    expect(tables.template_versions).toHaveLength(1);
+    expect(JSON.parse(tables.template_versions[0].variables)).toEqual(["asset", "price", "asset", "asset"]);
+  });
+
+  it("renders previews and reports missing variables without replacing unresolved tokens", async () => {
+    seedTemplate();
+
+    const preview = await service.previewTemplate("template-1", {
+      asset: "USDC",
+      user: "Mira",
+    });
+
+    expect(preview).toEqual({
+      subject: "Alert for USDC",
+      body: "Hello Mira, USDC is {{status}}.",
+      variables_used: ["asset", "user", "status"],
+      missing_variables: ["status"],
+    });
+  });
+
+  it("validates required and unused variables across body and subject", () => {
+    expect(
+      service.validateVariables(
+        "{{asset}} crossed {{threshold}}",
+        "Alert: {{asset}}",
+        ["asset", "channel"],
+      ),
+    ).toEqual({
+      valid: false,
+      missing: ["threshold"],
+      unused: ["channel"],
+    });
+  });
+
+  it("filters templates by channel and status variants", async () => {
+    seedTemplate({ id: "email-1", channel: "email", status: "approved" });
+    seedTemplate({ id: "webhook-1", channel: "webhook", status: "draft" });
+    seedTemplate({ id: "in-app-1", channel: "in_app", status: "approved" });
+    seedTemplate({ id: "sms-1", channel: "sms", status: "archived" });
+
+    await expect(service.getAllTemplates({ channel: "webhook" })).resolves.toEqual([
+      expect.objectContaining({ id: "webhook-1", channel: "webhook" }),
+    ]);
+    await expect(service.getAllTemplates({ status: "approved" })).resolves.toEqual([
+      expect.objectContaining({ id: "email-1", channel: "email" }),
+      expect.objectContaining({ id: "in-app-1", channel: "in_app" }),
+    ]);
+  });
+
+  it("updates status for approval flow and creates a version on content updates", async () => {
+    seedTemplate({ status: "draft", approved_by: null, approved_at: null });
+
+    await service.submitForApproval("template-1");
+    expect(tables.notification_templates[0].status).toBe("pending_approval");
+
+    await service.approveTemplate("template-1", "approver-1");
+    expect(tables.notification_templates[0]).toMatchObject({
+      status: "approved",
+      approved_by: "approver-1",
+    });
+
+    const updated = await service.updateTemplate(
+      "template-1",
+      { body: "Updated {{asset}} {{status}} {{severity}}" },
+      "editor-1",
+    );
+
+    expect(updated).toMatchObject({
+      version: 2,
+      status: "draft",
+      variables: ["asset", "user", "status", "severity"],
+    });
+    expect(tables.template_versions).toHaveLength(1);
+    expect(tables.template_versions[0]).toMatchObject({ template_id: "template-1", version: 2 });
+  });
+
+  it("throws when previewing an unknown template", async () => {
+    await expect(service.previewTemplate("missing", {})).rejects.toThrow("Template not found");
+  });
+});

--- a/backend/tests/services/pool.service.test.ts
+++ b/backend/tests/services/pool.service.test.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PoolService, type LiquidityPool } from "../../src/services/pool.service.js";
+
+vi.mock("../../src/utils/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("../../src/config/index.js", () => ({
+  config: {},
+}));
+
+const dbMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../src/database/connection.js", () => ({
+  getDatabase: () => dbMock,
+}));
+
+function makeDbPool(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "pool-1",
+    asset_a: "USDC",
+    asset_b: "XLM",
+    dex: "StellarX",
+    contract_address: "contract-1",
+    total_liquidity: "1000000",
+    reserve_a: "500000",
+    reserve_b: "2000000",
+    fee: "0.003",
+    apr: "5.2",
+    volume_24h: "100000",
+    health_score: 75,
+    last_updated: new Date("2026-01-01T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function makeEvent(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "event-1",
+    pool_id: "pool-1",
+    type: "deposit",
+    amount_a: "120000",
+    amount_b: "30000",
+    user: "GUSER",
+    timestamp: new Date("2026-01-02T00:00:00.000Z"),
+    tx_hash: "tx-1",
+    ...overrides,
+  };
+}
+
+function setupPoolMetricDb(poolRow: ReturnType<typeof makeDbPool> | null, volumeRow = { totalA: "700", totalB: "300" }) {
+  dbMock.mockImplementation((table: string) => {
+    if (table === "liquidity_pools") {
+      const builder = {
+        where: vi.fn().mockReturnThis(),
+        first: vi.fn().mockResolvedValue(poolRow),
+      };
+      return builder;
+    }
+
+    const builder = {
+      where: vi.fn().mockReturnThis(),
+      sum: vi.fn().mockReturnThis(),
+      first: vi.fn().mockResolvedValue(volumeRow),
+    };
+    return builder;
+  });
+}
+
+describe("PoolService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("aggregates pools across supported AMMs sorted by total liquidity", async () => {
+    const service = new PoolService();
+
+    const pools = await service.getAllPools();
+
+    expect(pools.map((pool) => pool.dex)).toEqual([
+      "StellarX",
+      "Phoenix",
+      "LumenSwap",
+      "Soroswap",
+      "SDEX",
+    ]);
+    expect(pools.map((pool) => pool.totalLiquidity)).toEqual([1_000_000, 800_000, 600_000, 400_000, 300_000]);
+  });
+
+  it("filters asset pairs in either asset order", async () => {
+    const service = new PoolService();
+
+    const forward = await service.getPoolsForPair("USDC", "XLM");
+    const reverse = await service.getPoolsForPair("XLM", "USDC");
+
+    expect(forward).toHaveLength(5);
+    expect(reverse.map((pool) => pool.id)).toEqual(forward.map((pool) => pool.id));
+    expect(await service.getPoolsForPair("USDC", "EURC")).toEqual([]);
+  });
+
+  it("compares multi-AMM pools and calculates aggregate liquidity and volume", async () => {
+    const service = new PoolService();
+
+    const comparison = await service.comparePools("USDC", "XLM");
+
+    expect(comparison?.bestTVL.dex).toBe("StellarX");
+    expect(comparison?.bestAPR.dex).toBe("Soroswap");
+    expect(comparison?.bestHealth.dex).toBe("StellarX");
+    expect(comparison?.aggregatedTVL).toBe(3_100_000);
+    expect(comparison?.aggregatedVolume).toBe(310_000);
+  });
+
+  it("returns null comparison when a pair has no pools", async () => {
+    const service = new PoolService();
+
+    await expect(service.comparePools("USDC", "EURC")).resolves.toBeNull();
+  });
+
+  it("calculates depth, utilization, volume, and health metrics for a pool", async () => {
+    setupPoolMetricDb(makeDbPool());
+    const service = new PoolService();
+
+    const metrics = await service.getPoolMetrics("pool-1");
+
+    expect(metrics).toEqual({
+      poolId: "pool-1",
+      tvl: 1_000_000,
+      volume24h: 100_000,
+      volume7d: 1_000,
+      apr: 5.2,
+      fee: 0.003,
+      utilization: 0.1,
+      healthScore: 90,
+      liquidityDepth: {
+        depth0_1: 10_000,
+        depth0_5: 50_000,
+        depth1: 100_000,
+        depth5: 500_000,
+      },
+    });
+  });
+
+  it("returns null metrics for an unknown pool", async () => {
+    setupPoolMetricDb(null);
+    const service = new PoolService();
+
+    await expect(service.getPoolMetrics("missing")).resolves.toBeNull();
+  });
+
+  it("detects large liquidity events relative to pool TVL", async () => {
+    dbMock.mockImplementation((table: string) => {
+      if (table === "pool_events") {
+        return {
+          where: vi.fn().mockReturnThis(),
+          orderBy: vi.fn().mockResolvedValue([
+            makeEvent({ id: "large", amount_a: "110000", amount_b: "10000" }),
+            makeEvent({ id: "small", amount_a: "1000", amount_b: "1000" }),
+          ]),
+        };
+      }
+      throw new Error(`Unexpected table ${table}`);
+    });
+    const service = new PoolService();
+    vi.spyOn(service, "getAllPools").mockResolvedValue([
+      {
+        id: "pool-1",
+        assetA: "USDC",
+        assetB: "XLM",
+        dex: "StellarX",
+        totalLiquidity: 1_000_000,
+        reserveA: 500_000,
+        reserveB: 2_000_000,
+        fee: 0.003,
+        apr: 5.2,
+        volume24h: 100_000,
+        healthScore: 75,
+        lastUpdated: new Date(),
+      } satisfies LiquidityPool,
+    ]);
+
+    const events = await service.detectLargeLiquidityEvents(0.1);
+
+    expect(events).toEqual([expect.objectContaining({ id: "large", amountA: 110_000, amountB: 10_000 })]);
+  });
+});

--- a/backend/tests/services/provenance.service.test.ts
+++ b/backend/tests/services/provenance.service.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  ProvenanceService,
+  type ProvenanceGraph,
+} from "../../src/services/provenance.service.js";
+
+function findReachableDestinations(graph: ProvenanceGraph, startId: string): string[] {
+  const adjacency = new Map<string, string[]>();
+  for (const edge of graph.edges) {
+    adjacency.set(edge.from, [...(adjacency.get(edge.from) ?? []), edge.to]);
+  }
+
+  const visited = new Set<string>();
+  const queue = [startId];
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    for (const next of adjacency.get(current) ?? []) {
+      if (!visited.has(next)) {
+        visited.add(next);
+        queue.push(next);
+      }
+    }
+  }
+
+  return graph.nodes
+    .filter((node) => node.kind === "destination" && visited.has(node.id))
+    .map((node) => node.id);
+}
+
+describe("ProvenanceService", () => {
+  const service = new ProvenanceService();
+
+  it("records available lineage entries with metric, asset, bridge, and node counts", () => {
+    const metrics = service.listMetrics();
+
+    expect(metrics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ metric: "price", asset: "USDC", bridge: null, nodeCount: 4 }),
+        expect.objectContaining({ metric: "health", asset: "USDC", bridge: null, nodeCount: 6 }),
+        expect.objectContaining({ metric: "tvl", asset: null, bridge: "Allbridge", nodeCount: 5 }),
+      ]),
+    );
+    for (const item of metrics) {
+      expect(new Date(item.lastUpdated).toString()).not.toBe("Invalid Date");
+      expect(item.nodeCount).toBeGreaterThan(0);
+    }
+  });
+
+  it("filters graph summaries by asset, bridge, and metric", () => {
+    expect(service.listMetrics({ asset: "USDC" }).map((item) => item.metric).sort()).toEqual([
+      "health",
+      "price",
+    ]);
+    expect(service.listMetrics({ bridge: "Allbridge" })).toEqual([
+      expect.objectContaining({ metric: "tvl", bridge: "Allbridge" }),
+    ]);
+    expect(service.listMetrics({ metric: "alerts", asset: "EURC" })).toEqual([
+      expect.objectContaining({ metric: "alerts", asset: "EURC" }),
+    ]);
+  });
+
+  it("returns a complete lineage graph for asset-scoped metrics", () => {
+    const graph = service.getLineage("price", "USDC");
+
+    expect(graph).toMatchObject({
+      metric: "price",
+      asset: "USDC",
+      bridge: null,
+    });
+    expect(graph?.nodes).toHaveLength(4);
+    expect(graph?.edges).toEqual([
+      expect.objectContaining({ from: "coinbase-feed", to: "price-aggregator", transformKind: "fetch" }),
+      expect.objectContaining({ from: "binance-feed", to: "price-aggregator", transformKind: "fetch" }),
+      expect.objectContaining({ from: "price-aggregator", to: "price-store", transformKind: "aggregate" }),
+    ]);
+  });
+
+  it("returns a bridge-scoped graph and preserves transform traversal order", () => {
+    const graph = service.getLineage("tvl", undefined, "Allbridge");
+
+    expect(graph?.bridge).toBe("Allbridge");
+    expect(graph?.edges.map((edge) => edge.transformKind)).toEqual([
+      "fetch",
+      "fetch",
+      "normalize",
+      "reconcile",
+    ]);
+  });
+
+  it("supports traversing from source nodes to destination nodes", () => {
+    const graph = service.getLineage("alerts", "EURC");
+
+    expect(graph).not.toBeNull();
+    expect(findReachableDestinations(graph!, "health-trigger")).toEqual(["notification-dest"]);
+  });
+
+  it("returns null when no graph exists for the requested scope", () => {
+    expect(service.getLineage("price", "EURC")).toBeNull();
+    expect(service.getLineage("tvl", undefined, "UnknownBridge")).toBeNull();
+  });
+});

--- a/backend/tests/services/retryPolicy.service.test.ts
+++ b/backend/tests/services/retryPolicy.service.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RetryPolicyService } from "../../src/services/retryPolicy.service.js";
+
+const recordCustomMetricMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../src/config/index.js", () => ({
+  config: { RETRY_MAX: 3 },
+}));
+
+vi.mock("../../src/utils/metrics.js", () => ({
+  getMetricsService: () => ({
+    recordCustomMetric: recordCustomMetricMock,
+  }),
+}));
+
+describe("RetryPolicyService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("normalizes default policy and per-operation overrides", () => {
+    const service = new RetryPolicyService({
+      maxRetries: -2,
+      baseDelayMs: 0,
+      maxDelayMs: 0,
+      backoffMultiplier: 0.5,
+      jitterRatio: 2,
+    });
+
+    expect(service.getPolicy()).toEqual({
+      maxRetries: 0,
+      baseDelayMs: 1,
+      maxDelayMs: 1,
+      backoffMultiplier: 1,
+      jitterRatio: 1,
+    });
+
+    expect(
+      service.getPolicy({
+        operation: "price-sync",
+        maxRetries: 5,
+        baseDelayMs: 250,
+        maxDelayMs: 10_000,
+        backoffMultiplier: 3,
+        jitterRatio: 0.1,
+      }),
+    ).toEqual({
+      maxRetries: 5,
+      baseDelayMs: 250,
+      maxDelayMs: 10_000,
+      backoffMultiplier: 3,
+      jitterRatio: 0.1,
+    });
+  });
+
+  it("calculates exponential backoff and caps delays at the max", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const service = new RetryPolicyService({
+      baseDelayMs: 100,
+      maxDelayMs: 500,
+      backoffMultiplier: 2,
+      jitterRatio: 0,
+    });
+
+    expect(service.getDelayMs(1)).toBe(100);
+    expect(service.getDelayMs(2)).toBe(200);
+    expect(service.getDelayMs(3)).toBe(400);
+    expect(service.getDelayMs(4)).toBe(500);
+    expect(service.getDelayMs(0)).toBe(100);
+  });
+
+  it("applies deterministic jitter within the configured window", () => {
+    const service = new RetryPolicyService({
+      baseDelayMs: 100,
+      maxDelayMs: 1_000,
+      backoffMultiplier: 2,
+      jitterRatio: 0.2,
+    });
+
+    vi.spyOn(Math, "random").mockReturnValueOnce(0).mockReturnValueOnce(0.999).mockReturnValueOnce(0.5);
+
+    expect(service.getDelayMs(2)).toBe(160);
+    expect(service.getDelayMs(2)).toBe(240);
+    expect(service.getDelayMs(2)).toBe(200);
+  });
+
+  it("classifies retryable and permanent failures", () => {
+    const service = new RetryPolicyService();
+
+    expect(service.classifyFailure(new Error("HTTP 429 rate limit exceeded"))).toBe("rate_limit");
+    expect(service.classifyFailure(new Error("request timeout"))).toBe("timeout");
+    expect(service.classifyFailure(new Error("forbidden"))).toBe("permanent");
+    expect(service.classifyFailure("socket reset")).toBe("transient");
+
+    expect(service.isRetryable(new Error("unauthorized"))).toBe(false);
+    expect(service.isRetryable(new Error("temporary outage"))).toBe(true);
+  });
+
+  it("records retry metrics and exposes BullMQ exponential backoff", () => {
+    const service = new RetryPolicyService({ baseDelayMs: 750 });
+
+    service.recordRetryMetric("reserve-check", "exhausted", 4, "timeout");
+
+    expect(recordCustomMetricMock).toHaveBeenCalledWith("retry_attempt_total", 1, "count", {
+      operation: "reserve-check",
+      status: "exhausted",
+      attempt: "4",
+      failureClass: "timeout",
+    });
+    expect(service.getBullMQBackoff({ operation: "reserve-check", baseDelayMs: 1250 })).toEqual({
+      type: "exponential",
+      delay: 1250,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add unit tests for retry policy backoff, max retry normalization, jitter, failure classification, and metrics
- Add provenance service tests for available lineage records, filtered graph queries, and traversal from sources to destinations
- Add pool service tests for multi-AMM aggregation, pair filtering, comparisons, depth metrics, and large liquidity events
- Add notification template tests for rendering, variable validation, channel/status variants, and approval/update flows

## Tests
- npm run test:unit --workspace=backend -- retryPolicy.service.test.ts provenance.service.test.ts pool.service.test.ts notificationTemplate.service.test.ts
- Attempted npm run test:backend; stopped after several minutes due unrelated existing Redis connection refusals/timeouts and unrelated suite failures

Closes #706
Closes #707
Closes #708
Closes #709