### PR TITLE
[codex] Separate raw and aggregate TimescaleDB retention

### DIFF
--- a/backend/src/database/migrations/044_timescale_aggregate_retention.ts
+++ b/backend/src/database/migrations/044_timescale_aggregate_retention.ts
@@ -1,0 +1,77 @@
+import type { Knex } from "knex";
+
+export const RAW_RETENTION_DAYS = 90;
+export const AGGREGATE_RETENTION_DAYS = 365;
+
+export const RAW_HYPERTABLES = [
+  "prices",
+  "health_scores",
+  "liquidity_snapshots",
+] as const;
+
+export const CONTINUOUS_AGGREGATES = [
+  "prices_hourly",
+  "prices_daily",
+  "health_scores_hourly",
+  "health_scores_daily",
+  "liquidity_hourly",
+  "liquidity_daily",
+] as const;
+
+async function supportsRetentionPolicies(knex: Knex): Promise<boolean> {
+  const result = await knex.raw(`
+    SELECT EXISTS (
+      SELECT 1 FROM pg_proc WHERE proname = 'add_retention_policy'
+    ) AS supported
+  `);
+  return Boolean((result.rows?.[0] as { supported?: boolean } | undefined)?.supported);
+}
+
+async function relationExists(knex: Knex, relation: string): Promise<boolean> {
+  const result = await knex.raw("SELECT to_regclass(?) AS relation", [relation]);
+  return Boolean((result.rows?.[0] as { relation?: string | null } | undefined)?.relation);
+}
+
+async function replacePolicy(
+  knex: Knex,
+  relation: string,
+  retentionDays: number,
+): Promise<void> {
+  if (!(await relationExists(knex, relation))) return;
+
+  await knex.raw("SELECT remove_retention_policy(?, if_exists => TRUE)", [relation]);
+  await knex.raw(
+    `SELECT add_retention_policy(?, INTERVAL '${retentionDays} days', if_not_exists => TRUE)`,
+    [relation],
+  );
+}
+
+async function removePolicy(knex: Knex, relation: string): Promise<void> {
+  if (!(await relationExists(knex, relation))) return;
+  await knex.raw("SELECT remove_retention_policy(?, if_exists => TRUE)", [relation]);
+}
+
+/**
+ * Keep high-volume raw measurements for 90 days while preserving continuous
+ * aggregate history for one year. Policies are replaced explicitly so an
+ * installation with an older value converges to the configured windows.
+ */
+export async function up(knex: Knex): Promise<void> {
+  if (!(await supportsRetentionPolicies(knex))) return;
+
+  for (const table of RAW_HYPERTABLES) {
+    await replacePolicy(knex, table, RAW_RETENTION_DAYS);
+  }
+  for (const view of CONTINUOUS_AGGREGATES) {
+    await replacePolicy(knex, view, AGGREGATE_RETENTION_DAYS);
+  }
+}
+
+/** Restore the previous behavior: raw policies remain at 90 days and aggregate data is indefinite. */
+export async function down(knex: Knex): Promise<void> {
+  if (!(await supportsRetentionPolicies(knex))) return;
+
+  for (const view of CONTINUOUS_AGGREGATES) {
+    await removePolicy(knex, view);
+  }
+}

--- a/backend/tests/services/timescaleRetentionMigration.test.ts
+++ b/backend/tests/services/timescaleRetentionMigration.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Knex } from "knex";
+import {
+  AGGREGATE_RETENTION_DAYS,
+  CONTINUOUS_AGGREGATES,
+  RAW_HYPERTABLES,
+  RAW_RETENTION_DAYS,
+  down,
+  up,
+} from "../../src/database/migrations/044_timescale_aggregate_retention.js";
+
+function mockKnex(supported = true): { knex: Knex; raw: ReturnType<typeof vi.fn> } {
+  const raw = vi.fn(async (sql: string, bindings?: string[]) => {
+    if (sql.includes("FROM pg_proc")) return { rows: [{ supported }] };
+    if (sql.includes("to_regclass")) return { rows: [{ relation: bindings?.[0] ?? null }] };
+    return { rows: [] };
+  });
+  return { knex: { raw } as unknown as Knex, raw };
+}
+
+function addPolicyCalls(raw: ReturnType<typeof vi.fn>) {
+  return raw.mock.calls.filter(([sql]) =>
+    String(sql).includes("SELECT add_retention_policy(?"),
+  );
+}
+
+describe("TimescaleDB aggregate retention migration", () => {
+  it("keeps raw data for 90 days and aggregate data for 365 days", async () => {
+    const { knex, raw } = mockKnex();
+
+    await up(knex);
+
+    const calls = addPolicyCalls(raw);
+    for (const table of RAW_HYPERTABLES) {
+      expect(calls).toContainEqual([
+        expect.stringContaining(`INTERVAL '${RAW_RETENTION_DAYS} days'`),
+        [table],
+      ]);
+    }
+    for (const view of CONTINUOUS_AGGREGATES) {
+      expect(calls).toContainEqual([
+        expect.stringContaining(`INTERVAL '${AGGREGATE_RETENTION_DAYS} days'`),
+        [view],
+      ]);
+      expect(calls).not.toContainEqual([
+        expect.stringContaining(`INTERVAL '${RAW_RETENTION_DAYS} days'`),
+        [view],
+      ]);
+    }
+  });
+
+  it("is a no-op when TimescaleDB retention functions are unavailable", async () => {
+    const { knex, raw } = mockKnex(false);
+
+    await up(knex);
+
+    expect(raw).toHaveBeenCalledOnce();
+    expect(addPolicyCalls(raw)).toHaveLength(0);
+  });
+
+  it("removes only aggregate policies on rollback", async () => {
+    const { knex, raw } = mockKnex();
+
+    await down(knex);
+
+    const removals = raw.mock.calls.filter(([sql]) =>
+      String(sql).includes("remove_retention_policy"),
+    );
+    expect(removals.map(([, bindings]) => bindings?.[0])).toEqual(
+      CONTINUOUS_AGGREGATES,
+    );
+    expect(removals.map(([, bindings]) => bindings?.[0])).not.toEqual(
+      expect.arrayContaining(RAW_HYPERTABLES),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a reversible TimescaleDB migration that keeps raw price, health, and liquidity hypertables for 90 days
- apply independent 365-day policies to hourly and daily continuous aggregates
- safely skip missing relations and installations without TimescaleDB retention support
- add migration tests for policy windows, graceful no-op behavior, and rollback scope

## Validation
- `npm run test:unit --workspace=backend -- tests/services/timescaleRetentionMigration.test.ts` (3 tests passed)
- `npm run build --workspace=backend`
- `npm run migrate:validate --workspace=backend` is blocked on Windows by the repository logger transport throwing `DataCloneError` before validation starts

Closes #821