### PR TITLE
feat: Add Webhook Batching Support for Multi-Event Dispatching

### DIFF
--- a/backend/src/api/routes/webhooks.ts
+++ b/backend/src/api/routes/webhooks.ts
@@ -264,6 +264,40 @@ export async function webhooksRoutes(server: FastifyInstance) {
   );
 
   // ---------------------------------------------------------------------------
+  // BATCH BUFFER
+  // ---------------------------------------------------------------------------
+
+  // Get live status of all open batch windows (or one endpoint's window)
+  server.get<{ Querystring: { endpointId?: string } }>(
+    "/batch-buffer",
+    async (request: FastifyRequest<{ Querystring: { endpointId?: string } }>, reply: FastifyReply) => {
+      const { endpointId } = request.query;
+      const status = webhookService.getBatchBufferStatus(endpointId);
+      if (endpointId && status === null) {
+        return reply.code(404).send({ error: "No open batch window for this endpoint" });
+      }
+      return { status };
+    }
+  );
+
+  // Manually flush the batch buffer for an endpoint before the window expires
+  server.post<{ Params: EndpointParams }>(
+    "/endpoints/:id/flush-batch",
+    async (request: FastifyRequest<{ Params: EndpointParams }>, reply: FastifyReply) => {
+      try {
+        const result = await webhookService.flushBatchBuffer(request.params.id);
+        if (result.flushed === 0) {
+          return reply.code(404).send({ error: "No buffered events for this endpoint" });
+        }
+        return { flushed: result.flushed, message: `Dispatched ${result.flushed} buffered event(s) as a single batch` };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Failed to flush batch buffer";
+        return reply.code(500).send({ error: message });
+      }
+    }
+  );
+
+  // ---------------------------------------------------------------------------
   // SIGNATURE VERIFICATION (utility endpoint for debugging)
   // ---------------------------------------------------------------------------
 

--- a/backend/src/services/webhook.service.ts
+++ b/backend/src/services/webhook.service.ts
@@ -3,6 +3,8 @@ import { getDatabase } from "../database/connection.js";
 import { logger } from "../utils/logger.js";
 import { Queue, Job, ConnectionOptions } from "bullmq";
 import { config } from "../config/index.js";
+import { WebhookBatchBufferService } from "./webhookBatchBuffer.service.js";
+import type { BatchBufferStatus } from "./webhookBatchBuffer.service.js";
 
 const fetch = globalThis.fetch;
 
@@ -22,7 +24,7 @@ export type WebhookEventType =
   | "price.deviation_detected"
   | "liquidity.threshold_breached";
 
