### PR TITLE
[codex] Fix Swagger schema drift for assets and alert history

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -58,7 +58,8 @@
     "prom-client": "^15.1.3",
     "telegraf": "^4.15.0",
     "uuid": "^14.0.0",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "zod-to-json-schema": "^3.24.6"
   },
   "devDependencies": {
     "@types/node": "^20.17.0",

--- a/backend/src/api/routes/alertHistory.routes.ts
+++ b/backend/src/api/routes/alertHistory.routes.ts
@@ -4,6 +4,13 @@ import {
   type RawAlertHistoryQuery,
 } from "../../services/alertHistorySearch.service.js";
 import { logger } from "../../utils/logger.js";
+import { validateRequest } from "../middleware/validation.js";
+import {
+  AlertHistoryRouteQuerySchema,
+  AlertHistorySuccessSchema,
+  ApiErrorSchema,
+  toOpenApiSchema,
+} from "../schemas/openapiSchemas.js";
 
 const service = new AlertHistorySearchService();
 
@@ -11,6 +18,18 @@ export async function alertHistoryRoutes(server: FastifyInstance) {
   // GET / — paginated, filtered search over historical alerts.
   server.get(
     "/",
+    {
+      preHandler: validateRequest({ query: AlertHistoryRouteQuerySchema }),
+      schema: {
+        tags: ["Alerts"],
+        summary: "Search alert history",
+        querystring: toOpenApiSchema(AlertHistoryRouteQuerySchema),
+        response: {
+          200: toOpenApiSchema(AlertHistorySuccessSchema),
+          400: toOpenApiSchema(ApiErrorSchema),
+        },
+      },
+    },
     async (
       request: FastifyRequest<{ Querystring: RawAlertHistoryQuery }>,
       reply: FastifyReply,
@@ -31,6 +50,18 @@ export async function alertHistoryRoutes(server: FastifyInstance) {
   // GET /export — same filters, returned as a CSV attachment.
   server.get(
     "/export",
+    {
+      preHandler: validateRequest({ query: AlertHistoryRouteQuerySchema }),
+      schema: {
+        tags: ["Alerts"],
+        summary: "Export alert history as CSV",
+        querystring: toOpenApiSchema(AlertHistoryRouteQuerySchema),
+        response: {
+          200: { type: "string", description: "CSV alert history export" },
+          400: toOpenApiSchema(ApiErrorSchema),
+        },
+      },
+    },
     async (
       request: FastifyRequest<{ Querystring: RawAlertHistoryQuery }>,
       reply: FastifyReply,

--- a/backend/src/api/routes/assets.ts
+++ b/backend/src/api/routes/assets.ts
@@ -4,6 +4,10 @@ import { LiquidityService } from "../../services/liquidity.service.js";
 import { PriceService } from "../../services/price.service.js";
 import { assetTagService } from "../../services/assetTag.service.js";
 import { authMiddleware } from "../middleware/auth.js";
+import {
+  AssetDetailsResponseSchema,
+  toOpenApiSchema,
+} from "../schemas/openapiSchemas.js";
 
 function getAuditActorType(source: "api-key" | "bootstrap" | undefined): "user" | "api_key" | "system" {
   if (source === "api-key") return "api_key";
@@ -53,13 +57,7 @@ export async function assetsRoutes(server: FastifyInstance) {
           required: ["symbol"],
         },
         response: {
-          200: {
-            type: "object",
-            properties: {
-              symbol: { type: "string" },
-              details: { nullable: true, type: "object", additionalProperties: true },
-            },
-          },
+          200: toOpenApiSchema(AssetDetailsResponseSchema),
           404: { $ref: "Error#" },
         },
       },

--- a/backend/src/api/schemas/openapiSchemas.ts
+++ b/backend/src/api/schemas/openapiSchemas.ts
@@ -1,0 +1,87 @@
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+export function toOpenApiSchema(schema: z.ZodTypeAny): Record<string, unknown> {
+  const jsonSchema = zodToJsonSchema(schema, {
+    $refStrategy: "none",
+    target: "openApi3",
+  }) as Record<string, unknown>;
+  delete jsonSchema.$schema;
+  return jsonSchema;
+}
+
+export const AssetMetadataSchema = z.object({
+  id: z.string().uuid(),
+  symbol: z.string(),
+  name: z.string(),
+  issuer: z.string().nullable(),
+  asset_type: z.enum(["native", "credit_alphanum4", "credit_alphanum12"]),
+  bridge_provider: z.string().nullable(),
+  source_chain: z.string().nullable(),
+  is_active: z.boolean(),
+  created_at: z.string().datetime(),
+  updated_at: z.string().datetime(),
+});
+
+export const AssetDetailsResponseSchema = z.object({
+  symbol: z.string(),
+  details: AssetMetadataSchema.nullable(),
+});
+
+const StringOrStringArraySchema = z.union([z.string(), z.array(z.string())]);
+const NumberOrNumericStringSchema = z.union([
+  z.number().int().positive(),
+  z.string().regex(/^\d+$/),
+]);
+
+export const AlertHistoryRouteQuerySchema = z.object({
+  from: z.string().datetime().optional(),
+  to: z.string().datetime().optional(),
+  severity: StringOrStringArraySchema.optional(),
+  source: StringOrStringArraySchema.optional(),
+  alertType: StringOrStringArraySchema.optional(),
+  q: z.string().optional(),
+  page: NumberOrNumericStringSchema.optional(),
+  pageSize: NumberOrNumericStringSchema.optional(),
+});
+
+export const AlertHistoryEventSchema = z.object({
+  time: z.string().datetime(),
+  rule_id: z.string().uuid(),
+  asset_code: z.string(),
+  alert_type: z.string(),
+  priority: z.string(),
+  triggered_value: z.union([z.string(), z.number()]),
+  threshold: z.union([z.string(), z.number()]),
+  metric: z.string(),
+  webhook_delivered: z.boolean(),
+  webhook_delivered_at: z.string().datetime().nullable(),
+  webhook_attempts: z.number().int(),
+  on_chain_event_id: z.union([z.string(), z.number()]).nullable(),
+  event_id: z.string().uuid(),
+  lifecycle_state: z.string(),
+  acknowledged_at: z.string().datetime().nullable(),
+  acknowledged_by: z.string().nullable(),
+  assigned_at: z.string().datetime().nullable(),
+  assigned_to: z.string().nullable(),
+  closed_at: z.string().datetime().nullable(),
+  closed_by: z.string().nullable(),
+  closure_note: z.string().nullable(),
+  updated_at: z.string().datetime(),
+});
+
+export const AlertHistorySuccessSchema = z.object({
+  success: z.literal(true),
+  data: z.object({
+    results: z.array(AlertHistoryEventSchema),
+    total: z.number().int().nonnegative(),
+    page: z.number().int().positive(),
+    pageSize: z.number().int().positive(),
+    totalPages: z.number().int().nonnegative(),
+  }),
+});
+
+export const ApiErrorSchema = z.object({
+  success: z.literal(false),
+  error: z.string(),
+});

--- a/backend/tests/api/openapiSchemas.test.ts
+++ b/backend/tests/api/openapiSchemas.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  AlertHistoryRouteQuerySchema,
+  AssetDetailsResponseSchema,
+  toOpenApiSchema,
+} from "../../src/api/schemas/openapiSchemas.js";
+
+function properties(schema: Record<string, unknown>): Record<string, unknown> {
+  return schema.properties as Record<string, unknown>;
+}
+
+describe("route OpenAPI schemas", () => {
+  it("documents nullable asset bridge metadata from the Zod response schema", () => {
+    const schema = toOpenApiSchema(AssetDetailsResponseSchema);
+    const details = properties(schema).details as Record<string, unknown>;
+    const detailSchema = (details.allOf as Record<string, unknown>[] | undefined)?.[0] ?? details;
+    const metadata = properties(detailSchema);
+
+    expect(JSON.stringify(metadata.bridge_provider)).toContain('"nullable":true');
+    expect(JSON.stringify(metadata.source_chain)).toContain('"nullable":true');
+    expect(JSON.stringify(metadata.issuer)).toContain('"nullable":true');
+  });
+
+  it("uses the live alert-history query names instead of stale aliases", () => {
+    const queryProperties = properties(toOpenApiSchema(AlertHistoryRouteQuerySchema));
+
+    expect(Object.keys(queryProperties)).toEqual(
+      expect.arrayContaining([
+        "from",
+        "to",
+        "severity",
+        "source",
+        "alertType",
+        "q",
+        "page",
+        "pageSize",
+      ]),
+    );
+    expect(queryProperties).not.toHaveProperty("assetCode");
+    expect(queryProperties).not.toHaveProperty("startDate");
+    expect(queryProperties).not.toHaveProperty("limit");
+  });
+
+  it("rejects malformed alert-history dates and page sizes", () => {
+    expect(
+      AlertHistoryRouteQuerySchema.safeParse({ from: "not-a-date", pageSize: "many" }).success,
+    ).toBe(false);
+    expect(
+      AlertHistoryRouteQuerySchema.safeParse({
+        from: "2026-01-01T00:00:00.000Z",
+        pageSize: "50",
+      }).success,
+    ).toBe(true);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,8 @@
         "prom-client": "^15.1.3",
         "telegraf": "^4.15.0",
         "uuid": "^14.0.0",
-        "zod": "^3.23.8"
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.24.6"
       },
       "devDependencies": {
         "@types/node": "^20.17.0",
@@ -185,6 +186,7 @@
       "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
@@ -321,6 +323,7 @@
       "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.6",
@@ -520,6 +523,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -980,6 +984,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -1029,7 +1034,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1047,7 +1051,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1065,7 +1068,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1083,7 +1085,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1101,7 +1102,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1119,7 +1119,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1137,7 +1136,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1155,7 +1153,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1173,7 +1170,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1191,7 +1187,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1209,7 +1204,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1227,7 +1221,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1245,7 +1238,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1263,7 +1255,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1281,7 +1272,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1299,7 +1289,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1317,7 +1306,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1335,7 +1323,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1353,7 +1340,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1371,7 +1357,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1389,7 +1374,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1407,7 +1391,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1425,7 +1408,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1443,7 +1425,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1461,7 +1442,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1479,7 +1459,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3980,6 +3959,7 @@
       "integrity": "sha512-AhvJsu5zl3uG40itSQVuSy5WByp3UVhS6xAnme4FWRwgSxhvZjATJ3AZkkHWOYjnnk+P2/sbz/XuPli1FVCWoQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@storybook/csf": "^0.1.11",
         "@storybook/global": "^5.0.0",
@@ -4004,6 +3984,7 @@
       "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -4614,6 +4595,7 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -4706,6 +4688,7 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -5109,6 +5092,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5655,6 +5639,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6249,6 +6234,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -6272,6 +6258,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6890,6 +6877,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -6973,6 +6961,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -7549,6 +7538,7 @@
       "integrity": "sha512-0DS4Nn4rV8qyFlQCpKK8brT61EUtswynrpfFTcgLErcilBIBskSMQ86fO2WVuybr14ywyKdRjv91FiRZwnEuvQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readline-sync": "^1.4.10",
         "sprintf-js": "^1.1.3",
@@ -8220,6 +8210,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.29.2"
       },
@@ -8377,6 +8368,7 @@
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.1.tgz",
       "integrity": "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ioredis/commands": "1.5.1",
         "cluster-key-slot": "^1.1.0",
@@ -8926,6 +8918,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -9695,6 +9688,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^5.0.0",
         "@mswjs/interceptors": "^0.41.2",
@@ -10537,6 +10531,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -10882,6 +10877,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -10939,6 +10935,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -11424,6 +11421,7 @@
       "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -11950,6 +11948,7 @@
       "integrity": "sha512-RP/nMJxiWyFc8EVMH5gp20ID032Wvk+Yr3lmKidoegto5Iy+2dVQnUoElZb2zpbVXNHWakGuAkfI0dY1Hfp/vw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@storybook/core": "8.4.7"
       },
@@ -12770,6 +12769,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12936,6 +12936,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -13445,6 +13446,7 @@
       "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "2.1.9",
         "@vitest/mocker": "2.1.9",
@@ -13973,8 +13975,18 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.24.6",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
+      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.24.1"
       }
     },
     "node_modules/zustand": {


### PR DESCRIPTION
## Summary
- derive asset metadata and alert-history OpenAPI schemas from shared Zod definitions
- document nullable asset issuer, bridge provider, and source chain fields correctly
- replace stale alert-history query names with the live route fields and validate requests against the same schema
- add regression tests for nullability, query names, and invalid values

## Validation
- `npm run test:unit -- tests/api/openapiSchemas.test.ts` (3 tests passed)
- `npm run build` in `backend/`
- `npm run docs:generate` is currently blocked on Windows by the repository logger transport throwing `DataCloneError` before server startup

Closes #825