### PR TITLE
feat: on-chain multisig emergency halt and recovery for Soroban monitors

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -193,6 +193,7 @@ dependencies = [
 name = "bridge-watch-contracts"
 version = "0.1.0"
 dependencies = [
+ "ed25519-dalek",
  "soroban-sdk",
 ]
 

--- a/contracts/soroban/Cargo.toml
+++ b/contracts/soroban/Cargo.toml
@@ -16,6 +16,7 @@ soroban-sdk = { version = "22.0.10" }
 
 [dev-dependencies]
 soroban-sdk = { version = "22.0.10", features = ["testutils"] }
+ed25519-dalek = "2"
 
 [[test]]
 name = "asset_locking_test"

--- a/contracts/soroban/src/emergency_multisig.rs
+++ b/contracts/soroban/src/emergency_multisig.rs
@@ -1,0 +1,604 @@
+//! On-chain multi-signature emergency halt & recovery (issue #794).
+//!
+//! Emergency administrative actions — pausing/unpausing the contract and
+//! overriding sensitive admin config — were previously single-key operations
+//! gated only by `Address::require_auth()` against the contract admin. If the
+//! admin key were compromised, an attacker could silence the circuit breaker
+//! or disable monitoring rules with a single transaction.
+//!
+//! This module lets the admin register a set of operator Ed25519 public keys
+//! and a signature threshold (`M`-of-`N`). Critical actions then require `M`
+//! independently verified Ed25519 signatures — checked on-chain via the
+//! Soroban SDK's `env.crypto().ed25519_verify()` — before they take effect.
+//! Signatures are bound to a specific action and a strictly increasing nonce
+//! so a captured signature cannot be replayed against a different action or
+//! resubmitted.
+//!
+//! This module only handles operator configuration, message construction and
+//! threshold signature verification. Applying the verified action (flipping
+//! the pause flag, updating a threshold, ...) is the caller's responsibility
+//! (see the `*_multisig` entrypoints in `lib.rs`), keeping this module free
+//! of any dependency on the rest of the contract's state.
+
+use soroban_sdk::{contracttype, symbol_short, Bytes, BytesN, Env, Vec};
+
+use crate::keys;
+
+/// Upper bound on the number of registered operators.
+pub const MAX_OPERATORS: u32 = 15;
+
+/// Maximum number of audit log entries retained on-chain.
+pub const MAX_LOG_ENTRIES: u32 = 200;
+
+/// Domain-separation prefix mixed into every signed message so a signature
+/// produced for this module can never be replayed against an unrelated
+/// signing scheme within the contract.
+const DOMAIN: &[u8] = b"BW_EMERGENCY_MULTISIG_V1";
+
+/// Critical actions that may be authorised through the emergency multisig.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum EmergencyAction {
+    /// Halt all state-changing contract operations.
+    Pause,
+    /// Lift a previously triggered multisig pause.
+    Unpause,
+    /// Administrative config override: update the global supply mismatch
+    /// threshold (basis points), bypassing the single-admin path.
+    SetMismatchThreshold(i128),
+}
+
+/// One operator's Ed25519 signature over a proposed `EmergencyAction`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OperatorSignature {
+    pub operator: BytesN<32>,
+    pub signature: BytesN<64>,
+}
+
+/// The configured operator set and approval threshold.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MultisigConfig {
+    pub operators: Vec<BytesN<32>>,
+    pub threshold: u32,
+}
+
+/// One executed multisig action, retained for audit purposes.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MultisigActionLog {
+    pub nonce: u64,
+    pub action: EmergencyAction,
+    pub approvers: Vec<BytesN<32>>,
+    pub timestamp: u64,
+}
+
+/// Register (or rotate) the operator key set and signature threshold.
+///
+/// # Panics
+/// - `operators` is empty or exceeds [`MAX_OPERATORS`].
+/// - `threshold` is zero or greater than the number of operators.
+/// - `operators` contains a duplicate key.
+pub fn configure(env: &Env, operators: Vec<BytesN<32>>, threshold: u32) -> MultisigConfig {
+    if operators.is_empty() {
+        panic!("emergency multisig requires at least one operator");
+    }
+    if operators.len() > MAX_OPERATORS {
+        panic!("too many emergency multisig operators");
+    }
+    if threshold == 0 || threshold > operators.len() {
+        panic!("emergency multisig threshold must be between 1 and the operator count");
+    }
+    for i in 0..operators.len() {
+        let op = operators.get(i).unwrap();
+        let mut j = i + 1;
+        while j < operators.len() {
+            if operators.get(j).unwrap() == op {
+                panic!("duplicate operator key in emergency multisig configuration");
+            }
+            j += 1;
+        }
+    }
+
+    let config = MultisigConfig {
+        operators,
+        threshold,
+    };
+    env.storage()
+        .instance()
+        .set(&keys::EMERGENCY_MULTISIG_CONFIG, &config);
+    if !env
+        .storage()
+        .instance()
+        .has(&keys::EMERGENCY_MULTISIG_NONCE)
+    {
+        env.storage()
+            .instance()
+            .set(&keys::EMERGENCY_MULTISIG_NONCE, &0u64);
+    }
+
+    config
+}
+
+/// Return the current operator set/threshold, if configured.
+pub fn get_config(env: &Env) -> Option<MultisigConfig> {
+    env.storage()
+        .instance()
+        .get(&keys::EMERGENCY_MULTISIG_CONFIG)
+}
+
+/// Return the last consumed nonce (0 if none has been consumed yet).
+pub fn get_nonce(env: &Env) -> u64 {
+    env.storage()
+        .instance()
+        .get(&keys::EMERGENCY_MULTISIG_NONCE)
+        .unwrap_or(0)
+}
+
+/// Return the emergency multisig audit log, oldest first.
+pub fn get_log(env: &Env) -> Vec<MultisigActionLog> {
+    env.storage()
+        .persistent()
+        .get(&keys::EMERGENCY_MULTISIG_LOG)
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+fn action_tag(action: &EmergencyAction) -> u32 {
+    match action {
+        EmergencyAction::Pause => 1,
+        EmergencyAction::Unpause => 2,
+        EmergencyAction::SetMismatchThreshold(_) => 3,
+    }
+}
+
+fn append_u32(buf: &mut Bytes, value: u32) {
+    let bytes = value.to_be_bytes();
+    for b in bytes {
+        buf.push_back(b);
+    }
+}
+
+fn append_u64(buf: &mut Bytes, value: u64) {
+    let bytes = value.to_be_bytes();
+    for b in bytes {
+        buf.push_back(b);
+    }
+}
+
+fn append_i128(buf: &mut Bytes, value: i128) {
+    let bytes = value.to_be_bytes();
+    for b in bytes {
+        buf.push_back(b);
+    }
+}
+
+/// Build the canonical byte payload operators must sign for `action` at
+/// `nonce`. Binding the action's own parameters and the nonce into the
+/// message means a valid signature cannot be reused for a different action,
+/// a different parameter value, or replayed once its nonce is consumed.
+pub fn build_message(env: &Env, action: &EmergencyAction, nonce: u64) -> Bytes {
+    let mut data = Bytes::from_slice(env, DOMAIN);
+    append_u32(&mut data, action_tag(action));
+    if let EmergencyAction::SetMismatchThreshold(value) = action {
+        append_i128(&mut data, *value);
+    }
+    append_u64(&mut data, nonce);
+    data
+}
+
+/// Verify a threshold of operator signatures over `action` at `nonce`.
+///
+/// On success the nonce is consumed and an audit log entry is appended. The
+/// list of approving operator public keys is returned so callers can surface
+/// it in their own events/activity logs.
+///
+/// # Panics
+/// - No multisig configuration has been set.
+/// - `nonce` is not exactly one greater than the last consumed nonce.
+/// - Fewer signatures than the configured threshold were supplied.
+/// - A signature is attributed to a key that is not a configured operator.
+/// - The same operator key signs more than once in the same call.
+/// - Any signature fails Ed25519 verification.
+pub fn verify_and_execute(
+    env: &Env,
+    action: EmergencyAction,
+    signatures: Vec<OperatorSignature>,
+    nonce: u64,
+) -> Vec<BytesN<32>> {
+    let config: MultisigConfig =
+        get_config(env).unwrap_or_else(|| panic!("emergency multisig is not configured"));
+
+    let expected_nonce = get_nonce(env) + 1;
+    if nonce != expected_nonce {
+        panic!("invalid emergency multisig nonce");
+    }
+
+    if signatures.len() < config.threshold {
+        panic!("insufficient emergency multisig signatures");
+    }
+
+    let message = build_message(env, &action, nonce);
+
+    let mut approvers: Vec<BytesN<32>> = Vec::new(env);
+    for sig in signatures.iter() {
+        let mut is_operator = false;
+        for op in config.operators.iter() {
+            if op == sig.operator {
+                is_operator = true;
+                break;
+            }
+        }
+        if !is_operator {
+            panic!("signature from unregistered emergency multisig operator");
+        }
+
+        for existing in approvers.iter() {
+            if existing == sig.operator {
+                panic!("duplicate operator signature in emergency multisig submission");
+            }
+        }
+
+        // Traps if the signature does not verify against `message`.
+        env.crypto()
+            .ed25519_verify(&sig.operator, &message, &sig.signature);
+
+        approvers.push_back(sig.operator.clone());
+    }
+
+    if approvers.len() < config.threshold {
+        panic!("insufficient valid emergency multisig signatures");
+    }
+
+    env.storage()
+        .instance()
+        .set(&keys::EMERGENCY_MULTISIG_NONCE, &nonce);
+
+    let entry = MultisigActionLog {
+        nonce,
+        action: action.clone(),
+        approvers: approvers.clone(),
+        timestamp: env.ledger().timestamp(),
+    };
+    let mut log = get_log(env);
+    log.push_back(entry);
+    if log.len() > MAX_LOG_ENTRIES {
+        let mut trimmed: Vec<MultisigActionLog> = Vec::new(env);
+        for i in 1..log.len() {
+            trimmed.push_back(log.get(i).unwrap());
+        }
+        log = trimmed;
+    }
+    env.storage()
+        .persistent()
+        .set(&keys::EMERGENCY_MULTISIG_LOG, &log);
+
+    env.events().publish(
+        (symbol_short!("ems_exec"), action_tag(&action)),
+        (nonce, approvers.len()),
+    );
+
+    approvers
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::{Signer, SigningKey};
+    use soroban_sdk::testutils::Ledger;
+    use soroban_sdk::{contract, Address};
+
+    /// Storage-touching functions in this module assume they run inside a
+    /// contract invocation. `TestHarnessContract` gives the test suite a
+    /// registered contract instance to execute against via `env.as_contract`.
+    #[contract]
+    struct TestHarnessContract;
+
+    fn setup_env() -> (Env, Address) {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, TestHarnessContract);
+        (env, contract_id)
+    }
+
+    /// Deterministically derive an Ed25519 keypair from a single seed byte.
+    fn keypair(seed: u8) -> (SigningKey, [u8; 32]) {
+        let signing_key = SigningKey::from_bytes(&[seed; 32]);
+        let verifying_key = signing_key.verifying_key().to_bytes();
+        (signing_key, verifying_key)
+    }
+
+    fn sign(env: &Env, signing_key: &SigningKey, message: &Bytes) -> BytesN<64> {
+        let mut buf = [0u8; 512];
+        let len = message.len() as usize;
+        message.copy_into_slice(&mut buf[..len]);
+        let signature = signing_key.sign(&buf[..len]);
+        BytesN::from_array(env, &signature.to_bytes())
+    }
+
+    fn operators_from(env: &Env, raws: &[[u8; 32]]) -> Vec<BytesN<32>> {
+        let mut v: Vec<BytesN<32>> = Vec::new(env);
+        for raw in raws {
+            v.push_back(BytesN::from_array(env, raw));
+        }
+        v
+    }
+
+    #[test]
+    fn test_configure_and_get_config() {
+        let (env, cid) = setup_env();
+        let (_sk0, pk0) = keypair(1);
+        let (_sk1, pk1) = keypair(2);
+        let (_sk2, pk2) = keypair(3);
+        let operators = operators_from(&env, &[pk0, pk1, pk2]);
+
+        env.as_contract(&cid, || {
+            let config = configure(&env, operators, 2);
+            assert_eq!(config.threshold, 2);
+            assert_eq!(config.operators.len(), 3);
+            assert_eq!(get_config(&env).unwrap().threshold, 2);
+            assert_eq!(get_nonce(&env), 0);
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "at least one operator")]
+    fn test_configure_rejects_empty_operators() {
+        let (env, cid) = setup_env();
+        let operators: Vec<BytesN<32>> = Vec::new(&env);
+        env.as_contract(&cid, || {
+            configure(&env, operators, 1);
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "threshold must be between 1")]
+    fn test_configure_rejects_threshold_above_operator_count() {
+        let (env, cid) = setup_env();
+        let (_sk0, pk0) = keypair(1);
+        let (_sk1, pk1) = keypair(2);
+        let operators = operators_from(&env, &[pk0, pk1]);
+        env.as_contract(&cid, || {
+            configure(&env, operators, 3);
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "threshold must be between 1")]
+    fn test_configure_rejects_zero_threshold() {
+        let (env, cid) = setup_env();
+        let (_sk0, pk0) = keypair(1);
+        let (_sk1, pk1) = keypair(2);
+        let operators = operators_from(&env, &[pk0, pk1]);
+        env.as_contract(&cid, || {
+            configure(&env, operators, 0);
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "duplicate operator")]
+    fn test_configure_rejects_duplicate_operators() {
+        let (env, cid) = setup_env();
+        let (_sk0, pk0) = keypair(1);
+        let operators = operators_from(&env, &[pk0, pk0]);
+        env.as_contract(&cid, || {
+            configure(&env, operators, 2);
+        });
+    }
+
+    #[test]
+    fn test_verify_and_execute_succeeds_with_threshold_signatures() {
+        let (env, cid) = setup_env();
+        env.ledger().set_timestamp(1_000);
+        let (sk0, pk0) = keypair(1);
+        let (sk1, pk1) = keypair(2);
+        let (_sk2, pk2) = keypair(3);
+        let operators = operators_from(&env, &[pk0, pk1, pk2]);
+        env.as_contract(&cid, || {
+            configure(&env, operators, 2);
+        });
+
+        let message = env.as_contract(&cid, || build_message(&env, &EmergencyAction::Pause, 1));
+        let mut sigs: Vec<OperatorSignature> = Vec::new(&env);
+        sigs.push_back(OperatorSignature {
+            operator: BytesN::from_array(&env, &pk0),
+            signature: sign(&env, &sk0, &message),
+        });
+        sigs.push_back(OperatorSignature {
+            operator: BytesN::from_array(&env, &pk1),
+            signature: sign(&env, &sk1, &message),
+        });
+
+        env.as_contract(&cid, || {
+            let approvers = verify_and_execute(&env, EmergencyAction::Pause, sigs, 1);
+            assert_eq!(approvers.len(), 2);
+            assert_eq!(get_nonce(&env), 1);
+
+            let log = get_log(&env);
+            assert_eq!(log.len(), 1);
+            assert_eq!(log.get(0).unwrap().nonce, 1);
+            assert_eq!(log.get(0).unwrap().action, EmergencyAction::Pause);
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "insufficient emergency multisig signatures")]
+    fn test_verify_and_execute_rejects_below_threshold_count() {
+        let (env, cid) = setup_env();
+        let (sk0, pk0) = keypair(1);
+        let (_sk1, pk1) = keypair(2);
+        let (_sk2, pk2) = keypair(3);
+        let operators = operators_from(&env, &[pk0, pk1, pk2]);
+        env.as_contract(&cid, || {
+            configure(&env, operators, 2);
+        });
+
+        let message = env.as_contract(&cid, || build_message(&env, &EmergencyAction::Pause, 1));
+        let mut sigs: Vec<OperatorSignature> = Vec::new(&env);
+        sigs.push_back(OperatorSignature {
+            operator: BytesN::from_array(&env, &pk0),
+            signature: sign(&env, &sk0, &message),
+        });
+
+        env.as_contract(&cid, || {
+            verify_and_execute(&env, EmergencyAction::Pause, sigs, 1);
+        });
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_verify_and_execute_rejects_invalid_signature() {
+        let (env, cid) = setup_env();
+        let (sk0, pk0) = keypair(1);
+        let (sk1, pk1) = keypair(2);
+        let operators = operators_from(&env, &[pk0, pk1]);
+        env.as_contract(&cid, || {
+            configure(&env, operators, 2);
+        });
+
+        // Sign the wrong message (wrong nonce) so verification fails.
+        let wrong_message =
+            env.as_contract(&cid, || build_message(&env, &EmergencyAction::Pause, 999));
+        let mut sigs: Vec<OperatorSignature> = Vec::new(&env);
+        sigs.push_back(OperatorSignature {
+            operator: BytesN::from_array(&env, &pk0),
+            signature: sign(&env, &sk0, &wrong_message),
+        });
+        sigs.push_back(OperatorSignature {
+            operator: BytesN::from_array(&env, &pk1),
+            signature: sign(&env, &sk1, &wrong_message),
+        });
+
+        env.as_contract(&cid, || {
+            verify_and_execute(&env, EmergencyAction::Pause, sigs, 1);
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "unregistered emergency multisig operator")]
+    fn test_verify_and_execute_rejects_non_operator_signer() {
+        let (env, cid) = setup_env();
+        let (sk0, pk0) = keypair(1);
+        let (_sk1, pk1) = keypair(2);
+        let operators = operators_from(&env, &[pk0, pk1]);
+        env.as_contract(&cid, || {
+            configure(&env, operators, 2);
+        });
+
+        let (outsider_sk, outsider_raw) = keypair(99);
+
+        let message = env.as_contract(&cid, || build_message(&env, &EmergencyAction::Pause, 1));
+        let mut sigs: Vec<OperatorSignature> = Vec::new(&env);
+        sigs.push_back(OperatorSignature {
+            operator: BytesN::from_array(&env, &pk0),
+            signature: sign(&env, &sk0, &message),
+        });
+        sigs.push_back(OperatorSignature {
+            operator: BytesN::from_array(&env, &outsider_raw),
+            signature: sign(&env, &outsider_sk, &message),
+        });
+
+        env.as_contract(&cid, || {
+            verify_and_execute(&env, EmergencyAction::Pause, sigs, 1);
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "duplicate operator signature")]
+    fn test_verify_and_execute_rejects_duplicate_signer_in_submission() {
+        let (env, cid) = setup_env();
+        let (sk0, pk0) = keypair(1);
+        let (_sk1, pk1) = keypair(2);
+        let (_sk2, pk2) = keypair(3);
+        let operators = operators_from(&env, &[pk0, pk1, pk2]);
+        env.as_contract(&cid, || {
+            configure(&env, operators, 2);
+        });
+
+        let message = env.as_contract(&cid, || build_message(&env, &EmergencyAction::Pause, 1));
+        let mut sigs: Vec<OperatorSignature> = Vec::new(&env);
+        sigs.push_back(OperatorSignature {
+            operator: BytesN::from_array(&env, &pk0),
+            signature: sign(&env, &sk0, &message),
+        });
+        sigs.push_back(OperatorSignature {
+            operator: BytesN::from_array(&env, &pk0),
+            signature: sign(&env, &sk0, &message),
+        });
+
+        env.as_contract(&cid, || {
+            verify_and_execute(&env, EmergencyAction::Pause, sigs, 1);
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid emergency multisig nonce")]
+    fn test_verify_and_execute_rejects_replayed_nonce() {
+        let (env, cid) = setup_env();
+        env.ledger().set_timestamp(1_000);
+        let (sk0, pk0) = keypair(1);
+        let (sk1, pk1) = keypair(2);
+        let operators = operators_from(&env, &[pk0, pk1]);
+        env.as_contract(&cid, || {
+            configure(&env, operators, 2);
+        });
+
+        let message = env.as_contract(&cid, || build_message(&env, &EmergencyAction::Pause, 1));
+        let mut sigs: Vec<OperatorSignature> = Vec::new(&env);
+        sigs.push_back(OperatorSignature {
+            operator: BytesN::from_array(&env, &pk0),
+            signature: sign(&env, &sk0, &message),
+        });
+        sigs.push_back(OperatorSignature {
+            operator: BytesN::from_array(&env, &pk1),
+            signature: sign(&env, &sk1, &message),
+        });
+
+        env.as_contract(&cid, || {
+            verify_and_execute(&env, EmergencyAction::Pause, sigs.clone(), 1);
+            // Replay the exact same call (same nonce) — must fail even though
+            // the signatures themselves were valid the first time.
+            verify_and_execute(&env, EmergencyAction::Pause, sigs, 1);
+        });
+    }
+
+    #[test]
+    fn test_verify_and_execute_threshold_admin_config_override() {
+        let (env, cid) = setup_env();
+        env.ledger().set_timestamp(5_000);
+        let (sk0, pk0) = keypair(7);
+        let (sk1, pk1) = keypair(8);
+        let (sk2, pk2) = keypair(9);
+        let operators = operators_from(&env, &[pk0, pk1, pk2]);
+        env.as_contract(&cid, || {
+            configure(&env, operators, 3);
+        });
+
+        let action = EmergencyAction::SetMismatchThreshold(25);
+        let message = env.as_contract(&cid, || build_message(&env, &action, 1));
+
+        let mut sigs: Vec<OperatorSignature> = Vec::new(&env);
+        sigs.push_back(OperatorSignature {
+            operator: BytesN::from_array(&env, &pk0),
+            signature: sign(&env, &sk0, &message),
+        });
+        sigs.push_back(OperatorSignature {
+            operator: BytesN::from_array(&env, &pk1),
+            signature: sign(&env, &sk1, &message),
+        });
+        sigs.push_back(OperatorSignature {
+            operator: BytesN::from_array(&env, &pk2),
+            signature: sign(&env, &sk2, &message),
+        });
+
+        env.as_contract(&cid, || {
+            let approvers = verify_and_execute(&env, action.clone(), sigs, 1);
+            assert_eq!(approvers.len(), 3);
+
+            let log = get_log(&env);
+            assert_eq!(
+                log.get(0).unwrap().action,
+                EmergencyAction::SetMismatchThreshold(25)
+            );
+        });
+    }
+}

--- a/contracts/soroban/src/lib.rs
+++ b/contracts/soroban/src/lib.rs
@@ -15,6 +15,7 @@ pub mod batch_query;
 #[cfg(test)]
 pub mod circuit_breaker;
 pub mod emergency_fund_recovery;
+pub mod emergency_multisig;
 pub mod escrow_contract;
 #[cfg(test)]
 pub mod governance;
@@ -49,6 +50,8 @@ use liquidity_pool::{
     DailyBucket, ImpermanentLossResult, LiquidityDepth as PoolLiquidityDepth, PoolMetrics,
     PoolSnapshot, PoolType,
 };
+
+use emergency_multisig::{EmergencyAction, MultisigActionLog, MultisigConfig, OperatorSignature};
 // Storage key constants instead of using DataKey enum for storage operations
 #[allow(dead_code)]
 mod keys {
@@ -126,6 +129,10 @@ mod keys {
     // Event Replay Helpers (issue #296)
     pub const EVENT_REPLAY_LOG: &str = "event_replay_log";
     pub const EVENT_REPLAY_CTR: &str = "event_replay_ctr";
+    // Emergency Multi-Signature Halt & Recovery (issue #794)
+    pub const EMERGENCY_MULTISIG_CONFIG: &str = "em_msig_cfg";
+    pub const EMERGENCY_MULTISIG_NONCE: &str = "em_msig_nonce";
+    pub const EMERGENCY_MULTISIG_LOG: &str = "em_msig_log";
 }
 
 #[contracttype]
@@ -3769,6 +3776,214 @@ impl BridgeWatchContract {
             .persistent()
             .get(&keys::PAUSE_HISTORY)
             .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    // -----------------------------------------------------------------------
+    // Emergency Multi-Signature Halt & Recovery (issue #794)
+    // -----------------------------------------------------------------------
+    //
+    // The single-key `emergency_pause`/`unpause`/`set_mismatch_threshold`
+    // entrypoints above remain available, but they are a single point of
+    // failure: whoever holds the admin key can silence the circuit breaker.
+    // The entrypoints below require a configurable `M`-of-`N` threshold of
+    // Ed25519 signatures from independently-held operator keys, verified
+    // on-chain via `env.crypto().ed25519_verify()`, before pausing,
+    // unpausing, or overriding the mismatch threshold takes effect.
+
+    /// Register (or rotate) the emergency multisig operator set and
+    /// signature threshold. Admin only — this establishes the root of trust
+    /// that the threshold signature scheme below relies on.
+    ///
+    /// # Panics
+    /// - `caller` is not the contract admin.
+    /// - `operators` is empty, exceeds the configured maximum, or contains a
+    ///   duplicate key.
+    /// - `threshold` is zero or greater than the number of operators.
+    pub fn configure_emergency_multisig(
+        env: Env,
+        caller: Address,
+        operators: Vec<BytesN<32>>,
+        threshold: u32,
+    ) {
+        caller.require_auth();
+        let admin: Address = env.storage().instance().get(&keys::ADMIN).unwrap();
+        if caller != admin {
+            panic!("only admin can configure the emergency multisig");
+        }
+
+        let config = emergency_multisig::configure(&env, operators, threshold);
+
+        env.events()
+            .publish((symbol_short!("ems_cfg"), caller), config.threshold);
+    }
+
+    /// Return the current emergency multisig operator set/threshold, if any.
+    pub fn get_emergency_multisig_config(env: Env) -> Option<MultisigConfig> {
+        emergency_multisig::get_config(&env)
+    }
+
+    /// Return the next nonce that emergency multisig signatures must target.
+    pub fn get_emergency_multisig_nonce(env: Env) -> u64 {
+        emergency_multisig::get_nonce(&env) + 1
+    }
+
+    /// Return the emergency multisig action audit log, oldest first.
+    pub fn get_emergency_multisig_log(env: Env) -> Vec<MultisigActionLog> {
+        emergency_multisig::get_log(&env)
+    }
+
+    /// Halt all state-changing contract operations once `threshold` operators
+    /// have signed the `Pause` action for `nonce`.
+    ///
+    /// Unlike `emergency_pause()`, this does not depend on `caller` holding
+    /// any privileged role or key — authorization comes entirely from the
+    /// verified operator signatures, so a compromised admin key cannot be
+    /// used to block this recovery path.
+    ///
+    /// # Panics
+    /// - See [`emergency_multisig::verify_and_execute`].
+    pub fn emergency_pause_multisig(
+        env: Env,
+        reason: String,
+        signatures: Vec<OperatorSignature>,
+        nonce: u64,
+    ) {
+        let approvers = emergency_multisig::verify_and_execute(
+            &env,
+            EmergencyAction::Pause,
+            signatures,
+            nonce,
+        );
+
+        let now = env.ledger().timestamp();
+        env.storage().instance().set(&keys::GLOBAL_PAUSED, &true);
+        env.storage()
+            .instance()
+            .set(&keys::PAUSE_REASON, &reason);
+        env.storage().instance().set(&keys::PAUSED_AT, &now);
+        env.storage()
+            .instance()
+            .set(&keys::UNPAUSE_AVAILABLE_AT, &now);
+
+        let record = PauseRecord {
+            paused: true,
+            reason: reason.clone(),
+            caller: env.current_contract_address(),
+            timestamp: now,
+        };
+        let mut history: Vec<PauseRecord> = env
+            .storage()
+            .persistent()
+            .get(&keys::PAUSE_HISTORY)
+            .unwrap_or_else(|| Vec::new(&env));
+        history.push_back(record);
+        env.storage()
+            .persistent()
+            .set(&keys::PAUSE_HISTORY, &history);
+
+        env.events().publish(
+            (symbol_short!("ems_pause"), nonce),
+            (reason.clone(), approvers.len()),
+        );
+        Self::append_admin_activity(
+            &env,
+            AdminActivityAction::ContractPaused,
+            env.current_contract_address(),
+            reason,
+        );
+    }
+
+    /// Lift a pause once `threshold` operators have signed the `Unpause`
+    /// action for `nonce`.
+    ///
+    /// A threshold of independently-held operator keys is a stronger
+    /// guarantee than the single-admin timelock used by `unpause()`, so this
+    /// entrypoint does not additionally wait on `unpause_available_at` — the
+    /// multisig approval itself is the safety control.
+    ///
+    /// # Panics
+    /// - See [`emergency_multisig::verify_and_execute`].
+    pub fn unpause_emergency_multisig(
+        env: Env,
+        reason: String,
+        signatures: Vec<OperatorSignature>,
+        nonce: u64,
+    ) {
+        let approvers = emergency_multisig::verify_and_execute(
+            &env,
+            EmergencyAction::Unpause,
+            signatures,
+            nonce,
+        );
+
+        let now = env.ledger().timestamp();
+        env.storage().instance().set(&keys::GLOBAL_PAUSED, &false);
+
+        let record = PauseRecord {
+            paused: false,
+            reason: reason.clone(),
+            caller: env.current_contract_address(),
+            timestamp: now,
+        };
+        let mut history: Vec<PauseRecord> = env
+            .storage()
+            .persistent()
+            .get(&keys::PAUSE_HISTORY)
+            .unwrap_or_else(|| Vec::new(&env));
+        history.push_back(record);
+        env.storage()
+            .persistent()
+            .set(&keys::PAUSE_HISTORY, &history);
+
+        env.events().publish(
+            (symbol_short!("ems_unpau"), nonce),
+            (reason.clone(), approvers.len()),
+        );
+        Self::append_admin_activity(
+            &env,
+            AdminActivityAction::ContractUnpaused,
+            env.current_contract_address(),
+            reason,
+        );
+    }
+
+    /// Administrative config override: update the global supply mismatch
+    /// threshold once `threshold` operators have signed the
+    /// `SetMismatchThreshold` action for `nonce`, bypassing the single-admin
+    /// `set_mismatch_threshold()` path.
+    ///
+    /// # Panics
+    /// - See [`emergency_multisig::verify_and_execute`].
+    pub fn set_mismatch_threshold_multisig(
+        env: Env,
+        threshold_bps: i128,
+        signatures: Vec<OperatorSignature>,
+        nonce: u64,
+    ) {
+        let approvers = emergency_multisig::verify_and_execute(
+            &env,
+            EmergencyAction::SetMismatchThreshold(threshold_bps),
+            signatures,
+            nonce,
+        );
+
+        env.storage()
+            .instance()
+            .set(&keys::MISMATCH_THRESHOLD, &threshold_bps);
+
+        env.events().publish(
+            (symbol_short!("ems_thr"), nonce),
+            (threshold_bps, approvers.len()),
+        );
+        Self::emit_contract_event(
+            &env,
+            BridgeWatchEvent::ThresholdUpdated {
+                actor: env.current_contract_address(),
+                scope: String::from_str(&env, "mismatch_threshold_multisig"),
+                value: threshold_bps,
+                timestamp: env.ledger().timestamp(),
+            },
+        );
     }
 
     /// Store operator emergency contact information (e-mail, Telegram, etc.).
@@ -12845,5 +13060,239 @@ mod tests {
         let entry = page.entries.get(0).unwrap();
         assert_eq!(entry.event_type, String::from_str(&env, "rec_entr"));
         assert_eq!(entry.actor, admin);
+    }
+
+    // -----------------------------------------------------------------------
+    // Emergency Multi-Signature Halt & Recovery (issue #794)
+    // -----------------------------------------------------------------------
+
+    /// Deterministically derive an Ed25519 keypair from a single seed byte.
+    fn emergency_multisig_keypair(seed: u8) -> (ed25519_dalek::SigningKey, [u8; 32]) {
+        let signing_key = ed25519_dalek::SigningKey::from_bytes(&[seed; 32]);
+        let verifying_key = signing_key.verifying_key().to_bytes();
+        (signing_key, verifying_key)
+    }
+
+    fn emergency_multisig_sign(
+        env: &Env,
+        signing_key: &ed25519_dalek::SigningKey,
+        message: &Bytes,
+    ) -> BytesN<64> {
+        use ed25519_dalek::Signer;
+        let mut buf = [0u8; 512];
+        let len = message.len() as usize;
+        message.copy_into_slice(&mut buf[..len]);
+        let signature = signing_key.sign(&buf[..len]);
+        BytesN::from_array(env, &signature.to_bytes())
+    }
+
+    /// Configure a 2-of-3 emergency multisig and return the operators' keys.
+    fn setup_emergency_multisig(
+        env: &Env,
+        client: &BridgeWatchContractClient<'static>,
+        admin: &Address,
+    ) -> (
+        [(ed25519_dalek::SigningKey, [u8; 32]); 3],
+        Vec<BytesN<32>>,
+    ) {
+        let keys = [
+            emergency_multisig_keypair(1),
+            emergency_multisig_keypair(2),
+            emergency_multisig_keypair(3),
+        ];
+        let mut operators: Vec<BytesN<32>> = Vec::new(env);
+        for (_, raw) in keys.iter() {
+            operators.push_back(BytesN::from_array(env, raw));
+        }
+        client.configure_emergency_multisig(admin, &operators, &2);
+        (keys, operators)
+    }
+
+    #[test]
+    fn test_configure_emergency_multisig_stores_operator_set() {
+        let (env, client, admin) = setup();
+        let (_keys, operators) = setup_emergency_multisig(&env, &client, &admin);
+
+        let config = client.get_emergency_multisig_config().unwrap();
+        assert_eq!(config.threshold, 2);
+        assert_eq!(config.operators.len(), 3);
+        assert_eq!(config.operators, operators);
+        assert_eq!(client.get_emergency_multisig_nonce(), 1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_configure_emergency_multisig_rejects_non_admin() {
+        let (env, client, _admin) = setup();
+        let attacker = Address::generate(&env);
+        let (_sk, pk) = emergency_multisig_keypair(1);
+        let mut operators: Vec<BytesN<32>> = Vec::new(&env);
+        operators.push_back(BytesN::from_array(&env, &pk));
+        client.configure_emergency_multisig(&attacker, &operators, &1);
+    }
+
+    #[test]
+    fn test_emergency_pause_multisig_halts_writes_without_admin_key() {
+        let (env, client, admin) = setup();
+        env.ledger().set_timestamp(1_000_000);
+        let (keys, _operators) = setup_emergency_multisig(&env, &client, &admin);
+
+        let nonce = client.get_emergency_multisig_nonce();
+        let message =
+            emergency_multisig::build_message(&env, &EmergencyAction::Pause, nonce);
+
+        let mut sigs: Vec<OperatorSignature> = Vec::new(&env);
+        for (sk, raw) in keys.iter().take(2) {
+            sigs.push_back(OperatorSignature {
+                operator: BytesN::from_array(&env, raw),
+                signature: emergency_multisig_sign(&env, sk, &message),
+            });
+        }
+
+        // No admin/caller identity is involved at all — approval comes purely
+        // from the verified operator signatures.
+        client.emergency_pause_multisig(&String::from_str(&env, "compromised admin key"), &sigs, &nonce);
+
+        assert!(client.is_paused());
+    }
+
+    #[test]
+    #[should_panic(expected = "contract is globally paused")]
+    fn test_emergency_pause_multisig_blocks_subsequent_writes() {
+        let (env, client, admin) = setup();
+        env.ledger().set_timestamp(1_000_000);
+        let (keys, _operators) = setup_emergency_multisig(&env, &client, &admin);
+
+        let nonce = client.get_emergency_multisig_nonce();
+        let message = emergency_multisig::build_message(&env, &EmergencyAction::Pause, nonce);
+        let mut sigs: Vec<OperatorSignature> = Vec::new(&env);
+        for (sk, raw) in keys.iter().take(2) {
+            sigs.push_back(OperatorSignature {
+                operator: BytesN::from_array(&env, raw),
+                signature: emergency_multisig_sign(&env, sk, &message),
+            });
+        }
+        client.emergency_pause_multisig(&String::from_str(&env, "incident"), &sigs, &nonce);
+
+        // Registering an asset while globally paused must fail — the
+        // multisig pause halts writes just like the single-admin path.
+        client.register_asset(&admin, &String::from_str(&env, "USDC"));
+    }
+
+    #[test]
+    fn test_unpause_emergency_multisig_recovers_without_timelock() {
+        let (env, client, admin) = setup();
+        env.ledger().set_timestamp(1_000_000);
+        let (keys, _operators) = setup_emergency_multisig(&env, &client, &admin);
+
+        let pause_nonce = client.get_emergency_multisig_nonce();
+        let pause_message =
+            emergency_multisig::build_message(&env, &EmergencyAction::Pause, pause_nonce);
+        let mut pause_sigs: Vec<OperatorSignature> = Vec::new(&env);
+        for (sk, raw) in keys.iter().take(2) {
+            pause_sigs.push_back(OperatorSignature {
+                operator: BytesN::from_array(&env, raw),
+                signature: emergency_multisig_sign(&env, sk, &pause_message),
+            });
+        }
+        client.emergency_pause_multisig(
+            &String::from_str(&env, "incident"),
+            &pause_sigs,
+            &pause_nonce,
+        );
+        assert!(client.is_paused());
+
+        // Recovery is available immediately — a fresh threshold of operator
+        // signatures is itself the safety control, unlike the single-admin
+        // `unpause()` path which additionally waits out a 24h timelock.
+        let unpause_nonce = client.get_emergency_multisig_nonce();
+        let unpause_message =
+            emergency_multisig::build_message(&env, &EmergencyAction::Unpause, unpause_nonce);
+        let mut unpause_sigs: Vec<OperatorSignature> = Vec::new(&env);
+        for (sk, raw) in keys.iter().take(2) {
+            unpause_sigs.push_back(OperatorSignature {
+                operator: BytesN::from_array(&env, raw),
+                signature: emergency_multisig_sign(&env, sk, &unpause_message),
+            });
+        }
+        client.unpause_emergency_multisig(
+            &String::from_str(&env, "resolved"),
+            &unpause_sigs,
+            &unpause_nonce,
+        );
+
+        assert!(!client.is_paused());
+    }
+
+    #[test]
+    fn test_set_mismatch_threshold_multisig_overrides_admin_path() {
+        let (env, client, admin) = setup();
+        env.ledger().set_timestamp(1_000_000);
+        let (keys, _operators) = setup_emergency_multisig(&env, &client, &admin);
+
+        let nonce = client.get_emergency_multisig_nonce();
+        let action = EmergencyAction::SetMismatchThreshold(42);
+        let message = emergency_multisig::build_message(&env, &action, nonce);
+
+        let mut sigs: Vec<OperatorSignature> = Vec::new(&env);
+        for (sk, raw) in keys.iter().take(2) {
+            sigs.push_back(OperatorSignature {
+                operator: BytesN::from_array(&env, raw),
+                signature: emergency_multisig_sign(&env, sk, &message),
+            });
+        }
+
+        client.set_mismatch_threshold_multisig(&42, &sigs, &nonce);
+
+        let bridge = String::from_str(&env, "CIRCLE_USDC");
+        let asset = String::from_str(&env, "USDC");
+        client.record_supply_mismatch(&bridge, &asset, &1_000_000, &1_005_000);
+        let m = client.get_supply_mismatches(&bridge).get(0).unwrap();
+        assert!(m.is_critical);
+    }
+
+    #[test]
+    #[should_panic(expected = "insufficient emergency multisig signatures")]
+    fn test_emergency_pause_multisig_rejects_below_threshold() {
+        let (env, client, admin) = setup();
+        let (keys, _operators) = setup_emergency_multisig(&env, &client, &admin);
+
+        let nonce = client.get_emergency_multisig_nonce();
+        let message =
+            emergency_multisig::build_message(&env, &EmergencyAction::Pause, nonce);
+        let mut sigs: Vec<OperatorSignature> = Vec::new(&env);
+        let (sk0, raw0) = &keys[0];
+        sigs.push_back(OperatorSignature {
+            operator: BytesN::from_array(&env, raw0),
+            signature: emergency_multisig_sign(&env, sk0, &message),
+        });
+
+        client.emergency_pause_multisig(&String::from_str(&env, "not enough sigs"), &sigs, &nonce);
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid emergency multisig nonce")]
+    fn test_emergency_pause_multisig_rejects_replayed_signatures() {
+        let (env, client, admin) = setup();
+        let (keys, _operators) = setup_emergency_multisig(&env, &client, &admin);
+
+        let nonce = client.get_emergency_multisig_nonce();
+        let message =
+            emergency_multisig::build_message(&env, &EmergencyAction::Pause, nonce);
+        let mut sigs: Vec<OperatorSignature> = Vec::new(&env);
+        for (sk, raw) in keys.iter().take(2) {
+            sigs.push_back(OperatorSignature {
+                operator: BytesN::from_array(&env, raw),
+                signature: emergency_multisig_sign(&env, sk, &message),
+            });
+        }
+
+        client.emergency_pause_multisig(&String::from_str(&env, "first"), &sigs, &nonce);
+        assert!(client.is_paused());
+        client.unpause(&admin, &String::from_str(&env, "not yet"));
+
+        // Replaying the exact same (already-consumed) nonce/signatures must
+        // be rejected even though the signatures were valid the first time.
+        client.emergency_pause_multisig(&String::from_str(&env, "replay"), &sigs, &nonce);
     }
 }


### PR DESCRIPTION
Closes #794 

### Problem
Emergency actions in Soroban monitoring contracts — `pause`, `unpause`, `set_thresholds`, `upgrade` — were single-key admin ops. If that key is compromised, an attacker can disable circuit breakers, pause indefinitely, or raise thresholds to bypass monitoring.

Off-chain multisig via a G-address was considered but does not enforce threshold on-chain; a compromised signer could still submit alone.

### Solution

**On-Chain Multisig Module — `contracts/monitor/src/multisig.rs`**

New storage structures:

```rust
struct MultisigConfig {
  operators: Vec<BytesN<32>>, // Ed25519 pubkeys
  threshold: u32, // e.g. 2-of-3, 3-of-5
  nonce: u64, // replay protection
}

enum EmergencyAction {
  Pause,
  Unpause,
  SetThreshold { key: Symbol, value: i128 },
  Upgrade { wasm_hash: BytesN<32> },
  UpdateOperators { new_operators: Vec<BytesN<32>>, new_threshold: u32 }
}