-export type WebhookDeliveryStatus = "pending" | "success" | "failed" | "retrying";
+export type WebhookDeliveryStatus = "pending" | "buffered" | "success" | "failed" | "retrying";
 
 export interface WebhookEndpoint {
   id: string;
@@ -108,8 +110,17 @@ export class WebhookService {
   private static instance: WebhookService;
   private deliveryQueue: Queue;
   private rateLimitMap: Map<string, RateLimitEntry> = new Map();
+  public readonly batchBuffer: WebhookBatchBufferService;
 
   private constructor() {
+    this.batchBuffer = new WebhookBatchBufferService(async (params) => {
+      await this.queueBatchDelivery({
+        webhookEndpointId: params.endpointId,
+        eventType: params.eventType,
+        events: params.events as Array<Record<string, any>>,
+      });
+    });
+
     this.deliveryQueue = new Queue(WEBHOOK_QUEUE_NAME, {
       connection: WEBHOOK_CONNECTION,
       defaultJobOptions: {
@@ -424,7 +435,6 @@ export class WebhookService {
   }): Promise<WebhookDelivery> {
     const db = getDatabase();
 
-    // Check rate limit
     const endpoint = await this.getEndpoint(params.webhookEndpointId);
     if (!endpoint) {
       throw new Error(`Webhook endpoint not found: ${params.webhookEndpointId}`);
@@ -434,7 +444,36 @@ export class WebhookService {
       throw new Error(`Rate limit exceeded for webhook endpoint: ${params.webhookEndpointId}`);
     }
 
-    // Create delivery record
+    // Route through batch buffer when enabled — the buffer auto-flushes after batchWindowMs
+    if (endpoint.isBatchDeliveryEnabled) {
+      const [delivery] = await db("webhook_deliveries")
+        .insert({
+          id: crypto.randomUUID(),
+          webhook_endpoint_id: params.webhookEndpointId,
+          event_type: params.eventType,
+          payload: JSON.stringify(params.payload),
+          status: "buffered",
+          attempts: 0,
+          created_at: new Date(),
+        })
+        .returning("*");
+
+      this.batchBuffer.buffer({
+        endpointId: params.webhookEndpointId,
+        eventType: params.eventType,
+        payload: params.payload,
+        windowMs: endpoint.batchWindowMs,
+      });
+
+      logger.info(
+        { deliveryId: delivery.id, webhookEndpointId: params.webhookEndpointId, eventType: params.eventType, windowMs: endpoint.batchWindowMs },
+        "Event buffered for batch delivery",
+      );
+
+      return this.mapToDelivery(delivery);
+    }
+
+    // Standard immediate delivery
     const [delivery] = await db("webhook_deliveries")
       .insert({
         id: crypto.randomUUID(),
@@ -455,20 +494,31 @@ export class WebhookService {
       attemptNumber: 0,
     };
 
-    // Add to queue with optional delay for scheduled delivery
     if (params.scheduledAt && params.scheduledAt > Date.now()) {
-      const delay = params.scheduledAt - Date.now();
-      await this.deliveryQueue.add("webhook-delivery", jobData, { delay });
+      await this.deliveryQueue.add("webhook-delivery", jobData, { delay: params.scheduledAt - Date.now() });
     } else {
       await this.deliveryQueue.add("webhook-delivery", jobData);
     }
 
     logger.info(
       { deliveryId: delivery.id, webhookEndpointId: params.webhookEndpointId, eventType: params.eventType },
-      "Webhook delivery queued"
+      "Webhook delivery queued",
     );
 
     return this.mapToDelivery(delivery);
+  }
+
+  /** Manually flush the batch buffer for a specific endpoint before the window expires. */
+  public async flushBatchBuffer(webhookEndpointId: string): Promise<{ flushed: number }> {
+    return this.batchBuffer.flush(webhookEndpointId);
+  }
+
+  /** Return live status of batch buffer windows. */
+  public getBatchBufferStatus(webhookEndpointId?: string): BatchBufferStatus | BatchBufferStatus[] | null {
+    if (webhookEndpointId) {
+      return this.batchBuffer.getStatus(webhookEndpointId);
+    }
+    return this.batchBuffer.listAll();
   }
 
   public async queueBatchDelivery(params: {

--- a/backend/src/services/webhook.service.ts
+++ b/backend/src/services/webhook.service.ts
@@ -114,11 +114,21 @@ export class WebhookService {
 
   private constructor() {
     this.batchBuffer = new WebhookBatchBufferService(async (params) => {
-      await this.queueBatchDelivery({
-        webhookEndpointId: params.endpointId,
-        eventType: params.eventType,
-        events: params.events as Array<Record<string, any>>,
-      });
+      try {
+        await this.queueBatchDelivery({
+          webhookEndpointId: params.endpointId,
+          eventType: params.eventType,
+          events: params.events as Array<Record<string, any>>,
+        });
+        await this.resolveBufferedDeliveries(params.deliveryIds, "success");
+      } catch (err) {
+        await this.resolveBufferedDeliveries(
+          params.deliveryIds,
+          "failed",
+          err instanceof Error ? err.message : String(err),
+        );
+        throw err;
+      }
     });
 
     this.deliveryQueue = new Queue(WEBHOOK_QUEUE_NAME, {
@@ -460,6 +470,7 @@ export class WebhookService {
 
       this.batchBuffer.buffer({
         endpointId: params.webhookEndpointId,
+        deliveryId: delivery.id,
         eventType: params.eventType,
         payload: params.payload,
         windowMs: endpoint.batchWindowMs,
@@ -511,6 +522,22 @@ export class WebhookService {
   /** Manually flush the batch buffer for a specific endpoint before the window expires. */
   public async flushBatchBuffer(webhookEndpointId: string): Promise<{ flushed: number }> {
     return this.batchBuffer.flush(webhookEndpointId);
+  }
+
+  private async resolveBufferedDeliveries(
+    deliveryIds: string[],
+    status: "success" | "failed",
+    errorMessage?: string,
+  ): Promise<void> {
+    if (deliveryIds.length === 0) return;
+    const db = getDatabase();
+    await db("webhook_deliveries")
+      .whereIn("id", deliveryIds)
+      .update({
+        status,
+        last_attempt_at: new Date(),
+        ...(errorMessage ? { error_message: errorMessage } : {}),
+      });
   }
 
   /** Return live status of batch buffer windows. */

--- a/backend/src/services/webhookBatchBuffer.service.ts
+++ b/backend/src/services/webhookBatchBuffer.service.ts
@@ -1,0 +1,137 @@
+import { logger } from "../utils/logger.js";
+import type { WebhookEventType } from "./webhook.service.js";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface BufferedEvent {
+  eventType: WebhookEventType;
+  payload: Record<string, unknown>;
+  bufferedAt: number;
+}
+
+export interface BatchBufferStatus {
+  endpointId: string;
+  eventCount: number;
+  ageMs: number | null;
+  windowMs: number;
+  willFlushAt: number;
+}
+
+export type BatchFlushCallback = (params: {
+  endpointId: string;
+  eventType: WebhookEventType;
+  events: Array<Record<string, unknown>>;
+}) => Promise<void>;
+
+interface BatchEntry {
+  events: BufferedEvent[];
+  timer: ReturnType<typeof setTimeout>;
+  windowMs: number;
+  scheduledFlushAt: number;
+}
+
+// ─── Service ─────────────────────────────────────────────────────────────────
+
+export class WebhookBatchBufferService {
+  private readonly buffers = new Map<string, BatchEntry>();
+
+  constructor(private readonly onFlush: BatchFlushCallback) {}
+
+  /**
+   * Add one event to the buffer for a given endpoint.
+   * If no window is open yet, starts one using windowMs.
+   * The flush fires automatically when the window expires.
+   */
+  buffer(params: {
+    endpointId: string;
+    eventType: WebhookEventType;
+    payload: Record<string, unknown>;
+    windowMs: number;
+  }): void {
+    const { endpointId, eventType, payload, windowMs } = params;
+
+    const event: BufferedEvent = { eventType, payload, bufferedAt: Date.now() };
+
+    const existing = this.buffers.get(endpointId);
+    if (existing) {
+      existing.events.push(event);
+      logger.debug(
+        { endpointId, bufferedCount: existing.events.length },
+        "Event appended to open batch window",
+      );
+      return;
+    }
+
+    const scheduledFlushAt = Date.now() + windowMs;
+    const timer = setTimeout(() => {
+      this.flush(endpointId).catch((err) => {
+        logger.error({ endpointId, err }, "Auto-flush of batch buffer failed");
+      });
+    }, windowMs);
+
+    this.buffers.set(endpointId, { events: [event], timer, windowMs, scheduledFlushAt });
+
+    logger.info(
+      { endpointId, windowMs, scheduledFlushAt: new Date(scheduledFlushAt).toISOString() },
+      "Batch window opened",
+    );
+  }
+
+  /**
+   * Immediately flush all buffered events for an endpoint as a single batch.
+   * Called automatically by the timer or explicitly via the manual-flush route.
+   */
+  async flush(endpointId: string): Promise<{ flushed: number }> {
+    const entry = this.buffers.get(endpointId);
+    if (!entry || entry.events.length === 0) {
+      this.buffers.delete(endpointId);
+      return { flushed: 0 };
+    }
+
+    clearTimeout(entry.timer);
+    this.buffers.delete(endpointId);
+
+    const events = [...entry.events];
+    // Determine the dominant event type from the first event in the batch
+    const eventType = events[0].eventType;
+    const payloads = events.map((e) => e.payload);
+
+    logger.info(
+      { endpointId, eventCount: events.length, eventType },
+      "Flushing batch buffer",
+    );
+
+    await this.onFlush({ endpointId, eventType, events: payloads });
+
+    return { flushed: events.length };
+  }
+
+  /** Get live status for one endpoint's buffer (null if no window is open). */
+  getStatus(endpointId: string): BatchBufferStatus | null {
+    const entry = this.buffers.get(endpointId);
+    if (!entry) return null;
+    return {
+      endpointId,
+      eventCount: entry.events.length,
+      ageMs: entry.events.length > 0 ? Date.now() - entry.events[0].bufferedAt : null,
+      windowMs: entry.windowMs,
+      willFlushAt: entry.scheduledFlushAt,
+    };
+  }
+
+  /** List status for every currently-open batch window. */
+  listAll(): BatchBufferStatus[] {
+    return Array.from(this.buffers.keys())
+      .map((id) => this.getStatus(id))
+      .filter((s): s is BatchBufferStatus => s !== null);
+  }
+
+  /** Flush all open windows — call on graceful shutdown. */
+  async flushAll(): Promise<void> {
+    await Promise.allSettled(Array.from(this.buffers.keys()).map((id) => this.flush(id)));
+  }
+
+  get openWindowCount(): number {
+    return this.buffers.size;
+  }
+}

--- a/backend/src/services/webhookBatchBuffer.service.ts
+++ b/backend/src/services/webhookBatchBuffer.service.ts
@@ -4,6 +4,7 @@ import type { WebhookEventType } from "./webhook.service.js";
 // ─── Types ───────────────────────────────────────────────────────────────────
 
 export interface BufferedEvent {
+  deliveryId: string;
   eventType: WebhookEventType;
   payload: Record<string, unknown>;
   bufferedAt: number;
@@ -21,6 +22,7 @@ export type BatchFlushCallback = (params: {
   endpointId: string;
   eventType: WebhookEventType;
   events: Array<Record<string, unknown>>;
+  deliveryIds: string[];
 }) => Promise<void>;
 
 interface BatchEntry {
@@ -44,13 +46,14 @@ export class WebhookBatchBufferService {
    */
   buffer(params: {
     endpointId: string;
+    deliveryId: string;
     eventType: WebhookEventType;
     payload: Record<string, unknown>;
     windowMs: number;
   }): void {
-    const { endpointId, eventType, payload, windowMs } = params;
+    const { endpointId, deliveryId, eventType, payload, windowMs } = params;
 
-    const event: BufferedEvent = { eventType, payload, bufferedAt: Date.now() };
+    const event: BufferedEvent = { deliveryId, eventType, payload, bufferedAt: Date.now() };
 
     const existing = this.buffers.get(endpointId);
     if (existing) {
@@ -92,16 +95,16 @@ export class WebhookBatchBufferService {
     this.buffers.delete(endpointId);
 
     const events = [...entry.events];
-    // Determine the dominant event type from the first event in the batch
     const eventType = events[0].eventType;
     const payloads = events.map((e) => e.payload);
+    const deliveryIds = events.map((e) => e.deliveryId);
 
     logger.info(
       { endpointId, eventCount: events.length, eventType },
       "Flushing batch buffer",
     );
 
-    await this.onFlush({ endpointId, eventType, events: payloads });
+    await this.onFlush({ endpointId, eventType, events: payloads, deliveryIds });
 
     return { flushed: events.length };
   }


### PR DESCRIPTION
## Summary

Implements automatic webhook batch buffering to eliminate rate-limit errors on receiver systems (Slack, Discord, etc.) when multiple alert events fire simultaneously.

### Problem

When multiple alert events trigger at the same time — for example during a market-wide liquidation cascade — the webhook dispatcher was sending one HTTP POST per event. Receiver systems impose strict rate limits and began returning 429s, causing delivery failures and retry storms.

### Solution

- **`WebhookBatchBufferService`** — a new in-process time-window buffer. The first event arriving for a batch-enabled endpoint opens a configurable window (default `batchWindowMs = 5 000 ms`). Every subsequent event that arrives within the window is appended. When the window closes, all accumulated events are dispatched as a **single** HTTP POST with an array payload, using the existing `queueBatchDelivery` path.

- **`queueDelivery` updated** — when an endpoint has `isBatchDeliveryEnabled = true`, events are routed through the buffer instead of queued immediately. A `"buffered"` delivery record is written to the DB for each individual event as an audit trail entry. The final batch dispatch creates one aggregate delivery record via `queueBatchDelivery`.

- **New `"buffered"` delivery status** — extends `WebhookDeliveryStatus` so operators can distinguish events sitting in a live window from those already dispatched.

### New API endpoints

| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/api/v1/webhooks/batch-buffer` | Live status of all open batch windows; pass `?endpointId=` to scope to one endpoint |
| `POST` | `/api/v1/webhooks/endpoints/:id/flush-batch` | Manually trigger an early flush before the window expires |

### Configuration

Batching is opt-in per endpoint, controlled by existing fields already in `webhook_endpoints`:

| Field | Default | Description |
|-------|---------|-------------|
| `isBatchDeliveryEnabled` | `false` | Enable buffering for this endpoint |
| `batchWindowMs` | `5000` | How long (ms) to accumulate events before dispatching |

No migration required — both columns were added in `012_webhook_system.ts`.

### Batch payload shape

```json
{
  "batch": true,
  "batchId": "uuid",
  "eventType": "alert.triggered",
  "count": 12,
  "events": [ ...individual event payloads... ],
  "timestamp": "2026-06-25T00:00:00.000Z"
}
```

## Test plan

- [ ] Create a webhook endpoint with `isBatchDeliveryEnabled: true`, `batchWindowMs: 2000`
- [ ] Fire 10 `queueDelivery` calls within the 2-second window — confirm receiver gets **one** POST with `count: 10`
- [ ] Fire calls across two windows — confirm two separate batch POSTs, not one
- [ ] Call `POST /endpoints/:id/flush-batch` mid-window — verify early dispatch and subsequent events open a new window
- [ ] Verify `GET /batch-buffer` reflects live event counts and `willFlushAt` timestamps
- [ ] Confirm `"buffered"` records appear in `webhook_deliveries` for individual events
- [ ] Verify endpoint with `isBatchDeliveryEnabled: false` still dispatches immediately (no regression)

Closes #826