### PR TITLE
test: add unit tests for supply chain, query preset, session, and incident timeline services

### DIFF
--- a/backend/tests/services/incidentTimeline.service.test.ts
+++ b/backend/tests/services/incidentTimeline.service.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { IncidentTimelineService } from "../../src/services/incidentTimeline.service.js";
+
+describe("IncidentTimelineService", () => {
+  let service: IncidentTimelineService;
+
+  beforeEach(() => {
+    service = new IncidentTimelineService();
+  });
+
+  describe("addEvent", () => {
+    it("adds an event and returns it with id and incidentId", async () => {
+      const event = await service.addEvent("incident-1", {
+        type: "created",
+        actor: "user-1",
+        occurredAt: new Date().toISOString(),
+      });
+
+      expect(event.id).toBeDefined();
+      expect(event.incidentId).toBe("incident-1");
+      expect(event.type).toBe("created");
+      expect(event.actor).toBe("user-1");
+    });
+
+    it("generates a unique id for each event", async () => {
+      const event1 = await service.addEvent("incident-1", { type: "created" });
+      const event2 = await service.addEvent("incident-1", { type: "updated" });
+
+      expect(event1.id).not.toBe(event2.id);
+    });
+
+    it("defaults actor to null when not provided", async () => {
+      const event = await service.addEvent("incident-1", {
+        type: "system_action",
+      });
+
+      expect(event.actor).toBeNull();
+    });
+
+    it("defaults metadata to null when not provided", async () => {
+      const event = await service.addEvent("incident-1", { type: "test" });
+
+      expect(event.metadata).toBeNull();
+    });
+
+    it("stores metadata when provided", async () => {
+      const event = await service.addEvent("incident-1", {
+        type: "escalated",
+        actor: "user-1",
+        metadata: { severity: "critical", from: "monitor" },
+      });
+
+      expect(event.metadata).toEqual({ severity: "critical", from: "monitor" });
+    });
+
+    it("defaults occurredAt to current time when not provided", async () => {
+      const before = new Date();
+      const event = await service.addEvent("incident-1", { type: "created" });
+      const after = new Date();
+
+      const eventTime = new Date(event.occurredAt);
+      expect(eventTime.getTime()).toBeGreaterThanOrEqual(before.getTime());
+      expect(eventTime.getTime()).toBeLessThanOrEqual(after.getTime());
+    });
+  });
+
+  describe("getTimeline", () => {
+    it("returns empty array for unknown incident", async () => {
+      const timeline = await service.getTimeline("incident-unknown");
+
+      expect(timeline).toEqual([]);
+    });
+
+    it("returns events sorted by occurredAt ascending", async () => {
+      await service.addEvent("incident-1", {
+        type: "first",
+        occurredAt: "2025-01-02T00:00:00Z",
+      });
+      await service.addEvent("incident-1", {
+        type: "second",
+        occurredAt: "2025-01-03T00:00:00Z",
+      });
+      await service.addEvent("incident-1", {
+        type: "third",
+        occurredAt: "2025-01-01T00:00:00Z",
+      });
+
+      const timeline = await service.getTimeline("incident-1");
+
+      expect(timeline).toHaveLength(3);
+      expect(timeline[0].type).toBe("third");
+      expect(timeline[1].type).toBe("first");
+      expect(timeline[2].type).toBe("second");
+    });
+
+    it("returns events in chronological order even when added out of order", async () => {
+      await service.addEvent("incident-1", {
+        type: "middle",
+        occurredAt: "2025-06-15T00:00:00Z",
+      });
+      await service.addEvent("incident-1", {
+        type: "earliest",
+        occurredAt: "2025-01-01T00:00:00Z",
+      });
+      await service.addEvent("incident-1", {
+        type: "latest",
+        occurredAt: "2025-12-31T00:00:00Z",
+      });
+
+      const timeline = await service.getTimeline("incident-1");
+
+      expect(timeline[0].type).toBe("earliest");
+      expect(timeline[1].type).toBe("middle");
+      expect(timeline[2].type).toBe("latest");
+    });
+
+    it("preserves all event data in the timeline", async () => {
+      await service.addEvent("incident-1", {
+        type: "created",
+        actor: "user-1",
+        metadata: { note: "initial" },
+        occurredAt: "2025-01-01T00:00:00Z",
+      });
+
+      const timeline = await service.getTimeline("incident-1");
+
+      expect(timeline[0].type).toBe("created");
+      expect(timeline[0].actor).toBe("user-1");
+      expect(timeline[0].metadata).toEqual({ note: "initial" });
+      expect(timeline[0].incidentId).toBe("incident-1");
+    });
+  });
+
+  describe("listAll", () => {
+    it("returns empty object when no events exist", async () => {
+      const all = await service.listAll();
+
+      expect(all).toEqual({});
+    });
+
+    it("groups events by incident id", async () => {
+      await service.addEvent("incident-1", { type: "created" });
+      await service.addEvent("incident-1", { type: "updated" });
+      await service.addEvent("incident-2", { type: "created" });
+
+      const all = await service.listAll();
+
+      expect(Object.keys(all)).toHaveLength(2);
+      expect(all["incident-1"]).toHaveLength(2);
+      expect(all["incident-2"]).toHaveLength(1);
+    });
+  });
+
+  describe("event isolation", () => {
+    it("does not mix events between different incidents", async () => {
+      await service.addEvent("incident-a", { type: "alpha" });
+      await service.addEvent("incident-b", { type: "beta" });
+
+      const timelineA = await service.getTimeline("incident-a");
+      const timelineB = await service.getTimeline("incident-b");
+
+      expect(timelineA).toHaveLength(1);
+      expect(timelineA[0].type).toBe("alpha");
+      expect(timelineB).toHaveLength(1);
+      expect(timelineB[0].type).toBe("beta");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles adding many events without performance degradation", async () => {
+      const count = 100;
+      for (let i = 0; i < count; i++) {
+        await service.addEvent("incident-1", {
+          type: `event-${i}`,
+          occurredAt: new Date(2025, 0, 1, 0, 0, i).toISOString(),
+        });
+      }
+
+      const timeline = await service.getTimeline("incident-1");
+
+      expect(timeline).toHaveLength(count);
+      expect(timeline[0].type).toBe("event-0");
+      expect(timeline[count - 1].type).toBe(`event-${count - 1}`);
+    });
+
+    it("handles special characters in event type", async () => {
+      const event = await service.addEvent("incident-1", {
+        type: "alert:triggered@bridge[0]",
+      });
+
+      expect(event.type).toBe("alert:triggered@bridge[0]");
+    });
+  });
+});

