### PR TITLE
test: add initial unit tests for reconciliation service

### DIFF
--- a/backend/src/services/rateLimit.service.ts
+++ b/backend/src/services/rateLimit.service.ts
@@ -1,6 +1,7 @@
 import { redis } from "../utils/redis.js";
 import { logger } from "../utils/logger.js";
 import type { RateLimitTier, EndpointCategory } from "../api/middleware/rateLimit.middleware.js";
+import { getRateLimitMetrics } from "../api/middleware/rateLimit.middleware.js";
 
 export interface RateLimitStats {
   totalRequests: number;
@@ -322,8 +323,19 @@ export class RateLimitService {
   }
 
   private async updateAggregatedStats(): Promise<void> {
-    // This would aggregate stats from individual keys into summary keys
-    // Implementation depends on specific requirements
+    try {
+      const middlewareMetrics = getRateLimitMetrics();
+      for (const range of ["1h", "24h", "7d"]) {
+        const key = `bw:rl:stats:${range}`;
+        await redis.hset(key, {
+          totalRequests: middlewareMetrics.totalRequests,
+          blockedRequests: middlewareMetrics.blockedRequests,
+          whitelistedRequests: middlewareMetrics.whitelistedRequests,
+        });
+      }
+    } catch (error) {
+      logger.error({ error }, "Failed to update aggregated stats");
+    }
   }
 
   private async checkAlertConditions(): Promise<void> {
@@ -384,25 +396,129 @@ export class RateLimitService {
     }
   }
 
-  private async getTopIPs(_startTime: number, _endTime: number, _limit: number): Promise<Array<{ ip: string; requests: number; blocked: number }>> {
-    // Implementation would scan Redis keys for IP patterns and aggregate
-    // This is a placeholder - actual implementation would depend on data structure
-    return [];
+  private async getTopIPs(startTime: number, endTime: number, limit: number): Promise<Array<{ ip: string; requests: number; blocked: number }>> {
+    try {
+      const keys = await redis.keys("bw:rl:ip:*");
+      const ipMap = new Map<string, number>();
+
+      for (const key of keys) {
+        const parts = key.split(":");
+        if (parts.length < 5) continue;
+        const ip = parts[3];
+
+        const members = await redis.zrangebyscore(key, startTime, endTime);
+        const count = members.length;
+        if (count > 0) {
+          ipMap.set(ip, (ipMap.get(ip) || 0) + count);
+        }
+      }
+
+      return Array.from(ipMap.entries())
+        .map(([ip, requests]) => ({ ip, requests, blocked: 0 }))
+        .sort((a, b) => b.requests - a.requests)
+        .slice(0, limit);
+    } catch (error) {
+      logger.error({ error, startTime, endTime, limit }, "Failed to get top IPs");
+      return [];
+    }
   }
 
-  private async getTopApiKeys(_startTime: number, _endTime: number, _limit: number): Promise<Array<{ apiKey: string; tier: RateLimitTier; requests: number; blocked: number }>> {
-    // Implementation would scan Redis keys for API key patterns and aggregate
-    return [];
+  private async getTopApiKeys(startTime: number, endTime: number, limit: number): Promise<Array<{ apiKey: string; tier: RateLimitTier; requests: number; blocked: number }>> {
+    try {
+      const keys = await redis.keys("bw:rl:key:*");
+      const keyMap = new Map<string, { requests: number; tier: RateLimitTier }>();
+
+      for (const key of keys) {
+        const parts = key.split(":");
+        if (parts.length < 5) continue;
+        const apiKey = parts[3];
+        const tier = this.getTierFromApiKey(apiKey);
+
+        const members = await redis.zrangebyscore(key, startTime, endTime);
+        const count = members.length;
+        if (count > 0) {
+          const existing = keyMap.get(apiKey) || { requests: 0, tier };
+          existing.requests += count;
+          keyMap.set(apiKey, existing);
+        }
+      }
+
+      return Array.from(keyMap.entries())
+        .map(([apiKey, { requests, tier }]) => ({ apiKey, tier, requests, blocked: 0 }))
+        .sort((a, b) => b.requests - a.requests)
+        .slice(0, limit);
+    } catch (error) {
+      logger.error({ error, startTime, endTime, limit }, "Failed to get top API keys");
+      return [];
+    }
   }
 
-  private async getEndpointStats(_startTime: number, _endTime: number): Promise<Array<{ endpoint: string; category: EndpointCategory; requests: number; blocked: number }>> {
-    // Implementation would aggregate endpoint statistics
-    return [];
+  private async getEndpointStats(startTime: number, endTime: number): Promise<Array<{ endpoint: string; category: EndpointCategory; requests: number; blocked: number }>> {
+    try {
+      const ipKeys = await redis.keys("bw:rl:ip:*");
+      const keyKeys = await redis.keys("bw:rl:key:*");
+      const allKeys = [...ipKeys, ...keyKeys];
+      const endpointMap = new Map<string, { requests: number; category: EndpointCategory }>();
+
+      for (const key of allKeys) {
+        const parts = key.split(":");
+        if (parts.length < 5) continue;
+        const endpoint = parts[4];
+
+        let category: EndpointCategory = "read";
+        if (endpoint === "ws" || endpoint === "websocket") {
+          category = "websocket";
+        } else if (endpoint === "admin" || endpoint === "circuit-breaker") {
+          category = "admin";
+        } else if (key.includes(":write:")) {
+          category = "write";
+        }
+
+        const members = await redis.zrangebyscore(key, startTime, endTime);
+        const count = members.length;
+        if (count > 0) {
+          const existing = endpointMap.get(endpoint) || { requests: 0, category };
+          existing.requests += count;
+          endpointMap.set(endpoint, existing);
+        }
+      }
+
+      return Array.from(endpointMap.entries()).map(([endpoint, { requests, category }]) => ({
+        endpoint,
+        category,
+        requests,
+        blocked: 0,
+      }));
+    } catch (error) {
+      logger.error({ error, startTime, endTime }, "Failed to get endpoint stats");
+      return [];
+    }
   }
 
-  private async getTierDistribution(_startTime: number, _endTime: number): Promise<Record<RateLimitTier, number>> {
-    // Implementation would aggregate tier distribution
-    return { free: 0, basic: 0, premium: 0, trusted: 0 };
+  private async getTierDistribution(startTime: number, endTime: number): Promise<Record<RateLimitTier, number>> {
+    const distribution: Record<RateLimitTier, number> = { free: 0, basic: 0, premium: 0, trusted: 0 };
+    try {
+      const ipKeys = await redis.keys("bw:rl:ip:*");
+      const keyKeys = await redis.keys("bw:rl:key:*");
+
+      for (const key of ipKeys) {
+        const members = await redis.zrangebyscore(key, startTime, endTime);
+        distribution.free += members.length;
+      }
+
+      for (const key of keyKeys) {
+        const parts = key.split(":");
+        if (parts.length < 5) continue;
+        const apiKey = parts[3];
+        const tier = this.getTierFromApiKey(apiKey);
+
+        const members = await redis.zrangebyscore(key, startTime, endTime);
+        distribution[tier] += members.length;
+      }
+    } catch (error) {
+      logger.error({ error, startTime, endTime }, "Failed to get tier distribution");
+    }
+    return distribution;
   }
 
   private async getCurrentWindowStats(): Promise<{
@@ -411,13 +527,57 @@ export class RateLimitService {
     averageRequestsPerIP: number;
     peakRequestsPerMinute: number;
   }> {
-    // Implementation would calculate current window statistics
-    return {
-      activeIPs: 0,
-      activeApiKeys: 0,
-      averageRequestsPerIP: 0,
-      peakRequestsPerMinute: 0,
-    };
+    try {
+      const ipKeys = await redis.keys("bw:rl:ip:*");
+      const keyKeys = await redis.keys("bw:rl:key:*");
+
+      const activeIPsSet = new Set<string>();
+      let totalIPRequests = 0;
+      for (const key of ipKeys) {
+        const parts = key.split(":");
+        if (parts.length < 5) continue;
+        const ip = parts[3];
+        const card = await redis.zcard(key);
+        if (card > 0) {
+          activeIPsSet.add(ip);
+          totalIPRequests += card;
+        }
+      }
+
+      const activeApiKeysSet = new Set<string>();
+      for (const key of keyKeys) {
+        const parts = key.split(":");
+        if (parts.length < 5) continue;
+        const apiKey = parts[3];
+        const card = await redis.zcard(key);
+        if (card > 0) {
+          activeApiKeysSet.add(apiKey);
+        }
+      }
+
+      const activeIPs = activeIPsSet.size;
+      const activeApiKeys = activeApiKeysSet.size;
+      const averageRequestsPerIP = activeIPs > 0 ? Number((totalIPRequests / activeIPs).toFixed(2)) : 0;
+
+      const now = Date.now();
+      const oneMinuteAgo = now - 60000;
+      const peakRequestsPerMinute = this.requestBuffer.filter(r => r.timestamp >= oneMinuteAgo).length;
+
+      return {
+        activeIPs,
+        activeApiKeys,
+        averageRequestsPerIP,
+        peakRequestsPerMinute,
+      };
+    } catch (error) {
+      logger.error({ error }, "Failed to get current window stats");
+      return {
+        activeIPs: 0,
+        activeApiKeys: 0,
+        averageRequestsPerIP: 0,
+        peakRequestsPerMinute: 0,
+      };
+    }
   }
 
   private getTierFromApiKey(apiKey: string): RateLimitTier {

--- a/backend/src/services/reconciliation.service.ts
+++ b/backend/src/services/reconciliation.service.ts
@@ -468,7 +468,7 @@ export class ReconciliationService {
     const latestRun = sorted[0];
     const previousRun = sorted[1] ?? null;
     const mismatchDelta =
-      latestRun.mismatchPercentage !== null && previousRun?.mismatchPercentage !== null
+      latestRun.mismatchPercentage !== null && previousRun && previousRun.mismatchPercentage !== null
         ? latestRun.mismatchPercentage - previousRun.mismatchPercentage
         : null;
 

--- a/backend/tests/services/rateLimit.service.test.ts
+++ b/backend/tests/services/rateLimit.service.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { RateLimitService } from "../../src/services/rateLimit.service.js";
+import { redis } from "../../src/utils/redis.js";
+
+// Mock logger to avoid spamming the console
+vi.mock("../../src/utils/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+describe("RateLimitService Unit Tests", () => {
+  let service: RateLimitService;
+
+  beforeEach(() => {
+    service = new RateLimitService();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("getRateLimitStats", () => {
+    it("aggregates data correctly from active IP and API key Redis keys", async () => {
+      // Mock redis.hgetall for stats
+      vi.spyOn(redis, "hgetall").mockResolvedValue({
+        totalRequests: "100",
+        blockedRequests: "5",
+        whitelistedRequests: "2",
+      });
+
+      // Mock redis.keys to return keys
+      vi.spyOn(redis, "keys").mockImplementation(async (pattern: string) => {
+        if (pattern.includes("ip")) {
+          return ["bw:rl:ip:192.168.1.1:read", "bw:rl:ip:192.168.1.2:write"];
+        } else if (pattern.includes("key")) {
+          return ["bw:rl:key:basic_key1:read", "bw:rl:key:premium_key2:write"];
+        }
+        return [];
+      });
+
+      // Mock redis.zrangebyscore to return array of members
+      vi.spyOn(redis, "zrangebyscore").mockResolvedValue(["member1", "member2"]);
+
+      // Mock redis.zcard to return active count
+      vi.spyOn(redis, "zcard").mockResolvedValue(2);
+
+      const stats = await service.getRateLimitStats("24h");
+
+      expect(stats.totalRequests).toBe(100);
+      expect(stats.blockedRequests).toBe(5);
+      expect(stats.whitelistedRequests).toBe(2);
+
+      // Verify top IPs list
+      expect(stats.topIPs.length).toBe(2);
+      expect(stats.topIPs[0].ip).toBe("192.168.1.1");
+      expect(stats.topIPs[0].requests).toBe(2);
+
+      // Verify top API keys list
+      expect(stats.topApiKeys.length).toBe(2);
+      expect(stats.topApiKeys[0].apiKey).toBe("basic_key1");
+      expect(stats.topApiKeys[0].tier).toBe("basic");
+
+      // Verify endpoint stats
+      expect(stats.endpointStats.length).toBe(2);
+      expect(stats.endpointStats[0].requests).toBe(4);
+
+      // Verify tier distribution
+      expect(stats.tierDistribution.basic).toBe(2);
+      expect(stats.tierDistribution.premium).toBe(2);
+
+      // Verify current window stats
+      expect(stats.currentWindowStats.activeIPs).toBe(2);
+      expect(stats.currentWindowStats.activeApiKeys).toBe(2);
+      expect(stats.currentWindowStats.averageRequestsPerIP).toBe(2);
+    });
+  });
+
+  describe("getRateLimitStatus", () => {
+    it("returns active limits and usage metrics for IP address", async () => {
+      vi.spyOn(redis, "keys").mockResolvedValue(["bw:rl:ip:127.0.0.1:read"]);
+      vi.spyOn(redis, "zcard").mockResolvedValue(5);
+      vi.spyOn(redis, "pttl").mockResolvedValue(60000);
+
+      const status = await service.getRateLimitStatus("127.0.0.1", "ip");
+      expect(status.currentUsage).toBe(5);
+      expect(status.endpointLimits[0].endpoint).toBe("read");
+    });
+  });
+
+  describe("resetRateLimit", () => {
+    it("deletes redis rate limit keys for the given identifier", async () => {
+      vi.spyOn(redis, "keys").mockResolvedValue(["bw:rl:ip:127.0.0.1:read"]);
+      const delSpy = vi.spyOn(redis, "del").mockResolvedValue(1);
+
+      await service.resetRateLimit("127.0.0.1", "ip");
+      expect(delSpy).toHaveBeenCalledWith("bw:rl:ip:127.0.0.1:read");
+    });
+  });
+
+  describe("updateRateLimit", () => {
+    it("updates target rate limit configuration in Redis and publishes the config change", async () => {
+      const hsetSpy = vi.spyOn(redis, "hset").mockResolvedValue(1);
+      const publishSpy = vi.spyOn(redis, "publish").mockResolvedValue(1);
+
+      const newLimits = {
+        requestsPerWindow: 200,
+        windowMs: 60000,
+        burstAllowance: 20,
+      };
+
+      await service.updateRateLimit("free", newLimits);
+
+      expect(hsetSpy).toHaveBeenCalledWith("bw:rl:config:free", expect.any(Object));
+      expect(publishSpy).toHaveBeenCalledWith("bw:rl:config-change", expect.any(String));
+    });
+  });
+
+  describe("exportData", () => {
+    it("exports metrics in JSON format", async () => {
+      vi.spyOn(redis, "hgetall").mockResolvedValue({ totalRequests: "10" });
+      vi.spyOn(redis, "keys").mockResolvedValue([]);
+
+      const data = await service.exportData("json");
+      const parsed = JSON.parse(data);
+      expect(parsed).toHaveProperty("totalRequests");
+    });
+
+    it("exports metrics in CSV format", async () => {
+      vi.spyOn(redis, "hgetall").mockResolvedValue({ totalRequests: "10" });
+      vi.spyOn(redis, "keys").mockResolvedValue([]);
+
+      const data = await service.exportData("csv");
+      expect(data).toContain("Type,Identifier,Tier,Endpoint,Requests,Blocked");
+    });
+  });
+});

--- a/backend/tests/services/reconciliation.service.test.ts
+++ b/backend/tests/services/reconciliation.service.test.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from "vitest";
+
+describe("ReconciliationService", () => {
+  it("initial placeholder test", () => {
+    expect(true).toBe(true);
+  });
+});

--- a/backend/tests/services/reconciliation.service.test.ts
+++ b/backend/tests/services/reconciliation.service.test.ts
@@ -1,7 +1,212 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ReconciliationService } from "../../src/services/reconciliation.service.js";
+
+// Mock connection
+let defaultDbResult: any = [];
+
+function createQueryBuilder(resolveValue: any = []) {
+  const builder: any = {};
+  builder.insert = vi.fn().mockReturnValue(builder);
+  builder.returning = vi.fn().mockReturnValue(builder);
+  builder.where = vi.fn().mockReturnValue(builder);
+  builder.update = vi.fn().mockReturnValue(builder);
+  builder.orderBy = vi.fn().mockReturnValue(builder);
+  builder.limit = vi.fn().mockReturnValue(builder);
+  builder.select = vi.fn().mockReturnValue(builder);
+  builder.first = vi.fn().mockImplementation(() => Promise.resolve(Array.isArray(resolveValue) ? resolveValue[0] : resolveValue));
+  builder.andWhere = vi.fn().mockReturnValue(builder);
+  builder.catch = vi.fn().mockImplementation((cb) => {
+    return Promise.resolve(resolveValue);
+  });
+  builder.then = vi.fn().mockImplementation((resolve) => resolve(resolveValue));
+  return builder;
+}
+
+const mockDb = vi.fn((table: string) => {
+  if (table === "assets") {
+    return createQueryBuilder([
+      { symbol: "USDC", issuer: "G_USDC", bridge_provider: "circle", source_chain: "ethereum" }
+    ]);
+  }
+  if (table === "bridges") {
+    return createQueryBuilder([
+      { name: "circle USDC", source_chain: "ethereum" }
+    ]);
+  }
+  if (table === "bridge_operators") {
+    return createQueryBuilder({ bridge_id: "circle" });
+  }
+  if (table === "reserve_commitments") {
+    return createQueryBuilder({
+      bridge_id: "circle",
+      sequence: 10,
+      merkle_root: "0xMerkle",
+      total_reserves: "1000000",
+      status: "verified",
+      tx_hash: "0xTxHash",
+      committed_at: Math.floor(Date.now() / 1000),
+      committed_ledger: 1000,
+      updated_at: new Date()
+    });
+  }
+  return createQueryBuilder(defaultDbResult);
+});
+
+vi.mock("../../src/database/connection.js", () => ({
+  getDatabase: () => mockDb,
+}));
+
+vi.mock("../../src/utils/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
 
 describe("ReconciliationService", () => {
-  it("initial placeholder test", () => {
-    expect(true).toBe(true);
+  let service: ReconciliationService;
+
+  beforeEach(() => {
+    service = new ReconciliationService();
+    defaultDbResult = [];
+    vi.clearAllMocks();
+  });
+
+  describe("startRun", () => {
+    it("starts a run and returns run id", async () => {
+      defaultDbResult = [{ id: "run-123" }];
+      const result = await service.startRun({
+        assetCode: "USDC",
+        jobId: "job-1",
+        attempt: 1,
+      });
+
+      expect(result.id).toBe("run-123");
+      expect(mockDb).toHaveBeenCalledWith("reconciliation_runs");
+    });
+  });
+
+  describe("finishRun", () => {
+    it("updates existing run status and details", async () => {
+      defaultDbResult = 1; // 1 row updated
+      await service.finishRun({
+        id: "run-123",
+        status: "success",
+        stellarSupply: 1000000,
+        reportedSupply: 1000000,
+        mismatchPercentage: 0,
+      });
+
+      expect(mockDb).toHaveBeenCalledWith("reconciliation_runs");
+    });
+  });
+
+  describe("listRuns", () => {
+    it("returns list of reconciliation runs", async () => {
+      const runs = [
+        { id: "run-1", asset_code: "USDC", status: "success", started_at: new Date() },
+        { id: "run-2", asset_code: "USDC", status: "mismatch", started_at: new Date() },
+      ];
+      defaultDbResult = runs;
+
+      const result = await service.listRuns({ assetCode: "USDC", limit: 10 });
+      expect(result).toEqual(runs);
+    });
+  });
+
+  describe("getLatestRun", () => {
+    it("returns the latest reconciliation run for an asset", async () => {
+      const run = { id: "run-2", asset_code: "USDC", status: "mismatch", started_at: new Date() };
+      defaultDbResult = [run];
+
+      const result = await service.getLatestRun("USDC");
+      expect(result).toEqual(run);
+    });
+  });
+
+  describe("getDriftSummaries", () => {
+    it("aggregates reconciliation runs and returns drift summaries", async () => {
+      const mockRuns = [
+        {
+          id: "run-1",
+          asset_code: "USDC",
+          bridge_name: "circle USDC",
+          source_chain: "ethereum",
+          status: "mismatch",
+          stellar_supply: "1005000",
+          reported_supply: "1000000",
+          mismatch_percentage: "0.5",
+          attempt: 1,
+          started_at: new Date().toISOString(),
+          finished_at: new Date().toISOString(),
+          triage_status: "open",
+        },
+      ];
+      defaultDbResult = mockRuns;
+
+      const result = await service.getDriftSummaries({ range: "24h" });
+      expect(result.totals.summaries).toBe(1);
+      expect(result.totals.unresolved).toBe(1);
+      expect(result.summaries[0].severity).toBe("low");
+    });
+  });
+
+  describe("getMismatchDetail", () => {
+    it("returns detailed mismatch information along with history and commitments", async () => {
+      const mockRun = {
+        id: "run-1",
+        asset_code: "USDC",
+        bridge_name: "circle USDC",
+        source_chain: "ethereum",
+        status: "mismatch",
+        stellar_supply: "1005000",
+        reported_supply: "1000000",
+        mismatch_percentage: "0.5",
+        attempt: 1,
+        started_at: new Date().toISOString(),
+        finished_at: new Date().toISOString(),
+        triage_status: "open",
+      };
+      defaultDbResult = [mockRun];
+
+      const result = await service.getMismatchDetail("run-1", { range: "7d" });
+      expect(result).not.toBeNull();
+      expect(result?.mismatch.id).toBe("run-1");
+      expect(result?.reserveCommitment).toBeDefined();
+    });
+  });
+
+  describe("updateTriageStatus", () => {
+    it("updates triage status, owner, and notes", async () => {
+      const mockRun = {
+        id: "run-1",
+        asset_code: "USDC",
+        bridge_name: "circle USDC",
+        source_chain: "ethereum",
+        status: "mismatch",
+        stellar_supply: "1005000",
+        reported_supply: "1000000",
+        mismatch_percentage: "0.5",
+        attempt: 1,
+        started_at: new Date().toISOString(),
+        finished_at: new Date().toISOString(),
+        triage_status: "investigating",
+        triage_owner: "Alice",
+        triage_note: "Investigating the drift",
+      };
+      defaultDbResult = [mockRun];
+
+      const result = await service.updateTriageStatus("run-1", {
+        status: "investigating",
+        owner: "Alice",
+        note: "Investigating the drift",
+      });
+
+      expect(result).not.toBeNull();
+      expect(result?.triageStatus).toBe("investigating");
+      expect(result?.triageOwner).toBe("Alice");
+    });
   });
 });

--- a/backend/tests/services/reserveVerification.service.test.ts
+++ b/backend/tests/services/reserveVerification.service.test.ts
@@ -1,0 +1,334 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock Stellar SDK and Soroban RPC components
+const mocks = vi.hoisted(() => {
+  const scvU64Obj = { name: "scvU64" };
+  const scvBoolObj = { name: "scvBool" };
+
+  class MockScVal {
+    static scvBytes = vi.fn(() => new MockScVal());
+    static scvVec = vi.fn(() => new MockScVal());
+    static scvString = vi.fn(() => new MockScVal());
+    static scvI128 = vi.fn(() => new MockScVal());
+    static scvU64 = vi.fn(() => new MockScVal());
+    static scvMap = vi.fn(() => new MockScVal());
+    static scvSymbol = vi.fn(() => new MockScVal());
+
+    switch = vi.fn().mockReturnValue(scvU64Obj);
+    u64 = vi.fn(() => ({
+      toBigInt: vi.fn().mockReturnValue(42n),
+    }));
+    b = vi.fn().mockReturnValue(true);
+  }
+
+  class MockInt128Parts {
+    constructor(public parts: any) {}
+  }
+
+  class MockInt64 {
+    static fromString = vi.fn((str) => str);
+  }
+
+  class MockUint64 {
+    static fromString = vi.fn((str) => str);
+  }
+
+  class MockScMapEntry {
+    constructor(public entry: any) {}
+  }
+
+  const mockGetTransactionResult = {
+    status: "SUCCESS",
+    returnValue: new MockScVal(),
+  };
+
+  const mockSendTransactionResult = {
+    status: "SUCCESS",
+    hash: "tx-123",
+  };
+
+  const mockSimulateResult = {
+    error: null,
+    result: {
+      retval: new MockScVal(),
+    },
+  };
+
+  const mockSorobanServer = {
+    getAccount: vi.fn().mockResolvedValue({
+      publicKey: () => "G_OPERATOR",
+      sequence: "1",
+    }),
+    simulateTransaction: vi.fn().mockResolvedValue(mockSimulateResult),
+    sendTransaction: vi.fn().mockResolvedValue(mockSendTransactionResult),
+    getTransaction: vi.fn().mockResolvedValue(mockGetTransactionResult),
+  };
+
+  const mockKeypair = {
+    publicKey: () => "G_OPERATOR",
+    sign: vi.fn(),
+  };
+
+  return {
+    scvU64Obj,
+    scvBoolObj,
+    MockScVal,
+    MockInt128Parts,
+    MockInt64,
+    MockUint64,
+    MockScMapEntry,
+    mockGetTransactionResult,
+    mockSendTransactionResult,
+    mockSimulateResult,
+    mockSorobanServer,
+    mockKeypair,
+    circuitBreakerPaused: false,
+  };
+});
+
+vi.mock("@stellar/stellar-sdk", () => {
+  const mockTxBuilder = {
+    addOperation: vi.fn().mockReturnThis(),
+    setTimeout: vi.fn().mockReturnThis(),
+    build: vi.fn().mockReturnValue({
+      sign: vi.fn(),
+    }),
+  };
+
+  return {
+    Networks: {
+      PUBLIC: "PUBLIC",
+      TESTNET: "TESTNET",
+    },
+    Keypair: {
+      fromSecret: vi.fn(() => mocks.mockKeypair),
+      random: vi.fn(() => mocks.mockKeypair),
+    },
+    Account: class {
+      constructor(public pk: string, public seq: string) {}
+    },
+    Contract: class {
+      constructor(public addr: string) {}
+      call = vi.fn().mockReturnValue({});
+    },
+    TransactionBuilder: vi.fn().mockImplementation(() => mockTxBuilder),
+    xdr: {
+      ScVal: mocks.MockScVal,
+      Int128Parts: mocks.MockInt128Parts,
+      Int64: mocks.MockInt64,
+      Uint64: mocks.MockUint64,
+      ScMapEntry: mocks.MockScMapEntry,
+      ScValType: {
+        scvBool: vi.fn().mockReturnValue(mocks.scvBoolObj),
+        scvU64: vi.fn().mockReturnValue(mocks.scvU64Obj),
+      },
+    },
+    SorobanRpc: {
+      Server: vi.fn().mockImplementation(() => mocks.mockSorobanServer),
+      Api: {
+        isSimulationError: vi.fn().mockReturnValue(false),
+        GetTransactionStatus: {
+          SUCCESS: "SUCCESS",
+          FAILED: "FAILED",
+        },
+      },
+      assembleTransaction: vi.fn().mockReturnValue({
+        build: vi.fn().mockReturnValue({
+          sign: vi.fn(),
+        }),
+      }),
+    },
+  };
+});
+
+// Mock Circuit Breaker
+vi.mock("../../src/services/circuitBreaker.service.js", () => {
+  return {
+    getCircuitBreakerService: vi.fn(() => ({
+      isPaused: vi.fn().mockImplementation(async () => mocks.circuitBreakerPaused),
+    })),
+    PauseScope: {
+      Bridge: "bridge",
+    },
+  };
+});
+
+// Mock database connection
+let defaultDbResult: any = [];
+function createQueryBuilder(resolveValue: any = []) {
+  const builder: any = {};
+  builder.insert = vi.fn().mockReturnValue(builder);
+  builder.onConflict = vi.fn().mockReturnValue(builder);
+  builder.merge = vi.fn().mockReturnValue(builder);
+  builder.select = vi.fn().mockReturnValue(builder);
+  builder.where = vi.fn().mockReturnValue(builder);
+  builder.update = vi.fn().mockReturnValue(builder);
+  builder.first = vi.fn().mockImplementation(() => Promise.resolve(Array.isArray(resolveValue) ? resolveValue[0] : resolveValue));
+  builder.count = vi.fn().mockReturnValue(builder);
+  builder.clone = vi.fn().mockReturnValue(builder);
+  builder.orderBy = vi.fn().mockReturnValue(builder);
+  builder.limit = vi.fn().mockReturnValue(builder);
+  builder.offset = vi.fn().mockReturnValue(builder);
+  builder.andWhere = vi.fn().mockReturnValue(builder);
+  builder.then = vi.fn().mockImplementation((resolve) => resolve(resolveValue));
+  return builder;
+}
+
+const mockDb = vi.fn((table: string) => {
+  if (table === "bridge_operators") {
+    return createQueryBuilder([{
+      contract_address: "C_CONTRACT",
+      contractAddress: "C_CONTRACT",
+      bridge_id: "bridge-1",
+      bridgeId: "bridge-1",
+      asset_code: "USDC",
+      assetCode: "USDC"
+    }]);
+  }
+  return createQueryBuilder(defaultDbResult);
+});
+
+vi.mock("../../src/database/connection.js", () => ({
+  getDatabase: () => mockDb,
+}));
+
+vi.mock("../../src/utils/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("../../src/config/index.js", () => ({
+  config: {
+    SOROBAN_RPC_URL: "https://soroban-testnet.stellar.org",
+    STELLAR_NETWORK: "testnet",
+    NODE_ENV: "test",
+  },
+}));
+
+import { ReserveVerificationService } from "../../src/services/reserveVerification.service.js";
+
+const testHash32 = "a".repeat(64);
+const testHash32Sibling = "b".repeat(64);
+
+describe("ReserveVerificationService", () => {
+  let service: ReserveVerificationService;
+
+  beforeEach(() => {
+    service = new ReserveVerificationService();
+    defaultDbResult = [];
+    mocks.circuitBreakerPaused = false;
+    process.env.OPERATOR_SECRET_BRIDGE_1 = "SDJZ5373R2QNW3A3U6466PVMQL3FNYJ24SPJWJMX7RGL4XGQL2ZZZZZZ";
+    vi.clearAllMocks();
+  });
+
+  describe("commitReserves", () => {
+    it("successfully commits reserves on-chain when not paused", async () => {
+      mocks.mockGetTransactionResult.status = "SUCCESS";
+      mocks.mockGetTransactionResult.returnValue.switch.mockReturnValue(mocks.scvU64Obj);
+      const sequence = await service.commitReserves("bridge-1", testHash32, 1000000n);
+      expect(sequence).toBe(42);
+      expect(mockDb).toHaveBeenCalledWith("reserve_commitments");
+    });
+
+    it("throws an error when bridge is paused by circuit breaker", async () => {
+      mocks.circuitBreakerPaused = true;
+      await expect(service.commitReserves("bridge-1", testHash32, 1000000n))
+        .rejects.toThrow("Bridge bridge-1 is paused by circuit breaker");
+    });
+  });
+
+  describe("verifyProofOnChain", () => {
+    it("returns true when proof is successfully simulated and verified on-chain", async () => {
+      // returnValue.switch() matches ScValType.scvBool() in mock setup
+      mocks.mockSimulateResult.result.retval.switch.mockReturnValue(mocks.scvBoolObj);
+      const result = await service.verifyProofOnChain("bridge-1", 10, {
+        leafHash: testHash32,
+        proofPath: [testHash32Sibling],
+        leafIndex: 0,
+      });
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("saveCommitment", () => {
+    it("inserts a new commitment record into database", async () => {
+      await service.saveCommitment({
+        bridgeId: "bridge-1",
+        sequence: 1,
+        merkleRootHex: testHash32,
+        totalReserves: 100n,
+      });
+      expect(mockDb).toHaveBeenCalledWith("reserve_commitments");
+    });
+  });
+
+  describe("saveVerificationResult", () => {
+    it("inserts a verification result into database", async () => {
+      await service.saveVerificationResult({
+        bridgeId: "bridge-1",
+        sequence: 1,
+        leafHash: testHash32,
+        leafIndex: 0,
+        isValid: true,
+        jobId: "job-1",
+      });
+      expect(mockDb).toHaveBeenCalledWith("verification_results");
+    });
+  });
+
+  describe("updateCommitmentStatus", () => {
+    it("updates target commitment status in database", async () => {
+      await service.updateCommitmentStatus("bridge-1", 1, "verified");
+      expect(mockDb).toHaveBeenCalledWith("reserve_commitments");
+    });
+  });
+
+  describe("getCommitment", () => {
+    it("retrieves target commitment record", async () => {
+      const record = { bridge_id: "bridge-1", sequence: 1 };
+      defaultDbResult = [record];
+      const result = await service.getCommitment("bridge-1", 1);
+      expect(result).toEqual(record);
+    });
+  });
+
+  describe("getLatestCommitment", () => {
+    it("retrieves latest commitment record for the bridge", async () => {
+      const record = { bridge_id: "bridge-1", sequence: 10 };
+      defaultDbResult = [record];
+      const result = await service.getLatestCommitment("bridge-1");
+      expect(result).toEqual(record);
+    });
+  });
+
+  describe("getCommitmentHistory", () => {
+    it("retrieves commitment history list for the bridge", async () => {
+      const records = [{ bridge_id: "bridge-1", sequence: 10 }];
+      defaultDbResult = records;
+      const result = await service.getCommitmentHistory("bridge-1");
+      expect(result).toEqual(records);
+    });
+  });
+
+  describe("getVerificationResults", () => {
+    it("retrieves verification results list", async () => {
+      const records = [{ bridge_id: "bridge-1", sequence: 1 }];
+      defaultDbResult = records;
+      const result = await service.getVerificationResults("bridge-1", 1);
+      expect(result).toEqual(records);
+    });
+  });
+
+  describe("getActiveBridgeOperators", () => {
+    it("retrieves active bridge operators", async () => {
+      const result = await service.getActiveBridgeOperators();
+      expect(result.length).toBeGreaterThan(0);
+      expect(result[0].bridgeId).toBe("bridge-1");
+    });
+  });
+});

--- a/backend/tests/services/transaction.service.test.ts
+++ b/backend/tests/services/transaction.service.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock Stellar SDK
+const mocks = vi.hoisted(() => {
+  class MockAsset {
+    constructor(public code: string, public issuer: string) {}
+  }
+
+  const mockHorizonPaymentsRecords = {
+    records: [] as any[],
+  };
+
+  const mockHorizonPaymentsCall = vi.fn().mockResolvedValue(mockHorizonPaymentsRecords);
+
+  const mockHorizonPaymentsBuilder: any = {
+    forAsset: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    cursor: vi.fn().mockReturnThis(),
+    call: mockHorizonPaymentsCall,
+  };
+
+  class MockHorizonServer {
+    constructor(public url: string, public opts: any) {}
+    payments = vi.fn().mockReturnValue(mockHorizonPaymentsBuilder);
+  }
+
+  return {
+    MockAsset,
+    MockHorizonServer,
+    mockHorizonPaymentsRecords,
+  };
+});
+
+vi.mock("@stellar/stellar-sdk", () => {
+  return {
+    Asset: mocks.MockAsset,
+    Horizon: {
+      Server: mocks.MockHorizonServer,
+    },
+  };
+});
+
+// Mock database connection
+let defaultDbResult: any = [];
+let defaultSyncState: any = null;
+
+function createQueryBuilder(resolveValue: any = []) {
+  const builder: any = {};
+  let cloneCount = 0;
+  builder.insert = vi.fn().mockReturnValue(builder);
+  builder.onConflict = vi.fn().mockReturnValue(builder);
+  builder.merge = vi.fn().mockReturnValue(builder);
+  builder.select = vi.fn().mockReturnValue(builder);
+  builder.where = vi.fn().mockReturnValue(builder);
+  builder.update = vi.fn().mockReturnValue(builder);
+  builder.first = vi.fn().mockImplementation(() => Promise.resolve(Array.isArray(resolveValue) ? resolveValue[0] : resolveValue));
+  builder.count = vi.fn().mockReturnValue(builder);
+  builder.clone = vi.fn().mockImplementation(() => {
+    cloneCount++;
+    if (cloneCount === 1) {
+      return createQueryBuilder([{ count: "1" }]);
+    } else {
+      return createQueryBuilder(defaultDbResult);
+    }
+  });
+  builder.orderBy = vi.fn().mockReturnValue(builder);
+  builder.limit = vi.fn().mockReturnValue(builder);
+  builder.offset = vi.fn().mockReturnValue(builder);
+  builder.andWhere = vi.fn().mockImplementation((fn) => {
+    if (typeof fn === "function") {
+      fn(builder);
+    }
+    return builder;
+  });
+  builder.orWhere = vi.fn().mockReturnValue(builder);
+  builder.then = vi.fn().mockImplementation((resolve) => resolve(resolveValue));
+  return builder;
+}
+
+const mockDb = vi.fn((table: string) => {
+  if (table === "asset_transaction_sync_state") {
+    return createQueryBuilder(defaultSyncState);
+  }
+  return createQueryBuilder(defaultDbResult);
+});
+(mockDb as any).raw = vi.fn((str) => str);
+(mockDb as any).fn = {
+  now: vi.fn(() => new Date()),
+};
+
+vi.mock("../../src/database/connection.js", () => ({
+  getDatabase: () => mockDb,
+}));
+
+vi.mock("../../src/utils/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("../../src/config/index.js", () => ({
+  config: {
+    STELLAR_HORIZON_URL: "https://horizon-testnet.stellar.org",
+    NODE_ENV: "test",
+  },
+}));
+
+import { TransactionService } from "../../src/services/transaction.service.js";
+
+describe("TransactionService", () => {
+  let service: TransactionService;
+
+  beforeEach(() => {
+    service = new TransactionService();
+    defaultDbResult = [];
+    defaultSyncState = null;
+    mocks.mockHorizonPaymentsRecords.records = [];
+    vi.clearAllMocks();
+  });
+
+  describe("fetchTransactionsByAsset", () => {
+    it("fetches payments from Horizon and upserts into database", async () => {
+      const mockRecord = {
+        id: "op-1",
+        type: "payment",
+        transaction_hash: "tx-1",
+        transaction_successful: true,
+        ledger: 12345,
+        paging_token: "pt-123",
+        source_account: "GA1",
+        from: "GA1",
+        to: "GA2",
+        amount: "100.5",
+        created_at: new Date().toISOString(),
+      };
+      mocks.mockHorizonPaymentsRecords.records = [mockRecord];
+
+      const result = await service.fetchTransactionsByAsset("USDC", "G_ISSUER", {
+        pageSize: 10,
+        maxPages: 1,
+      });
+
+      expect(result.fetched).toBe(1);
+      expect(result.stored).toBe(1);
+      expect(result.lastCursor).toBe("pt-123");
+      expect(mockDb).toHaveBeenCalledWith("asset_transactions");
+      expect(mockDb).toHaveBeenCalledWith("asset_transaction_sync_state");
+    });
+
+    it("handles zero fetched records cleanly", async () => {
+      mocks.mockHorizonPaymentsRecords.records = [];
+
+      const result = await service.fetchTransactionsByAsset("USDC", "G_ISSUER", {
+        pageSize: 10,
+        maxPages: 1,
+      });
+
+      expect(result.fetched).toBe(0);
+      expect(result.stored).toBe(0);
+      expect(result.lastCursor).toBeNull();
+    });
+  });
+
+  describe("backfillAssetTransactions", () => {
+    it("backfills asset transactions by fetching history in ascending order", async () => {
+      const mockRecord = {
+        id: "op-1",
+        type: "payment",
+        transaction_hash: "tx-1",
+        transaction_successful: true,
+        paging_token: "pt-1",
+      };
+      mocks.mockHorizonPaymentsRecords.records = [mockRecord];
+
+      const result = await service.backfillAssetTransactions("USDC", "G_ISSUER", {
+        pages: 1,
+      });
+
+      expect(result.fetched).toBe(1);
+      expect(result.stored).toBe(1);
+    });
+  });
+
+  describe("detectNewTransactions", () => {
+    it("detects new transactions using saved cursor", async () => {
+      defaultSyncState = {
+        asset_code: "USDC",
+        asset_issuer: "G_ISSUER",
+        last_paging_token: "pt-500",
+      };
+
+      const result = await service.detectNewTransactions("USDC", "G_ISSUER");
+      expect(result.fetched).toBe(0);
+    });
+  });
+
+  describe("listTransactions", () => {
+    it("queries database and returns filtered/paginated transaction list", async () => {
+      const dbRows = [
+        {
+          id: "1",
+          transaction_hash: "tx-1",
+          bridge_name: "circle",
+          asset_code: "USDC",
+          amount: "100",
+          status: "completed",
+          occurred_at: new Date(),
+          fee_charged: "0.01",
+        },
+      ];
+      defaultDbResult = dbRows;
+
+      const result = await service.listTransactions({ asset: "USDC" }, 1, 10);
+      expect(result.total).toBe(1);
+      expect(result.transactions.length).toBe(1);
+      expect(result.transactions[0].txHash).toBe("tx-1");
+    });
+  });
+
+  describe("exportTransactionsCsv", () => {
+    it("returns transactions formatted as CSV string", async () => {
+      const dbRows = [
+        {
+          id: "1",
+          transaction_hash: "tx-1",
+          bridge_name: "circle",
+          asset_code: "USDC",
+          amount: "100",
+          status: "completed",
+          occurred_at: new Date(),
+          fee_charged: "0.01",
+        },
+      ];
+      defaultDbResult = dbRows;
+
+      const csv = await service.exportTransactionsCsv({ asset: "USDC" });
+      expect(csv).toContain("id,txHash,bridge,asset,operationType,status,amount,fee,senderAddress,recipientAddress,timestamp");
+      expect(csv).toContain("tx-1");
+    });
+  });
+
+  describe("getSyncState", () => {
+    it("returns sync state from database", async () => {
+      const state = {
+        asset_code: "USDC",
+        asset_issuer: "G_ISSUER",
+        last_paging_token: "pt-123",
+      };
+      defaultSyncState = state;
+
+      const result = await service.getSyncState("USDC", "G_ISSUER");
+      expect(result).toEqual(state);
+    });
+  });
+});


### PR DESCRIPTION
Fix Bridge-Watch Issues: Closes #697, Closes #751, Cloes #684, and Closes #698
This plan covers adding dedicated unit tests for the reconciliation service, transaction service, and reserve verification service, as well as implementing the real-time external rate limit metric helper with comprehensive tests.

