### PR TITLE
feat: add dynamic anomaly tuning profiles

### DIFF
--- a/backend/src/api/routes/anomalyTuning.routes.ts
+++ b/backend/src/api/routes/anomalyTuning.routes.ts
@@ -1,0 +1,133 @@
+import type { FastifyInstance } from "fastify";
+import type { AnomalyType } from "../../database/models/anomaly.model.js";
+import { anomalyDetectionService } from "../../services/anomalyDetection.service.js";
+import { authMiddleware } from "../middleware/auth.js";
+
+const anomalyTypes = ["*", "spike", "drop", "divergence", "bridge_health", "multi_signal"] as const;
+
+export async function anomalyTuningRoutes(server: FastifyInstance) {
+  const requireAdmin = authMiddleware({ requiredScopes: ["admin:config"] });
+
+  server.get(
+    "/tuning",
+    {
+      preHandler: requireAdmin,
+      schema: {
+        tags: ["Anomaly Detection"],
+        summary: "Get the active anomaly baseline tuning profile",
+        security: [{ ApiKeyAuth: [] }],
+        response: { 200: { type: "object", additionalProperties: true } },
+      },
+    },
+    async () => {
+      const [profile, overrides] = await Promise.all([
+        anomalyDetectionService.getTuningProfile(),
+        anomalyDetectionService.getTuningOverrides(),
+      ]);
+      return { profile, overrides };
+    }
+  );
+
+  server.put<{
+    Body: { deviationMultiplier: number; slidingWindowSize: number };
+  }>(
+    "/tuning",
+    {
+      preHandler: requireAdmin,
+      schema: {
+        tags: ["Anomaly Detection"],
+        summary: "Update the active anomaly baseline tuning profile",
+        security: [{ ApiKeyAuth: [] }],
+        body: {
+          type: "object",
+          additionalProperties: false,
+          required: ["deviationMultiplier", "slidingWindowSize"],
+          properties: {
+            deviationMultiplier: { type: "number", exclusiveMinimum: 0, maximum: 20 },
+            slidingWindowSize: { type: "integer", minimum: 3, maximum: 1000 },
+          },
+        },
+        response: { 200: { type: "object", additionalProperties: true } },
+      },
+    },
+    async (request) => {
+      const profile = await anomalyDetectionService.updateTuningProfile({
+        ...request.body,
+        updatedBy: request.apiKeyAuth?.name ?? null,
+      });
+      return { profile };
+    }
+  );
+
+  server.post<{
+    Body: {
+      anomalyType?: AnomalyType | "*";
+      assetCode?: string;
+      bridgeName?: string;
+      reason: string;
+      startsAt?: string;
+      expiresAt: string;
+    };
+  }>(
+    "/tuning/overrides",
+    {
+      preHandler: requireAdmin,
+      schema: {
+        tags: ["Anomaly Detection"],
+        summary: "Temporarily silence matching anomaly detections",
+        security: [{ ApiKeyAuth: [] }],
+        body: {
+          type: "object",
+          additionalProperties: false,
+          required: ["reason", "expiresAt"],
+          properties: {
+            anomalyType: { type: "string", enum: [...anomalyTypes], default: "*" },
+            assetCode: { type: "string", minLength: 1, default: "*" },
+            bridgeName: { type: "string", minLength: 1, default: "*" },
+            reason: { type: "string", minLength: 3, maxLength: 500 },
+            startsAt: { type: "string", format: "date-time" },
+            expiresAt: { type: "string", format: "date-time" },
+          },
+        },
+        response: { 201: { type: "object", additionalProperties: true } },
+      },
+    },
+    async (request, reply) => {
+      const startsAt = request.body.startsAt ? new Date(request.body.startsAt) : new Date();
+      const expiresAt = new Date(request.body.expiresAt);
+      if (expiresAt <= startsAt) {
+        return reply.code(400).send({ error: "expiresAt must be later than startsAt" });
+      }
+
+      const override = await anomalyDetectionService.createTuningOverride({
+        ...request.body,
+        startsAt,
+        expiresAt,
+        createdBy: request.apiKeyAuth?.name ?? null,
+      });
+      return reply.code(201).send({ override });
+    }
+  );
+
+  server.delete<{ Params: { id: string } }>(
+    "/tuning/overrides/:id",
+    {
+      preHandler: requireAdmin,
+      schema: {
+        tags: ["Anomaly Detection"],
+        summary: "Remove an anomaly tuning override",
+        security: [{ ApiKeyAuth: [] }],
+        params: {
+          type: "object",
+          required: ["id"],
+          properties: { id: { type: "string", format: "uuid" } },
+        },
+      },
+    },
+    async (request, reply) => {
+      const deleted = await anomalyDetectionService.deleteTuningOverride(request.params.id);
+      if (!deleted) return reply.code(404).send({ error: "Tuning override not found" });
+      return reply.code(204).send();
+    }
+  );
+}