--- a/backend/tests/services/queryPreset.service.test.ts
+++ b/backend/tests/services/queryPreset.service.test.ts
@@ -1,0 +1,322 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryPresetService } from "../../src/services/queryPreset.service.js";
+
+interface PresetRow {
+  id: string;
+  name: string;
+  description: string | null;
+  category: string;
+  query_definition: string;
+  is_shared: boolean;
+  created_by: string;
+  version: string;
+  access_rules: string;
+  metadata: string | null;
+  created_at: Date;
+  updated_at: Date;
+  last_used_at: Date | null;
+}
+
+let mockPresets: PresetRow[] = [];
+const presetInserted: PresetRow[] = [];
+let mockVersions: unknown[] = [];
+
+function buildQB(rows: unknown[]) {
+  const thenable = (resolve: (v: unknown) => void) => resolve(rows);
+  const qb: Record<string, unknown> = {
+    then: vi.fn((resolve: (v: unknown) => void) => {
+      resolve(rows);
+      return Promise.resolve(rows);
+    }),
+    catch: vi.fn(),
+    where: vi.fn((_col: unknown, _val?: unknown) => {
+      if (typeof _col === "object" && _col !== null && !_val) {
+        const obj = _col as Record<string, unknown>;
+        const key = Object.keys(obj)[0];
+        return buildQB(rows.filter((r: any) => r[key] === obj[key]));
+      }
+      if (typeof _col === "string" && _val !== undefined) {
+        return buildQB(rows.filter((r: any) => r[_col as string] === _val));
+      }
+      return buildQB(rows);
+    }),
+    whereNot: vi.fn().mockReturnThis(),
+    orWhere: vi.fn().mockReturnThis(),
+    orderBy: vi.fn((_col: string, _dir?: string) => buildQB(rows)),
+    first: vi.fn(() => Promise.resolve(rows[0] ?? null)),
+    limit: vi.fn((n: number) => buildQB(rows.slice(0, n))),
+    insert: vi.fn((data: Record<string, unknown>) => {
+      const now = new Date();
+      const newRow: PresetRow = {
+        id: "123e4567-e89b-12d3-a456-426614174000",
+        name: data.name as string,
+        description: (data.description as string) ?? null,
+        category: data.category as string,
+        query_definition: data.query_definition as string,
+        is_shared: (data.is_shared as boolean) ?? false,
+        created_by: data.created_by as string,
+        version: (data.version as string) ?? "1.0.0",
+        access_rules: (data.access_rules as string) ?? "{}",
+        metadata: (data.metadata as string) ?? null,
+        created_at: now,
+        updated_at: now,
+        last_used_at: null,
+      };
+      presetInserted.push(newRow);
+      return { returning: vi.fn(() => Promise.resolve([newRow])) };
+    }),
+    update: vi.fn((_data: Record<string, unknown>) =>
+      Promise.resolve(1),
+    ),
+    delete: vi.fn(() => Promise.resolve(1)),
+    returning: vi.fn(() => Promise.resolve(rows)),
+    clone: vi.fn(() => buildQB(rows)),
+    count: vi.fn(() => Promise.resolve([{ count: String(rows.length) }])),
+    select: vi.fn(() => Promise.resolve(rows)),
+  };
+  return qb;
+}
+
+vi.mock("../../src/database/connection.js", () => ({
+  getDatabase: vi.fn(() => {
+    const fn = (_table: string) => buildQB(mockPresets);
+    fn.raw = vi.fn((v: string) => v);
+    fn.fn = { now: () => new Date() };
+    return fn;
+  }),
+}));
+
+vi.mock("../../src/utils/redis.js", () => ({
+  redis: {
+    get: vi.fn(),
+    set: vi.fn(),
+    setex: vi.fn(),
+    del: vi.fn(),
+  },
+}));
+
+vi.mock("../../src/utils/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("../../src/config/index.js", () => ({
+  config: {
+    REDIS_HOST: "localhost",
+    REDIS_PORT: 6379,
+    REDIS_PASSWORD: undefined,
+  },
+}));
+
+function makePresetRow(overrides: Partial<PresetRow> = {}): PresetRow {
+  return {
+    id: "123e4567-e89b-12d3-a456-426614174000",
+    name: "Test Preset",
+    description: "A test preset",
+    category: "reports",
+    query_definition: JSON.stringify({ filters: ["asset"], fields: ["price"] }),
+    is_shared: false,
+    created_by: "user-1",
+    version: "1.0.0",
+    access_rules: JSON.stringify({}),
+    metadata: JSON.stringify({ tags: ["test"] }),
+    created_at: new Date(),
+    updated_at: new Date(),
+    last_used_at: null,
+    ...overrides,
+  };
+}
+
+describe("QueryPresetService", () => {
+  let service: QueryPresetService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPresets = [];
+    presetInserted.length = 0;
+    mockVersions = [];
+    service = new QueryPresetService();
+  });
+
+  describe("createPreset", () => {
+    it("creates a preset with initial version", async () => {
+      const result = await service.createPreset({
+        name: "Test Preset",
+        description: "A test preset",
+        category: "reports",
+        query_definition: { filters: ["asset"], fields: ["price"] },
+        created_by: "user-1",
+      });
+
+      expect(result.name).toBe("Test Preset");
+      expect(result.version).toBe("1.0.0");
+    });
+
+    it("defaults is_shared to false", async () => {
+      const result = await service.createPreset({
+        name: "Private Preset",
+        category: "analytics",
+        query_definition: { filters: [], fields: [] },
+        created_by: "user-1",
+      });
+
+      expect(result.is_shared).toBe(false);
+    });
+  });
+
+  describe("getPresetById", () => {
+    it("returns null for non-existent preset", async () => {
+      const result = await service.getPresetById("nonexistent", "user-1");
+      expect(result).toBeNull();
+    });
+
+    it("returns preset when found and user has access", async () => {
+      mockPresets = [makePresetRow({ created_by: "user-1" })];
+
+      const result = await service.getPresetById(
+        "123e4567-e89b-12d3-a456-426614174000",
+        "user-1",
+      );
+
+      expect(result).not.toBeNull();
+      expect(result?.name).toBe("Test Preset");
+    });
+
+    it("returns cached data on cache hit", async () => {
+      const { redis } = await import("../../src/utils/redis.js");
+      const cached = makePresetRow();
+      vi.mocked(redis.get).mockResolvedValue(JSON.stringify(cached));
+
+      const result = await service.getPresetById("some-id", "user-1");
+
+      expect(result).not.toBeNull();
+      expect(result?.name).toBe("Test Preset");
+    });
+
+    it("writes to cache on successful fetch", async () => {
+      const { redis } = await import("../../src/utils/redis.js");
+      vi.mocked(redis.get).mockResolvedValue(null);
+      mockPresets = [makePresetRow({ created_by: "user-1" })];
+
+      await service.getPresetById(
+        "123e4567-e89b-12d3-a456-426614174000",
+        "user-1",
+      );
+
+      expect(redis.setex).toHaveBeenCalled();
+    });
+  });
+
+  describe("listPresets", () => {
+    it("returns presets for the user", async () => {
+      mockPresets = [
+        makePresetRow({ name: "Mine", created_by: "user-1" }),
+        makePresetRow({ name: "Shared", created_by: "other", is_shared: true }),
+      ];
+
+      const result = await service.listPresets("user-1");
+
+      expect(result.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("updatePreset", () => {
+    it("returns null when preset not found", async () => {
+      const result = await service.updatePreset("nonexistent", "user-1", {
+        name: "Updated",
+        updated_by: "user-1",
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null when user cannot modify", async () => {
+      mockPresets = [makePresetRow({ created_by: "other-user" })];
+
+      const result = await service.updatePreset(
+        "123e4567-e89b-12d3-a456-426614174000",
+        "user-1",
+        { name: "Updated", updated_by: "user-1" },
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("deletePreset", () => {
+    it("returns false when preset not found", async () => {
+      const result = await service.deletePreset("nonexistent", "user-1");
+      expect(result).toBe(false);
+    });
+
+    it("returns false when user cannot modify", async () => {
+      mockPresets = [makePresetRow({ created_by: "other-user" })];
+
+      const result = await service.deletePreset(
+        "123e4567-e89b-12d3-a456-426614174000",
+        "user-1",
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it("returns true on successful deletion", async () => {
+      mockPresets = [makePresetRow({ created_by: "user-1" })];
+
+      const result = await service.deletePreset(
+        "123e4567-e89b-12d3-a456-426614174000",
+        "user-1",
+      );
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("getPresetVersions", () => {
+    it("returns empty array when preset not found", async () => {
+      const result = await service.getPresetVersions("nonexistent", "user-1");
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("validateQueryDefinition", () => {
+    it("returns true for valid definition", async () => {
+      const result = await service.validateQueryDefinition({
+        filters: ["asset"],
+        fields: ["price"],
+      });
+      expect(result).toBe(true);
+    });
+
+    it("returns false for invalid definition", async () => {
+      const result = await service.validateQueryDefinition({ foo: "bar" });
+      expect(result).toBe(false);
+    });
+
+    it("returns false for null", async () => {
+      const result = await service.validateQueryDefinition(
+        null as unknown as Record<string, unknown>,
+      );
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("recordUsage", () => {
+    it("does not throw", async () => {
+      await expect(
+        service.recordUsage("123e4567-e89b-12d3-a456-426614174000"),
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe("incrementVersion", () => {
+    it("increments the patch version", () => {
+      const result = (service as any).incrementVersion("1.0.0");
+      expect(result).toBe("1.0.1");
+    });
+
+    it("handles multi-digit versions", () => {
+      const result = (service as any).incrementVersion("2.15.99");
+      expect(result).toBe("2.15.100");
+    });
+  });
+});

--- a/backend/tests/services/session.service.test.ts
+++ b/backend/tests/services/session.service.test.ts
@@ -1,0 +1,333 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { SessionService } from "../../src/services/session.service.js";
+
+let mockRows: Record<string, unknown>[] = [];
+let mockCount = 0;
+
+function buildQB(rows: Record<string, unknown>[]) {
+  const qb: Record<string, unknown> = {
+    then: vi.fn((resolve: (v: unknown) => void) => {
+      resolve(rows);
+      return Promise.resolve(rows);
+    }),
+    catch: vi.fn(),
+    where: vi.fn((_col: unknown, _val?: unknown) => {
+      if (typeof _col === "object" && _col !== null && !_val) {
+        const obj = _col as Record<string, unknown>;
+        const key = Object.keys(obj)[0];
+        return buildQB(rows.filter((r) => r[key] === obj[key]));
+      }
+      if (typeof _col === "string" && _val !== undefined) {
+        if (_col === "token_hash") return buildQB(rows);
+        return buildQB(rows.filter((r) => r[_col as string] === _val));
+      }
+      return buildQB(rows);
+    }),
+    whereNot: vi.fn((_col: string, _val: unknown) =>
+      buildQB(rows.filter((r) => r[_col] !== _val)),
+    ),
+    orderBy: vi.fn((_col: string, _dir?: string) => buildQB(rows)),
+    limit: vi.fn((n: number) => buildQB(rows.slice(0, n))),
+    offset: vi.fn((_n: number) => buildQB(rows)),
+    first: vi.fn(() => Promise.resolve(rows[0] ?? null)),
+    insert: vi.fn(() => Promise.resolve(undefined)),
+    update: vi.fn(() => Promise.resolve(1)),
+    delete: vi.fn(() => Promise.resolve(1)),
+    returning: vi.fn(() => Promise.resolve(rows)),
+    clone: vi.fn(() => buildQB(rows)),
+    count: vi.fn(() => Promise.resolve([{ count: String(mockCount) }])),
+    select: vi.fn(() => Promise.resolve(rows)),
+  };
+  return qb;
+}
+
+vi.mock("../../src/database/connection.js", () => ({
+  getDatabase: vi.fn(() => {
+    const fn = (_table: string) => buildQB(mockRows);
+    fn.raw = vi.fn((v: string) => v);
+    fn.fn = { now: () => new Date() };
+    return fn;
+  }),
+}));
+
+vi.mock("../../src/utils/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("../../src/utils/pagination.js", () => ({
+  getPaginationParams: vi.fn((opts?: { page?: number; limit?: number }) => ({
+    page: opts?.page ?? 1,
+    limit: opts?.limit ?? 20,
+    offset: ((opts?.page ?? 1) - 1) * (opts?.limit ?? 20),
+  })),
+  formatPaginatedResponse: vi.fn(
+    (data: unknown[], total: number, page: number, limit: number) => ({
+      data,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+      hasMore: page * limit < total,
+    }),
+  ),
+}));
+
+describe("SessionService", () => {
+  let service: SessionService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRows = [];
+    mockCount = 0;
+    service = new SessionService();
+  });
+
+  describe("createSession", () => {
+    it("creates a session and returns session with token", async () => {
+      const result = await service.createSession({
+        userId: "user-1",
+        ipAddress: "127.0.0.1",
+      });
+
+      expect(result.session).toBeDefined();
+      expect(result.token).toBeDefined();
+      expect(result.session.userId).toBe("user-1");
+      expect(result.session.status).toBe("active");
+      expect(result.token.length).toBe(64);
+    });
+
+    it("sets default TTL of 7 days", async () => {
+      const result = await service.createSession({ userId: "user-1" });
+
+      const expiresAt = new Date(result.session.expiresAt);
+      const now = new Date();
+      const diffDays =
+        (expiresAt.getTime() - now.getTime()) / (1000 * 60 * 60 * 24);
+
+      expect(diffDays).toBeGreaterThan(6.5);
+      expect(diffDays).toBeLessThan(7.5);
+    });
+
+    it("respects custom TTL", async () => {
+      const result = await service.createSession({
+        userId: "user-1",
+        ttlSeconds: 3600,
+      });
+
+      const expiresAt = new Date(result.session.expiresAt);
+      const now = new Date();
+      const diffHours =
+        (expiresAt.getTime() - now.getTime()) / (1000 * 60 * 60);
+
+      expect(diffHours).toBeGreaterThan(0.5);
+      expect(diffHours).toBeLessThan(1.5);
+    });
+
+    it("includes device info when provided", async () => {
+      const result = await service.createSession({
+        userId: "user-1",
+        deviceId: "device-1",
+        deviceName: "iPhone 15",
+        deviceType: "mobile",
+        userAgent: "Mozilla/5.0",
+      });
+
+      expect(result.session.deviceId).toBe("device-1");
+      expect(result.session.deviceName).toBe("iPhone 15");
+      expect(result.session.deviceType).toBe("mobile");
+      expect(result.session.userAgent).toBe("Mozilla/5.0");
+    });
+  });
+
+  describe("validateSession", () => {
+    it("returns null for invalid token", async () => {
+      const result = await service.validateSession("invalid-token");
+      expect(result).toBeNull();
+    });
+
+    it("returns session for valid token when db row exists and is active", async () => {
+      const now = new Date();
+      const future = new Date(now.getTime() + 86400000);
+      mockRows = [
+        {
+          id: "session-abc",
+          user_id: "user-1",
+          token_hash: "any_hash",
+          device_id: null,
+          device_name: null,
+          device_type: null,
+          user_agent: null,
+          ip_address: "127.0.0.1",
+          status: "active",
+          expires_at: future.toISOString(),
+          last_active_at: now.toISOString(),
+          revoked_at: null,
+          revoked_reason: null,
+          created_at: now.toISOString(),
+          updated_at: now.toISOString(),
+        },
+      ];
+
+      const result = await service.validateSession("some-valid-token");
+
+      expect(result).not.toBeNull();
+      expect(result?.userId).toBe("user-1");
+      expect(result?.status).toBe("active");
+    });
+
+    it("returns null for revoked session", async () => {
+      mockRows = [
+        {
+          id: "session-abc",
+          user_id: "user-1",
+          status: "revoked",
+          token_hash: "hash",
+          expires_at: new Date(Date.now() + 86400000).toISOString(),
+          device_id: null,
+          device_name: null,
+          device_type: null,
+          user_agent: null,
+          ip_address: null,
+          last_active_at: new Date().toISOString(),
+          revoked_at: null,
+          revoked_reason: null,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        },
+      ];
+
+      const result = await service.validateSession("revoked-token");
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("getSessionById", () => {
+    it("returns null for non-existent session", async () => {
+      const result = await service.getSessionById("nonexistent");
+      expect(result).toBeNull();
+    });
+
+    it("returns session when found", async () => {
+      const now = new Date();
+      const future = new Date(now.getTime() + 86400000);
+      mockRows = [
+        {
+          id: "session-found",
+          user_id: "user-1",
+          token_hash: "hash",
+          device_id: null,
+          device_name: null,
+          device_type: null,
+          user_agent: null,
+          ip_address: "127.0.0.1",
+          status: "active",
+          expires_at: future.toISOString(),
+          last_active_at: now.toISOString(),
+          revoked_at: null,
+          revoked_reason: null,
+          created_at: now.toISOString(),
+          updated_at: now.toISOString(),
+        },
+      ];
+
+      const result = await service.getSessionById("session-found");
+
+      expect(result).not.toBeNull();
+      expect(result?.id).toBe("session-found");
+    });
+  });
+
+  describe("listSessions", () => {
+    it("returns paginated sessions", async () => {
+      mockCount = 3;
+      const now = new Date();
+      mockRows = [
+        {
+          id: "s1",
+          user_id: "user-1",
+          status: "active",
+          token_hash: "h1",
+          expires_at: new Date(Date.now() + 86400000).toISOString(),
+          last_active_at: now.toISOString(),
+          created_at: now.toISOString(),
+          updated_at: now.toISOString(),
+          device_id: null,
+          device_name: null,
+          device_type: null,
+          user_agent: null,
+          ip_address: "1.1.1.1",
+          revoked_at: null,
+          revoked_reason: null,
+        },
+        {
+          id: "s2",
+          user_id: "user-1",
+          status: "active",
+          token_hash: "h2",
+          expires_at: new Date(Date.now() + 86400000).toISOString(),
+          last_active_at: now.toISOString(),
+          created_at: now.toISOString(),
+          updated_at: now.toISOString(),
+          device_id: null,
+          device_name: null,
+          device_type: null,
+          user_agent: null,
+          ip_address: "1.1.1.2",
+          revoked_at: null,
+          revoked_reason: null,
+        },
+      ];
+
+      const result = await service.listSessions({ userId: "user-1" });
+
+      expect(result.data).toBeDefined();
+      expect(typeof result.total).toBe("number");
+      expect(typeof result.page).toBe("number");
+    });
+  });
+
+  describe("revokeSession", () => {
+    it("returns false for non-existent session", async () => {
+      const result = await service.revokeSession("nonexistent", "user-1");
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("revokeAllUserSessions", () => {
+    it("returns 0 when no active sessions", async () => {
+      const result = await service.revokeAllUserSessions("user-1", "admin");
+      expect(result).toBe(0);
+    });
+  });
+
+  describe("purgeExpiredSessions", () => {
+    it("returns count of purged sessions", async () => {
+      const result = await service.purgeExpiredSessions();
+      expect(typeof result).toBe("number");
+    });
+  });
+
+  describe("getAuditLog", () => {
+    it("returns audit entries for a session", async () => {
+      mockRows = [
+        {
+          id: 1,
+          session_id: "session-abc123",
+          user_id: "u1",
+          action: "created",
+          actor: "u1",
+          ip_address: "1.1.1.1",
+          metadata: null,
+          created_at: new Date().toISOString(),
+        },
+      ];
+
+      const result = await service.getAuditLog("session-abc123");
+
+      expect(Array.isArray(result)).toBe(true);
+      expect(result).toHaveLength(1);
+      expect(result[0].action).toBe("created");
+    });
+  });
+});

--- a/backend/tests/services/supplyChain.service.test.ts
+++ b/backend/tests/services/supplyChain.service.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { SupplyChainService } from "../../src/services/supplyChain.service.js";
+
+vi.mock("../../src/utils/redis.js", () => ({
+  redis: {
+    get: vi.fn(),
+    set: vi.fn(),
+  },
+}));
+
+vi.mock("../../src/utils/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+describe("SupplyChainService", () => {
+  let service: SupplyChainService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new SupplyChainService();
+  });
+
+  describe("getGraph", () => {
+    it("returns a graph with nodes and edges when cache is empty", async () => {
+      const { redis } = await import("../../src/utils/redis.js");
+      vi.mocked(redis.get).mockResolvedValue(null);
+
+      const graph = await service.getGraph();
+
+      expect(graph.nodes).toHaveLength(6);
+      expect(graph.edges).toHaveLength(7);
+      expect(graph.totalSupplyUsd).toBeGreaterThan(0);
+      expect(graph.totalBridgeVolumeUsd).toBeGreaterThan(0);
+      expect(graph.lastUpdated).toBeTruthy();
+    });
+
+    it("returns cached graph when cache hit", async () => {
+      const cached = {
+        nodes: [],
+        edges: [],
+        totalSupplyUsd: 0,
+        totalBridgeVolumeUsd: 0,
+        lastUpdated: new Date().toISOString(),
+      };
+      const { redis } = await import("../../src/utils/redis.js");
+      vi.mocked(redis.get).mockResolvedValue(JSON.stringify(cached));
+
+      const graph = await service.getGraph();
+
+      expect(graph.totalSupplyUsd).toBe(0);
+    });
+
+    it("builds and caches the graph on cache miss", async () => {
+      const { redis } = await import("../../src/utils/redis.js");
+      vi.mocked(redis.get).mockResolvedValue(null);
+
+      await service.getGraph();
+
+      expect(redis.set).toHaveBeenCalledWith(
+        "supply-chain:graph",
+        expect.any(String),
+        "EX",
+        60,
+      );
+    });
+
+    it("includes all chain nodes with correct structure", async () => {
+      const { redis } = await import("../../src/utils/redis.js");
+      vi.mocked(redis.get).mockResolvedValue(null);
+
+      const graph = await service.getGraph();
+      const stellar = graph.nodes.find((n) => n.id === "stellar");
+
+      expect(stellar).toBeDefined();
+      expect(stellar?.label).toBe("Stellar");
+      expect(stellar?.chain).toBe("stellar");
+      expect(stellar?.totalSupplyUsd).toBeGreaterThan(0);
+      expect(stellar?.healthScore).toBeGreaterThan(0);
+      expect(stellar?.assets.length).toBeGreaterThan(0);
+    });
+
+    it("includes all bridge edges with correct structure", async () => {
+      const { redis } = await import("../../src/utils/redis.js");
+      vi.mocked(redis.get).mockResolvedValue(null);
+
+      const graph = await service.getGraph();
+      const bridge = graph.edges.find((e) => e.id === "stellar-ethereum-allbridge");
+
+      expect(bridge).toBeDefined();
+      expect(bridge?.bridgeName).toBe("Allbridge");
+      expect(bridge?.volume24hUsd).toBeGreaterThan(0);
+      expect(["healthy", "degraded", "offline"]).toContain(bridge?.status);
+    });
+
+    it("handles unknown chain gracefully", async () => {
+      const { redis } = await import("../../src/utils/redis.js");
+      vi.mocked(redis.get).mockResolvedValue(null);
+
+      const graph = await service.getGraph();
+      graph.nodes.forEach((node) => {
+        expect(node.healthScore).toBeGreaterThanOrEqual(0);
+        expect(node.totalSupplyUsd).toBeGreaterThanOrEqual(0);
+      });
+    });
+
+    it("handles cache read error gracefully", async () => {
+      const { redis } = await import("../../src/utils/redis.js");
+      vi.mocked(redis.get).mockRejectedValue(new Error("Connection error"));
+
+      const graph = await service.getGraph();
+
+      expect(graph.nodes).toHaveLength(6);
+      expect(graph.edges).toHaveLength(7);
+    });
+
+    it("handles cache write error gracefully", async () => {
+      const { redis } = await import("../../src/utils/redis.js");
+      vi.mocked(redis.get).mockResolvedValue(null);
+      vi.mocked(redis.set).mockRejectedValue(new Error("Write error"));
+
+      const graph = await service.getGraph();
+
+      expect(graph.nodes).toHaveLength(6);
+      expect(graph.totalSupplyUsd).toBeGreaterThan(0);
+    });
+  });
+
+  describe("graph data integrity", () => {
+    it("computes totalSupplyUsd as sum of all node supplies", async () => {
+      const { redis } = await import("../../src/utils/redis.js");
+      vi.mocked(redis.get).mockResolvedValue(null);
+
+      const graph = await service.getGraph();
+      const expectedTotal = graph.nodes.reduce((s, n) => s + n.totalSupplyUsd, 0);
+
+      expect(graph.totalSupplyUsd).toBe(expectedTotal);
+    });
+
+    it("computes totalBridgeVolumeUsd as sum of all edge volumes", async () => {
+      const { redis } = await import("../../src/utils/redis.js");
+      vi.mocked(redis.get).mockResolvedValue(null);
+
+      const graph = await service.getGraph();
+      const expectedVolume = graph.edges.reduce((s, e) => s + e.volume24hUsd, 0);
+
+      expect(graph.totalBridgeVolumeUsd).toBe(expectedVolume);
+    });
+
+    it("reports lastUpdated as a valid ISO string", async () => {
+      const { redis } = await import("../../src/utils/redis.js");
+      vi.mocked(redis.get).mockResolvedValue(null);
+
+      const graph = await service.getGraph();
+
+      expect(() => new Date(graph.lastUpdated)).not.toThrow();
+      expect(new Date(graph.lastUpdated).toISOString()).toBe(graph.lastUpdated);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds unit tests for four previously untested services:

### Issues
Closes #750
Closes #753
Closes #754
Closes #776

### Changes

| File | Tests | Coverage |
|------|-------|----------|
| `backend/tests/services/supplyChain.service.test.ts` | 11 | Graph construction, caching (hit/miss/errors), data integrity |
| `backend/tests/services/queryPreset.service.test.ts` | 19 | CRUD, access control, caching, validation, versioning |
| `backend/tests/services/session.service.test.ts` | 14 | Creation, validation, expiry, revocation, listing, audit |
| `backend/tests/services/incidentTimeline.service.test.ts` | 15 | Event add/get/list, ordering, isolation, edge cases |

All 59 new tests pass against the unit vitest config.