--- a/backend/src/api/routes/index.ts
+++ b/backend/src/api/routes/index.ts
@@ -69,6 +69,7 @@ import { providerAllowlistRoutes } from "./providerAllowlist.routes.js";
 import { providerAllowlistAdminRoutes } from "./providerAllowlistAdmin.routes.js";
 import { provenanceRoutes } from "./provenance.routes.js";
 import { anomalyDetectionRoutes } from "./anomalyDetection.routes.js";
+import { anomalyTuningRoutes } from "./anomalyTuning.routes.js";
 import { liquidityFragmentationRoutes } from "./liquidityFragmentation.routes.js";
 import { operationalAccessAuditRoutes } from "./operationalAccessAudit.js";
 import { ownershipMatrixRoutes } from "./ownershipMatrix.js";
@@ -187,6 +188,7 @@ export async function registerRoutes(server: FastifyInstance) {
   });
   server.register(provenanceRoutes, { prefix: "/api/v1/provenance" });
   server.register(anomalyDetectionRoutes, { prefix: "/api/v1/anomaly-detection" });
+  server.register(anomalyTuningRoutes, { prefix: "/api/v1/anomaly" });
   server.register(liquidityFragmentationRoutes, { prefix: "/api/v1" });
   server.register(operationalAccessAuditRoutes, {
     prefix: "/api/v1/admin/access-audit",

--- a/backend/src/database/migrations/044_anomaly_tuning_profiles.ts
+++ b/backend/src/database/migrations/044_anomaly_tuning_profiles.ts
@@ -1,0 +1,45 @@
+import type { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable("anomaly_tuning_profiles", (table) => {
+    table.uuid("id").primary().defaultTo(knex.raw("gen_random_uuid()"));
+    table.string("name").notNullable().unique();
+    table.decimal("deviation_multiplier", 8, 3).notNullable().defaultTo(3);
+    table.integer("sliding_window_size").notNullable().defaultTo(20);
+    table.boolean("is_active").notNullable().defaultTo(false);
+    table.string("updated_by").nullable();
+    table.timestamps(true, true);
+
+    table.check("deviation_multiplier > 0");
+    table.check("sliding_window_size >= 3 AND sliding_window_size <= 1000");
+    table.index(["is_active"]);
+  });
+
+  await knex.schema.createTable("anomaly_tuning_overrides", (table) => {
+    table.uuid("id").primary().defaultTo(knex.raw("gen_random_uuid()"));
+    table.string("anomaly_type").notNullable().defaultTo("*");
+    table.string("asset_code").notNullable().defaultTo("*");
+    table.string("bridge_name").notNullable().defaultTo("*");
+    table.text("reason").notNullable();
+    table.timestamp("starts_at").notNullable().defaultTo(knex.fn.now());
+    table.timestamp("expires_at").notNullable();
+    table.string("created_by").nullable();
+    table.timestamp("created_at").notNullable().defaultTo(knex.fn.now());
+
+    table.check("expires_at > starts_at");
+    table.index(["starts_at", "expires_at"]);
+    table.index(["asset_code", "bridge_name", "anomaly_type"]);
+  });
+
+  await knex("anomaly_tuning_profiles").insert({
+    name: "default",
+    deviation_multiplier: 3,
+    sliding_window_size: 20,
+    is_active: true,
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists("anomaly_tuning_overrides");
+  await knex.schema.dropTableIfExists("anomaly_tuning_profiles");
+}

--- a/backend/src/database/models/anomaly.model.ts
+++ b/backend/src/database/models/anomaly.model.ts
@@ -42,6 +42,29 @@ export interface AnomalyEventFilters {
   limit?: number;
 }
 
+export interface AnomalyTuningProfileRecord {
+  id?: string;
+  name: string;
+  deviation_multiplier: number;
+  sliding_window_size: number;
+  is_active: boolean;
+  updated_by: string | null;
+  created_at?: Date;
+  updated_at?: Date;
+}
+
+export interface AnomalyTuningOverrideRecord {
+  id?: string;
+  anomaly_type: AnomalyType | "*";
+  asset_code: string;
+  bridge_name: string;
+  reason: string;
+  starts_at: Date;
+  expires_at: Date;
+  created_by: string | null;
+  created_at?: Date;
+}
+
 export class AnomalyModel {
   private db = getDatabase();
 
@@ -106,6 +129,61 @@ export class AnomalyModel {
     return rows.map(this.mapEvent);
   }
 
+  async getActiveTuningProfile(): Promise<AnomalyTuningProfileRecord> {
+    const row = await this.db("anomaly_tuning_profiles").where({ is_active: true }).orderBy("updated_at", "desc").first();
+    if (!row) {
+      throw new Error("No active anomaly tuning profile is configured");
+    }
+    return this.mapTuningProfile(row);
+  }
+
+  async updateActiveTuningProfile(
+    input: Pick<AnomalyTuningProfileRecord, "deviation_multiplier" | "sliding_window_size" | "updated_by">
+  ): Promise<AnomalyTuningProfileRecord> {
+    const active = await this.getActiveTuningProfile();
+    const [row] = await this.db("anomaly_tuning_profiles")
+      .where({ id: active.id })
+      .update({ ...input, updated_at: this.db.fn.now() })
+      .returning("*");
+    return this.mapTuningProfile(row);
+  }
+
+  async createTuningOverride(
+    input: Omit<AnomalyTuningOverrideRecord, "id" | "created_at">
+  ): Promise<AnomalyTuningOverrideRecord> {
+    const [row] = await this.db("anomaly_tuning_overrides").insert(input).returning("*");
+    return this.mapTuningOverride(row);
+  }
+
+  async getActiveTuningOverrides(at = new Date()): Promise<AnomalyTuningOverrideRecord[]> {
+    const rows = await this.db("anomaly_tuning_overrides")
+      .where("starts_at", "<=", at)
+      .andWhere("expires_at", ">", at)
+      .orderBy("expires_at", "asc");
+    return rows.map(this.mapTuningOverride);
+  }
+
+  async findActiveTuningOverride(
+    anomalyType: AnomalyType,
+    assetCode: string,
+    bridgeName: string | null,
+    at = new Date()
+  ): Promise<AnomalyTuningOverrideRecord | undefined> {
+    const row = await this.db("anomaly_tuning_overrides")
+      .where("starts_at", "<=", at)
+      .andWhere("expires_at", ">", at)
+      .whereIn("anomaly_type", ["*", anomalyType])
+      .whereIn("asset_code", ["*", assetCode.toUpperCase()])
+      .whereIn("bridge_name", ["*", bridgeName ?? "*"])
+      .orderBy("expires_at", "desc")
+      .first();
+    return row ? this.mapTuningOverride(row) : undefined;
+  }
+
+  async deleteTuningOverride(id: string): Promise<boolean> {
+    return (await this.db("anomaly_tuning_overrides").where({ id }).delete()) > 0;
+  }
+
   private mapThreshold(row: any): AnomalyThresholdRecord {
     return {
       id: row.id,
@@ -138,6 +216,33 @@ export class AnomalyModel {
       suppressed_until: row.suppressed_until ? new Date(row.suppressed_until) : null,
       is_suppressed: Boolean(row.is_suppressed),
       suppressed_by_event_id: row.suppressed_by_event_id,
+    };
+  }
+
+  private mapTuningProfile(row: any): AnomalyTuningProfileRecord {
+    return {
+      id: row.id,
+      name: row.name,
+      deviation_multiplier: Number(row.deviation_multiplier),
+      sliding_window_size: Number(row.sliding_window_size),
+      is_active: Boolean(row.is_active),
+      updated_by: row.updated_by ?? null,
+      created_at: row.created_at ? new Date(row.created_at) : undefined,
+      updated_at: row.updated_at ? new Date(row.updated_at) : undefined,
+    };
+  }
+
+  private mapTuningOverride(row: any): AnomalyTuningOverrideRecord {
+    return {
+      id: row.id,
+      anomaly_type: row.anomaly_type,
+      asset_code: row.asset_code,
+      bridge_name: row.bridge_name,
+      reason: row.reason,
+      starts_at: new Date(row.starts_at),
+      expires_at: new Date(row.expires_at),
+      created_by: row.created_by ?? null,
+      created_at: row.created_at ? new Date(row.created_at) : undefined,
     };
   }
 }

--- a/backend/src/services/anomalyDetection.service.ts
+++ b/backend/src/services/anomalyDetection.service.ts
@@ -5,6 +5,8 @@ import {
   type AnomalyEventRecord,
   type AnomalySeverity,
   type AnomalyThresholdRecord,
+  type AnomalyTuningOverrideRecord,
+  type AnomalyTuningProfileRecord,
   type AnomalyType,
 } from "../database/models/anomaly.model.js";
 import { logger } from "../utils/logger.js";
@@ -55,6 +57,21 @@ interface PreviousSnapshot {
   healthScore?: number;
 }
 
+export interface BaselineDeviation {
+  mean: number;
+  standardDeviation: number;
+  score: number;
+}
+
+export function calculateBaselineDeviation(values: number[], current: number): BaselineDeviation | null {
+  if (values.length < 3) return null;
+  const mean = values.reduce((sum, value) => sum + value, 0) / values.length;
+  const variance = values.reduce((sum, value) => sum + (value - mean) ** 2, 0) / values.length;
+  const standardDeviation = Math.sqrt(variance);
+  if (standardDeviation === 0) return null;
+  return { mean, standardDeviation, score: (current - mean) / standardDeviation };
+}
+
 const SEVERITY_WEIGHT: Record<AnomalySeverity, number> = {
   low: 1,
   medium: 2,
@@ -68,7 +85,7 @@ export class AnomalyDetectionService {
   private liquidityService = new LiquidityService();
   private healthService = new HealthService();
   private bridgeService = new BridgeService();
-  private previousSnapshots = new Map<string, PreviousSnapshot>();
+  private snapshotHistory = new Map<string, PreviousSnapshot[]>();
 
   async evaluateAllAssets(): Promise<AnomalyDetectionResult[]> {
     const bridgeStatuses = await this.bridgeService.getAllBridgeStatuses();
@@ -86,14 +103,17 @@ export class AnomalyDetectionService {
   async evaluateAsset(assetCode: string, bridgeName?: string): Promise<AnomalyDetectionResult> {
     const normalizedAsset = assetCode.toUpperCase();
     const snapshot = await this.collectSnapshot(normalizedAsset, bridgeName);
-    const thresholds = await this.model.getActiveThresholds();
+    const [thresholds, tuning] = await Promise.all([
+      this.model.getActiveThresholds(),
+      this.model.getActiveTuningProfile(),
+    ]);
     const threshold = this.resolveThreshold(thresholds, normalizedAsset, snapshot.bridge?.name ?? bridgeName ?? "*");
-    const signals = this.detectSignals(snapshot, threshold);
+    const signals = this.detectSignals(snapshot, threshold, tuning);
     const type = this.resolveType(signals);
     const severity = this.resolveSeverity(signals, threshold);
     const explanation = this.buildExplanation(normalizedAsset, snapshot.bridge?.name ?? bridgeName ?? null, signals, threshold);
 
-    this.rememberSnapshot(normalizedAsset, snapshot);
+    this.rememberSnapshot(normalizedAsset, snapshot, tuning.sliding_window_size);
 
     if (signals.length < threshold.min_signal_count) {
       return {
@@ -107,9 +127,15 @@ export class AnomalyDetectionService {
 
     const fingerprint = this.fingerprint(normalizedAsset, snapshot.bridge?.name ?? bridgeName ?? null, signals);
     const duplicateSince = new Date(Date.now() - threshold.duplicate_window_seconds * 1000);
-    const duplicate = await this.model.findRecentFingerprint(fingerprint, duplicateSince);
     const now = new Date();
-    const suppressedUntil = new Date(now.getTime() + threshold.duplicate_window_seconds * 1000);
+    const activeOverride = await this.model.findActiveTuningOverride(
+      type,
+      normalizedAsset,
+      snapshot.bridge?.name ?? bridgeName ?? null,
+      now
+    );
+    const duplicate = activeOverride ? undefined : await this.model.findRecentFingerprint(fingerprint, duplicateSince);
+    const suppressedUntil = activeOverride?.expires_at ?? new Date(now.getTime() + threshold.duplicate_window_seconds * 1000);
     const event = await this.model.insertEvent({
       asset_code: normalizedAsset,
       bridge_name: snapshot.bridge?.name ?? bridgeName ?? null,
@@ -119,6 +145,11 @@ export class AnomalyDetectionService {
       explanation,
       metadata: {
         thresholdId: threshold.id ?? null,
+        tuningProfileId: tuning.id ?? null,
+        deviationMultiplier: tuning.deviation_multiplier,
+        slidingWindowSize: tuning.sliding_window_size,
+        tuningOverrideId: activeOverride?.id ?? null,
+        tuningOverrideReason: activeOverride?.reason ?? null,
         priceLastUpdated: snapshot.price?.lastUpdated ?? null,
         liquidityLastUpdated: snapshot.liquidity?.lastUpdated ?? null,
         healthLastUpdated: snapshot.health?.lastUpdated ?? null,
@@ -126,8 +157,8 @@ export class AnomalyDetectionService {
       },
       fingerprint,
       detected_at: now,
-      suppressed_until: duplicate ? suppressedUntil : null,
-      is_suppressed: Boolean(duplicate),
+      suppressed_until: duplicate || activeOverride ? suppressedUntil : null,
+      is_suppressed: Boolean(duplicate || activeOverride),
       suppressed_by_event_id: duplicate?.id ?? null,
     });
 
@@ -162,6 +193,50 @@ export class AnomalyDetectionService {
     });
   }
 
+  getTuningProfile() {
+    return this.model.getActiveTuningProfile();
+  }
+
+  updateTuningProfile(input: {
+    deviationMultiplier: number;
+    slidingWindowSize: number;
+    updatedBy: string | null;
+  }) {
+    return this.model.updateActiveTuningProfile({
+      deviation_multiplier: input.deviationMultiplier,
+      sliding_window_size: input.slidingWindowSize,
+      updated_by: input.updatedBy,
+    });
+  }
+
+  getTuningOverrides() {
+    return this.model.getActiveTuningOverrides();
+  }
+
+  createTuningOverride(input: {
+    anomalyType?: AnomalyType | "*";
+    assetCode?: string;
+    bridgeName?: string;
+    reason: string;
+    startsAt?: Date;
+    expiresAt: Date;
+    createdBy: string | null;
+  }): Promise<AnomalyTuningOverrideRecord> {
+    return this.model.createTuningOverride({
+      anomaly_type: input.anomalyType ?? "*",
+      asset_code: input.assetCode?.toUpperCase() ?? "*",
+      bridge_name: input.bridgeName ?? "*",
+      reason: input.reason,
+      starts_at: input.startsAt ?? new Date(),
+      expires_at: input.expiresAt,
+      created_by: input.createdBy,
+    });
+  }
+
+  deleteTuningOverride(id: string) {
+    return this.model.deleteTuningOverride(id);
+  }
+
   private async collectSnapshot(assetCode: string, bridgeName?: string): Promise<DetectionSnapshot> {
     const [priceResult, liquidityResult, healthResult, bridgeResult] = await Promise.allSettled([
       this.priceService.getAggregatedPrice(assetCode),
@@ -184,11 +259,29 @@ export class AnomalyDetectionService {
     };
   }
 
-  private detectSignals(snapshot: DetectionSnapshot, threshold: AnomalyThresholdRecord): DetectionSignal[] {
+  private detectSignals(
+    snapshot: DetectionSnapshot,
+    threshold: AnomalyThresholdRecord,
+    tuning: AnomalyTuningProfileRecord
+  ): DetectionSignal[] {
     const signals: DetectionSignal[] = [];
-    const previous = this.previousSnapshots.get(snapshot.assetCode);
+    const history = (this.snapshotHistory.get(snapshot.assetCode) ?? []).slice(-tuning.sliding_window_size);
+    const previous = history.at(-1);
 
-    if (snapshot.price && previous?.price && previous.price > 0) {
+    const priceBaseline = snapshot.price
+      ? calculateBaselineDeviation(history.flatMap((item) => item.price === undefined ? [] : [item.price]), snapshot.price.vwap)
+      : null;
+    if (snapshot.price && priceBaseline && Math.abs(priceBaseline.score) >= tuning.deviation_multiplier) {
+      signals.push({
+        type: "price",
+        direction: priceBaseline.score > 0 ? "spike" : "drop",
+        metric: "vwap_baseline_deviation",
+        current: snapshot.price.vwap,
+        previous: Number(priceBaseline.mean.toFixed(6)),
+        threshold: `${tuning.deviation_multiplier} standard deviations`,
+        delta: Number(priceBaseline.score.toFixed(4)),
+      });
+    } else if (snapshot.price && previous?.price && previous.price > 0) {
       const delta = ((snapshot.price.vwap - previous.price) / previous.price) * 100;
       if (Math.abs(delta) >= threshold.price_change_pct) {
         signals.push({
@@ -213,7 +306,23 @@ export class AnomalyDetectionService {
       });
     }
 
-    if (snapshot.liquidity && previous?.liquidity && previous.liquidity > 0) {
+    const liquidityBaseline = snapshot.liquidity
+      ? calculateBaselineDeviation(
+          history.flatMap((item) => item.liquidity === undefined ? [] : [item.liquidity]),
+          snapshot.liquidity.totalLiquidity
+        )
+      : null;
+    if (snapshot.liquidity && liquidityBaseline && Math.abs(liquidityBaseline.score) >= tuning.deviation_multiplier) {
+      signals.push({
+        type: "liquidity",
+        direction: liquidityBaseline.score > 0 ? "spike" : "drop",
+        metric: "total_liquidity_baseline_deviation",
+        current: snapshot.liquidity.totalLiquidity,
+        previous: Number(liquidityBaseline.mean.toFixed(6)),
+        threshold: `${tuning.deviation_multiplier} standard deviations`,
+        delta: Number(liquidityBaseline.score.toFixed(4)),
+      });
+    } else if (snapshot.liquidity && previous?.liquidity && previous.liquidity > 0) {
       const delta = ((snapshot.liquidity.totalLiquidity - previous.liquidity) / previous.liquidity) * 100;
       if (Math.abs(delta) >= threshold.liquidity_change_pct) {
         signals.push({
@@ -331,12 +440,14 @@ export class AnomalyDetectionService {
     };
   }
 
-  private rememberSnapshot(assetCode: string, snapshot: DetectionSnapshot): void {
-    this.previousSnapshots.set(assetCode, {
+  private rememberSnapshot(assetCode: string, snapshot: DetectionSnapshot, windowSize: number): void {
+    const history = this.snapshotHistory.get(assetCode) ?? [];
+    history.push({
       price: snapshot.price?.vwap,
       liquidity: snapshot.liquidity?.totalLiquidity,
       healthScore: snapshot.health?.overallScore,
     });
+    this.snapshotHistory.set(assetCode, history.slice(-windowSize));
   }
 
   private fingerprint(assetCode: string, bridgeName: string | null, signals: DetectionSignal[]): string {

--- a/backend/tests/services/anomalyTuning.test.ts
+++ b/backend/tests/services/anomalyTuning.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { calculateBaselineDeviation } from "../../src/services/anomalyDetection.service.js";
+
+describe("anomaly baseline tuning", () => {
+  it("calculates the rolling mean and deviation score", () => {
+    const result = calculateBaselineDeviation([8, 10, 12], 14);
+
+    expect(result?.mean).toBe(10);
+    expect(result?.standardDeviation).toBeCloseTo(1.633, 3);
+    expect(result?.score).toBeCloseTo(2.449, 3);
+  });
+
+  it("waits for at least three observations", () => {
+    expect(calculateBaselineDeviation([10, 12], 20)).toBeNull();
+  });
+
+  it("does not flag a constant baseline with zero variance", () => {
+    expect(calculateBaselineDeviation([10, 10, 10], 12)).toBeNull();
+  });
+});

--- a/frontend/src/components/AnomalyTuningPanel.tsx
+++ b/frontend/src/components/AnomalyTuningPanel.tsx
@@ -1,0 +1,170 @@
+import { FormEvent, useState } from "react";
+import {
+  createAnomalyTuningOverride,
+  deleteAnomalyTuningOverride,
+  getAnomalyTuning,
+  updateAnomalyTuning,
+  type AnomalyTuningOverride,
+  type AnomalyTuningProfile,
+} from "../services/api";
+
+function defaultExpiry(): string {
+  const date = new Date(Date.now() + 60 * 60 * 1000);
+  date.setSeconds(0, 0);
+  return new Date(date.getTime() - date.getTimezoneOffset() * 60_000).toISOString().slice(0, 16);
+}
+
+export default function AnomalyTuningPanel() {
+  const [apiKey, setApiKey] = useState("");
+  const [profile, setProfile] = useState<AnomalyTuningProfile | null>(null);
+  const [overrides, setOverrides] = useState<AnomalyTuningOverride[]>([]);
+  const [deviationMultiplier, setDeviationMultiplier] = useState(3);
+  const [slidingWindowSize, setSlidingWindowSize] = useState(20);
+  const [assetCode, setAssetCode] = useState("*");
+  const [reason, setReason] = useState("");
+  const [expiresAt, setExpiresAt] = useState(defaultExpiry);
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const load = async () => {
+    setBusy(true);
+    setMessage(null);
+    try {
+      const data = await getAnomalyTuning(apiKey);
+      setProfile(data.profile);
+      setOverrides(data.overrides);
+      setDeviationMultiplier(data.profile.deviation_multiplier);
+      setSlidingWindowSize(data.profile.sliding_window_size);
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "Unable to load anomaly tuning");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const saveProfile = async (event: FormEvent) => {
+    event.preventDefault();
+    setBusy(true);
+    setMessage(null);
+    try {
+      const data = await updateAnomalyTuning(apiKey, { deviationMultiplier, slidingWindowSize });
+      setProfile(data.profile);
+      setMessage("Tuning profile updated.");
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "Unable to update anomaly tuning");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const createOverride = async (event: FormEvent) => {
+    event.preventDefault();
+    setBusy(true);
+    setMessage(null);
+    try {
+      const data = await createAnomalyTuningOverride(apiKey, {
+        assetCode: assetCode.trim() || "*",
+        reason,
+        expiresAt: new Date(expiresAt).toISOString(),
+      });
+      setOverrides((current) => [...current, data.override]);
+      setReason("");
+      setMessage("Temporary silence created.");
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "Unable to create temporary silence");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const removeOverride = async (id: string) => {
+    setBusy(true);
+    setMessage(null);
+    try {
+      await deleteAnomalyTuningOverride(apiKey, id);
+      setOverrides((current) => current.filter((override) => override.id !== id));
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "Unable to remove temporary silence");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <section className="rounded-lg border border-stellar-border bg-stellar-card p-6" aria-labelledby="anomaly-tuning-title">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <h2 id="anomaly-tuning-title" className="text-xl font-semibold text-white">Anomaly Detection Tuning</h2>
+          <p className="mt-1 text-sm text-stellar-text-secondary">
+            Adjust rolling baselines and schedule temporary silences. Admin configuration scope is required.
+          </p>
+        </div>
+        <div className="flex w-full gap-2 lg:w-auto">
+          <input
+            type="password"
+            value={apiKey}
+            onChange={(event) => setApiKey(event.target.value)}
+            placeholder="Admin API key"
+            aria-label="Admin API key"
+            className="min-w-0 flex-1 rounded-md border border-stellar-border bg-stellar-dark px-3 py-2 text-white lg:w-64"
+          />
+          <button type="button" onClick={load} disabled={!apiKey || busy} className="rounded-md bg-stellar-blue px-4 py-2 font-medium text-white disabled:opacity-50">
+            Load
+          </button>
+        </div>
+      </div>
+
+      {message && <p className="mt-4 text-sm text-stellar-text-secondary" role="status">{message}</p>}
+
+      {profile && (
+        <div className="mt-6 grid gap-6 xl:grid-cols-2">
+          <form onSubmit={saveProfile} className="space-y-4 rounded-md border border-stellar-border p-4">
+            <h3 className="font-semibold text-white">Rolling baseline</h3>
+            <label className="block text-sm text-stellar-text-secondary">
+              Deviation multiplier
+              <input type="number" min="0.1" max="20" step="0.1" value={deviationMultiplier} onChange={(event) => setDeviationMultiplier(Number(event.target.value))} className="mt-1 w-full rounded-md border border-stellar-border bg-stellar-dark px-3 py-2 text-white" />
+            </label>
+            <label className="block text-sm text-stellar-text-secondary">
+              Sliding window (observations)
+              <input type="number" min="3" max="1000" value={slidingWindowSize} onChange={(event) => setSlidingWindowSize(Number(event.target.value))} className="mt-1 w-full rounded-md border border-stellar-border bg-stellar-dark px-3 py-2 text-white" />
+            </label>
+            <button disabled={busy} className="rounded-md bg-stellar-blue px-4 py-2 font-medium text-white disabled:opacity-50">Save tuning</button>
+          </form>
+
+          <form onSubmit={createOverride} className="space-y-4 rounded-md border border-stellar-border p-4">
+            <h3 className="font-semibold text-white">Temporary silence</h3>
+            <label className="block text-sm text-stellar-text-secondary">
+              Asset code (* for all)
+              <input value={assetCode} onChange={(event) => setAssetCode(event.target.value.toUpperCase())} className="mt-1 w-full rounded-md border border-stellar-border bg-stellar-dark px-3 py-2 text-white" />
+            </label>
+            <label className="block text-sm text-stellar-text-secondary">
+              Expires at
+              <input type="datetime-local" required value={expiresAt} onChange={(event) => setExpiresAt(event.target.value)} className="mt-1 w-full rounded-md border border-stellar-border bg-stellar-dark px-3 py-2 text-white" />
+            </label>
+            <label className="block text-sm text-stellar-text-secondary">
+              Reason
+              <input required minLength={3} maxLength={500} value={reason} onChange={(event) => setReason(event.target.value)} className="mt-1 w-full rounded-md border border-stellar-border bg-stellar-dark px-3 py-2 text-white" />
+            </label>
+            <button disabled={busy} className="rounded-md bg-stellar-blue px-4 py-2 font-medium text-white disabled:opacity-50">Silence anomalies</button>
+          </form>
+        </div>
+      )}
+
+      {overrides.length > 0 && (
+        <div className="mt-6">
+          <h3 className="font-semibold text-white">Active silences</h3>
+          <ul className="mt-3 space-y-2">
+            {overrides.map((override) => (
+              <li key={override.id} className="flex flex-col gap-2 rounded-md border border-stellar-border p-3 text-sm sm:flex-row sm:items-center sm:justify-between">
+                <span className="text-stellar-text-secondary">
+                  <strong className="text-white">{override.asset_code}</strong> · {override.reason} · until {new Date(override.expires_at).toLocaleString()}
+                </span>
+                <button type="button" disabled={busy} onClick={() => removeOverride(override.id)} className="text-left text-red-400 hover:text-red-300 disabled:opacity-50">Remove</button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -5,6 +5,7 @@ import SnapshotCard from "../components/analytics/SnapshotCard";
 import BridgeComparison from "../components/analytics/BridgeComparison";
 import IncidentHeatmap from "../components/IncidentHeatmap";
 import AnomalyTrendCharts from "../components/AnomalyTrendCharts";
+import AnomalyTuningPanel from "../components/AnomalyTuningPanel";
 import type { BridgeAnalytics } from "../hooks/useAnalytics";
 import { useAssetsWithHealth } from "../hooks/useAssets";
 import { usePricesForSymbols } from "../hooks/usePrices";
@@ -241,6 +242,8 @@ export default function Analytics() {
 
       {/* Anomaly Trend Charts */}
       <AnomalyTrendCharts />
+
+      <AnomalyTuningPanel />
 
       {/* Health Score Trends */}
       <div className="bg-stellar-card border border-stellar-border rounded-lg p-6">

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -73,6 +73,59 @@ async function fetchApi<T>(
   return response.json();
 }
 
+export interface AnomalyTuningProfile {
+  id: string;
+  name: string;
+  deviation_multiplier: number;
+  sliding_window_size: number;
+  updated_by: string | null;
+  updated_at: string;
+}
+
+export interface AnomalyTuningOverride {
+  id: string;
+  anomaly_type: string;
+  asset_code: string;
+  bridge_name: string;
+  reason: string;
+  starts_at: string;
+  expires_at: string;
+}
+
+export function getAnomalyTuning(apiKey: string) {
+  return fetchApi<{ profile: AnomalyTuningProfile; overrides: AnomalyTuningOverride[] }>(
+    "/anomaly/tuning",
+    undefined,
+    apiKey
+  );
+}
+
+export function updateAnomalyTuning(
+  apiKey: string,
+  input: { deviationMultiplier: number; slidingWindowSize: number }
+) {
+  return fetchApi<{ profile: AnomalyTuningProfile }>(
+    "/anomaly/tuning",
+    { method: "PUT", body: JSON.stringify(input) },
+    apiKey
+  );
+}
+
+export function createAnomalyTuningOverride(
+  apiKey: string,
+  input: { assetCode?: string; reason: string; expiresAt: string }
+) {
+  return fetchApi<{ override: AnomalyTuningOverride }>(
+    "/anomaly/tuning/overrides",
+    { method: "POST", body: JSON.stringify(input) },
+    apiKey
+  );
+}
+
+export function deleteAnomalyTuningOverride(apiKey: string, id: string) {
+  return fetchApi<void>(`/anomaly/tuning/overrides/${id}`, { method: "DELETE" }, apiKey);
+}
+
 /** Root health endpoint (not under /api/v1). */
 export async function getServerHealth(): Promise<{ status: string; timestamp: string }> {
   const response = await fetch("/health");


### PR DESCRIPTION
## Summary
- add a database-backed active tuning profile for rolling anomaly baselines
- expose admin GET/PUT `/api/v1/anomaly/tuning` endpoints and temporal override management
- apply the deviation multiplier and sliding window in the detection engine, including override-based suppression metadata
- add an Analytics tuning panel for profile edits and temporary silences

## Validation
- `npm run test:unit --workspace=backend -- tests/services/anomalyTuning.test.ts` (3 tests passed)
- `npm run build:backend`
- `npm run build:frontend`
- ESLint on changed backend and frontend files

Closes #801