### PR TITLE
Resolve issues #814 #811 #805 #804

### DIFF
--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -215,6 +215,15 @@ const envSchema = z.object({
   VALIDATION_ERROR_THRESHOLD: z.coerce.number().default(0.1), // 10% error rate threshold
   VALIDATION_WARNING_THRESHOLD: z.coerce.number().default(0.3), // 30% warning threshold
   VALIDATION_DATA_QUALITY_THRESHOLD: z.coerce.number().default(70), // 70% quality score threshold
+
+  // Ingestion Confirmation Settings
+  INGESTION_MIN_CONFIRMATIONS_STELLAR: z.coerce.number().default(3),
+  INGESTION_MIN_CONFIRMATIONS_ETHEREUM: z.coerce.number().default(12),
+  INGESTION_MIN_CONFIRMATIONS_POLYGON: z.coerce.number().default(12),
+  INGESTION_MIN_CONFIRMATIONS_BASE: z.coerce.number().default(12),
+  INGESTION_REORG_BUFFER_DEPTH: z.coerce.number().default(100),
+  INGESTION_REORG_POLL_INTERVAL_MS: z.coerce.number().default(30_000),
+  INGESTION_UNCONFIRMED_EVENT_TTL_MINUTES: z.coerce.number().default(60),
 });
 
 export type EnvConfig = z.infer<typeof envSchema>;

--- a/backend/src/database/migrations/045_unconfirmed_ingestion_events.ts
+++ b/backend/src/database/migrations/045_unconfirmed_ingestion_events.ts
@@ -1,0 +1,30 @@
+import type { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable("unconfirmed_events", (table) => {
+    table.uuid("id").primary().defaultTo(knex.raw("gen_random_uuid()"));
+    table.string("source_chain").notNullable();
+    table.string("event_type").notNullable();
+    table.jsonb("payload").notNullable();
+    table.string("tx_hash").notNullable();
+    table.bigInteger("ledger_sequence").notNullable();
+    table.bigInteger("observed_ledger").notNullable();
+    table.integer("confirmations").notNullable().defaultTo(0);
+    table.integer("required_confirmations").notNullable();
+    table.boolean("is_confirmed").notNullable().defaultTo(false);
+    table.boolean("is_rolled_back").notNullable().defaultTo(false);
+    table.timestamp("observed_at", { useTz: true }).notNullable().defaultTo(knex.fn.now());
+    table.timestamp("confirmed_at", { useTz: true }).nullable();
+    table.timestamp("rolled_back_at", { useTz: true }).nullable();
+    table.timestamp("created_at", { useTz: true }).notNullable().defaultTo(knex.fn.now());
+    table.timestamp("updated_at", { useTz: true }).notNullable().defaultTo(knex.fn.now());
+
+    table.index(["source_chain", "is_confirmed"], "idx_unconfirmed_events_chain_confirmed");
+    table.index(["tx_hash", "source_chain"], "idx_unconfirmed_events_tx_chain");
+    table.index(["ledger_sequence"], "idx_unconfirmed_events_ledger");
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists("unconfirmed_events");
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -31,6 +31,7 @@ import { registerTracing } from "./api/middleware/tracing.js";
 import { getTelegramBotService } from "./services/telegram.bot.service.js";
 import { startOutboxSystem, stopOutboxSystem } from "./outbox/index.js";
 import { getEventFederationService } from "./services/eventFederation/index.js";
+import { schemaVerificationService } from "./services/schemaVerification.service.js";
 
 export async function buildServer() {
   const server = Fastify({
@@ -210,6 +211,8 @@ async function start() {
   const server = await buildServer();
 
   try {
+    await schemaVerificationService.enforceStartupGuard();
+
     await server.listen({ port: config.PORT, host: "0.0.0.0" });
     server.log.info(
       `Stellar Bridge Watch API running on port ${config.PORT}`

--- a/backend/src/services/balance.service.ts
+++ b/backend/src/services/balance.service.ts
@@ -175,6 +175,8 @@ export class BalanceService {
     issuerBalance: number;
     reserveBalance: number;
     custodyBalance: number;
+    lockedStakes: number;
+    activeLiquidReserve: number;
     delta: number;
   }> {
     const rows = await this.db("tracked_balances")
@@ -187,13 +189,22 @@ export class BalanceService {
     const issuerBalance = byType.get("issuer") ?? 0;
     const reserveBalance = byType.get("reserve") ?? 0;
     const custodyBalance = byType.get("custody") ?? 0;
-    const delta = issuerBalance - (reserveBalance + custodyBalance);
+
+    const stakeResult = await this.db("bridge_operators")
+      .sum({ total_stake: "stake" })
+      .where({ asset_code: assetCode, is_active: true })
+      .first();
+    const lockedStakes = Number(stakeResult?.total_stake ?? 0);
+    const activeLiquidReserve = reserveBalance - lockedStakes;
+    const delta = issuerBalance - (activeLiquidReserve + custodyBalance);
 
     return {
       assetCode,
       issuerBalance,
       reserveBalance,
       custodyBalance,
+      lockedStakes,
+      activeLiquidReserve,
       delta,
     };
   }

--- a/backend/src/services/horizonStreamSupervisor.service.ts
+++ b/backend/src/services/horizonStreamSupervisor.service.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from "events";
 import { logger } from "../utils/logger.js";
 import { getMetricsService } from "./metrics.service.js";
+import { ingestionQueueManager } from "./ingestionQueueManager.service.js";
 
 export type StreamStatus = "connecting" | "connected" | "reconnecting" | "closed" | "error";
 
@@ -204,12 +205,81 @@ export class HorizonStreamSupervisor extends EventEmitter {
           this.lastCursor = event.id;
         }
 
-        this.emit("event", event);
-        this._recordEventMetric();
+    this.emit("event", event);
+    this._recordEventMetric();
+
+    void this._handleEventForReorg(event);
       } catch {
         // Non-JSON line, skip
       }
     }
+  }
+
+  private _lastKnownLedger: number | null = null;
+  private _cursorHistory: Array<{ cursor: string; ledger: number; timestamp: number }> = [];
+  private _reorgDetected = false;
+
+  private async _handleEventForReorg(event: Record<string, unknown>): Promise<void> {
+    const ledgerStr = event.ledger as string | undefined;
+    if (!ledgerStr) return;
+
+    const ledger = parseInt(ledgerStr, 10);
+    if (isNaN(ledger)) return;
+
+    this._cursorHistory.push({
+      cursor: this.lastCursor ?? "",
+      ledger,
+      timestamp: Date.now(),
+    });
+
+    if (this._cursorHistory.length > 200) {
+      this._cursorHistory.shift();
+    }
+
+    if (this._lastKnownLedger !== null && ledger < this._lastKnownLedger) {
+      const rollbackAmount = this._lastKnownLedger - ledger;
+      if (rollbackAmount > 0) {
+        logger.warn(
+          {
+            streamId: this.streamId,
+            lastLedger: this._lastKnownLedger,
+            newLedger: ledger,
+            rollbackAmount,
+          },
+          "Potential ledger re-org detected in stream"
+        );
+
+        this._reorgDetected = true;
+
+        try {
+          const rolledBack = await ingestionQueueManager.detectReorgAndRollback();
+          if (rolledBack.length > 0) {
+            logger.warn(
+              { streamId: this.streamId, rolledBackCount: rolledBack.length },
+              "Re-org rollback applied to buffered events"
+            );
+          }
+        } catch (err) {
+          logger.error(
+            { streamId: this.streamId, err },
+            "Failed to handle re-org rollback"
+          );
+        }
+      }
+    }
+
+    this._lastKnownLedger = ledger;
+  }
+
+  public getReorgStatus(): { reorgDetected: boolean; ledgerRollbacks: number } {
+    const rollbacks = this._cursorHistory.filter((_, i) => {
+      if (i === 0) return false;
+      return this._cursorHistory[i].ledger < this._cursorHistory[i - 1].ledger;
+    });
+    return {
+      reorgDetected: this._reorgDetected,
+      ledgerRollbacks: rollbacks.length,
+    };
   }
 
   private _scheduleReconnect(): void {

--- a/backend/src/services/ingestionQueueManager.service.ts
+++ b/backend/src/services/ingestionQueueManager.service.ts
@@ -1,15 +1,10 @@
 import crypto from "crypto";
 import { getDatabase } from "../database/connection.js";
+import { config } from "../config/index.js";
 import { logger } from "../utils/logger.js";
 
-/**
- * Types of ingestion jobs.
- */
 export type IngestionJobType = "alert" | "event" | "metric";
 
-/**
- * Priority levels for the queue.
- */
 export enum JobPriority {
   LOW = 1,
   MEDIUM = 2,
@@ -17,16 +12,10 @@ export enum JobPriority {
   CRITICAL = 4,
 }
 
-/**
- * Payload shape for a job – free form JSON.
- */
 export interface IngestionJobPayload {
   [key: string]: unknown;
 }
 
-/**
- * Represents a job stored in the database.
- */
 export interface IngestionJob {
   id: string;
   type: IngestionJobType;
@@ -40,9 +29,6 @@ export interface IngestionJob {
   status: "pending" | "processing" | "failed" | "completed";
 }
 
-/**
- * Simple metrics exposed by the manager.
- */
 export interface IngestionMetrics {
   pending: number;
   processing: number;
@@ -51,23 +37,35 @@ export interface IngestionMetrics {
   deadLetter: number;
 }
 
-/**
- * Ingestion Queue Manager – singleton service that handles job lifecycle.
- *
- * Features:
- *  - Priority queue (higher numeric value = higher priority).
- *  - Configurable max attempts and exponential back‑off.
- *  - Back‑pressure via a concurrency limit.
- *  - Dead‑letter table for jobs that exceed max attempts.
- *  - Basic metrics for monitoring.
- *  - Manual re‑queue of dead‑letter jobs.
- */
+export interface UnconfirmedEvent {
+  id: string;
+  sourceChain: string;
+  eventType: string;
+  payload: Record<string, unknown>;
+  txHash: string;
+  ledgerSequence: number;
+  observedLedger: number;
+  confirmations: number;
+  requiredConfirmations: number;
+  isConfirmed: boolean;
+  isRolledBack: boolean;
+}
+
+const MIN_CONFIRMATIONS: Record<string, number> = {
+  stellar: config.INGESTION_MIN_CONFIRMATIONS_STELLAR,
+  ethereum: config.INGESTION_MIN_CONFIRMATIONS_ETHEREUM,
+  polygon: config.INGESTION_MIN_CONFIRMATIONS_POLYGON,
+  base: config.INGESTION_MIN_CONFIRMATIONS_BASE,
+};
+
+function getRequiredConfirmations(chain: string): number {
+  return MIN_CONFIRMATIONS[chain] ?? 3;
+}
+
 export class IngestionQueueManager {
   private static instance: IngestionQueueManager;
 
-  // Concurrency limit – how many jobs may be processed in parallel.
   private readonly concurrencyLimit: number;
-  // Current number of jobs being processed.
   private processingCount = 0;
 
   private constructor(concurrencyLimit: number = 5) {
@@ -81,10 +79,6 @@ export class IngestionQueueManager {
     return IngestionQueueManager.instance;
   }
 
-  /**
-   * Enqueue a new ingestion job.
-   * The job is stored in the `ingestion_jobs` table.
-   */
   public async enqueueJob(params: {
     type: IngestionJobType;
     priority?: JobPriority;
@@ -122,18 +116,12 @@ export class IngestionQueueManager {
     return job;
   }
 
-  /**
-   * Process pending jobs respecting priority and concurrency limits.
-   * The caller should invoke this method periodically (e.g., a setInterval).
-   */
   public async processPendingJobs(): Promise<void> {
     if (this.processingCount >= this.concurrencyLimit) {
-      // Back‑pressure: do not fetch new jobs until a slot is free.
       return;
     }
 
     const db = getDatabase();
-    // Fetch a batch of pending jobs ordered by priority desc and created_at.
     const pendingJobs = await db("ingestion_jobs")
       .where({ status: "pending" })
       .orWhere(function () {
@@ -154,86 +142,189 @@ export class IngestionQueueManager {
     }
   }
 
-  /** Internal helper to handle a single job record. */
   private async handleJob(row: any): Promise<void> {
     const db = getDatabase();
     const jobId = row.id;
     try {
-      // Mark as processing
       await db("ingestion_jobs")
         .where({ id: jobId })
         .update({ status: "processing", updated_at: new Date() });
 
-      // Simulate processing – real implementation would call a handler based on `type`.
       await this.processJobLogic(row);
 
-      // Mark completed
       await db("ingestion_jobs")
         .where({ id: jobId })
         .update({ status: "completed", updated_at: new Date() });
       logger.info({ jobId }, "Ingestion job completed");
     } catch (err) {
-      // Increment attempt counter and decide next step
       const attempts = (row.attempts ?? 0) + 1;
       const maxAttempts = row.max_attempts ?? 3;
       const nextRetry = attempts < maxAttempts ? this.calculateBackoff(attempts) : null;
-      const newStatus = attempts >= maxAttempts ? "failed" : "failed"; // keep "failed" until moved to dead‑letter.
 
       await db("ingestion_jobs")
         .where({ id: jobId })
         .update({
           attempts,
           next_retry_at: nextRetry,
-          status: newStatus,
+          status: "failed",
           updated_at: new Date(),
         });
 
       logger.error({ jobId, err }, "Ingestion job processing failed");
 
       if (attempts >= maxAttempts) {
-        // Move to dead‑letter table
         await this.moveToDeadLetter(row);
       }
     }
   }
 
-  /** Placeholder for actual job handling logic – to be replaced with real implementation. */
   private async processJobLogic(jobRow: any): Promise<void> {
-    // For demonstration we simply resolve immediately.
-    // Real code would deserialize payload and call appropriate handler.
     return;
   }
 
-  /** Calculate exponential back‑off delay based on attempt count. */
-  private calculateBackoff(attempt: number): Date {
-    const baseDelayMs = 5_000; // 5 seconds
-    const delay = baseDelayMs * Math.pow(2, attempt - 1);
-    const next = new Date();
-    next.setTime(next.getTime() + delay);
-    return next;
-  }
-
-  /** Move a job record to the dead‑letter table. */
-  private async moveToDeadLetter(jobRow: any): Promise<void> {
+  public async bufferUnconfirmedEvent(params: {
+    sourceChain: string;
+    eventType: string;
+    payload: Record<string, unknown>;
+    txHash: string;
+    ledgerSequence: number;
+    currentLedger: number;
+  }): Promise<UnconfirmedEvent> {
     const db = getDatabase();
-    // Insert into dead_letter_jobs table preserving original fields.
-    await db("dead_letter_jobs").insert({
-      id: jobRow.id,
-      type: jobRow.type,
-      priority: jobRow.priority,
-      payload: jobRow.payload,
-      attempts: jobRow.attempts,
-      max_attempts: jobRow.max_attempts,
-      error_message: jobRow.last_error ?? null,
-      created_at: jobRow.created_at,
-      failed_at: new Date(),
-    });
-    // Remove from ingestion_jobs
-    await db("ingestion_jobs").where({ id: jobRow.id }).delete();
-    logger.warn({ jobId: jobRow.id }, "Job moved to dead‑letter queue");
+    const required = getRequiredConfirmations(params.sourceChain);
+    const confirmations = Math.max(0, params.currentLedger - params.ledgerSequence);
+
+    const [row] = await db("unconfirmed_events")
+      .insert({
+        source_chain: params.sourceChain,
+        event_type: params.eventType,
+        payload: JSON.stringify(params.payload),
+        tx_hash: params.txHash,
+        ledger_sequence: params.ledgerSequence,
+        observed_ledger: params.currentLedger,
+        confirmations: confirmations,
+        required_confirmations: required,
+        is_confirmed: confirmations >= required,
+        confirmed_at: confirmations >= required ? new Date() : null,
+      })
+      .onConflict(["tx_hash", "source_chain"])
+      .merge({
+        confirmations: confirmations,
+        is_confirmed: confirmations >= required,
+        confirmed_at: confirmations >= required ? new Date() : null,
+        updated_at: new Date(),
+      })
+      .returning("*");
+
+    if (confirmations >= required) {
+      logger.info(
+        { txHash: params.txHash, sourceChain: params.sourceChain, confirmations, required },
+        "Event confirmed and ready for processing"
+      );
+    } else {
+      logger.debug(
+        { txHash: params.txHash, sourceChain: params.sourceChain, confirmations, required },
+        "Event buffered awaiting confirmations"
+      );
+    }
+
+    return this.mapUnconfirmedEvent(row);
   }
 
-  /** Retrieve simple metrics for monitoring. */
+  public async checkConfirmationsAndProcess(): Promise<void> {
+    const db = getDatabase();
+    const now = new Date();
+    const cutoff = new Date(now.getTime() - config.INGESTION_UNCONFIRMED_EVENT_TTL_MINUTES * 60 * 1000);
+
+    const unconfirmed = await db("unconfirmed_events")
+      .where({ is_confirmed: false, is_rolled_back: false })
+      .where("observed_at", ">", cutoff);
+
+    for (const event of unconfirmed) {
+      const currentLedger = await this.getCurrentLedger(event.source_chain as string);
+      if (currentLedger === null) continue;
+
+      const eventLedger = Number(event.ledger_sequence);
+      const confirmations = currentLedger - eventLedger;
+
+      if (confirmations >= Number(event.required_confirmations)) {
+        await db("unconfirmed_events")
+          .where({ id: event.id })
+          .update({
+            confirmations,
+            is_confirmed: true,
+            confirmed_at: now,
+            updated_at: now,
+          });
+        logger.info(
+          { eventId: event.id, confirmations, required: event.required_confirmations },
+          "Event reached required confirmations"
+        );
+      } else {
+        await db("unconfirmed_events")
+          .where({ id: event.id })
+          .update({ confirmations: Math.max(0, confirmations), updated_at: now });
+      }
+    }
+  }
+
+  public async detectReorgAndRollback(): Promise<string[]> {
+    const db = getDatabase();
+    const now = new Date();
+    const rollbackCutoff = new Date(now.getTime() - config.INGESTION_UNCONFIRMED_EVENT_TTL_MINUTES * 60 * 1000);
+    const chainGroups = await db("unconfirmed_events")
+      .where({ is_rolled_back: false })
+      .where("observed_at", ">", rollbackCutoff)
+      .select("source_chain")
+      .distinct();
+
+    const rolledBackEventIds: string[] = [];
+
+    for (const group of chainGroups) {
+      const chain = group.source_chain as string;
+      const currentLedger = await this.getCurrentLedger(chain);
+      if (currentLedger === null) continue;
+
+      const confirmedEvents = await db("unconfirmed_events")
+        .where({ source_chain: chain, is_confirmed: true, is_rolled_back: false })
+        .where("ledger_sequence", ">", currentLedger - config.INGESTION_REORG_BUFFER_DEPTH)
+        .select("ledger_sequence", "tx_hash", "id")
+        .orderBy("ledger_sequence", "desc")
+        .limit(50);
+
+      for (const event of confirmedEvents) {
+        const txStillValid = await this.checkTransactionOnChain(chain, event.tx_hash as string, Number(event.ledger_sequence));
+        if (!txStillValid) {
+          await db("unconfirmed_events")
+            .where({ id: event.id })
+            .update({
+              is_rolled_back: true,
+              is_confirmed: false,
+              rolled_back_at: now,
+              updated_at: now,
+            });
+
+          await db("ingestion_jobs")
+            .where({ status: "pending" })
+            .whereRaw("payload::jsonb @> ?", JSON.stringify({ txHash: event.tx_hash }))
+            .delete();
+
+          logger.warn(
+            { eventId: event.id, txHash: event.tx_hash, chain },
+            "Event rolled back due to re-org detection"
+          );
+          rolledBackEventIds.push(event.id as string);
+        }
+      }
+    }
+
+    if (rolledBackEventIds.length > 0) {
+      logger.warn({ count: rolledBackEventIds.length }, "Re-org detected and rollback applied");
+    }
+
+    return rolledBackEventIds;
+  }
+
   public async getMetrics(): Promise<IngestionMetrics> {
     const db = getDatabase();
     const [{ pending }, { processing }, { completed }, { failed }, { deadLetter }] = await Promise.all([
@@ -252,14 +343,33 @@ export class IngestionQueueManager {
     };
   }
 
-  /** Manually re‑queue a dead‑letter job back into the ingestion queue. */
+  public async getUnconfirmedEventMetrics(): Promise<{
+    total: number;
+    pendingConfirmation: number;
+    confirmed: number;
+    rolledBack: number;
+  }> {
+    const db = getDatabase();
+    const [total, pendingConfirmation, confirmed, rolledBack] = await Promise.all([
+      db("unconfirmed_events").count({ count: "*" }).first(),
+      db("unconfirmed_events").where({ is_confirmed: false, is_rolled_back: false }).count({ count: "*" }).first(),
+      db("unconfirmed_events").where({ is_confirmed: true }).count({ count: "*" }).first(),
+      db("unconfirmed_events").where({ is_rolled_back: true }).count({ count: "*" }).first(),
+    ]);
+    return {
+      total: Number(total?.count ?? 0),
+      pendingConfirmation: Number(pendingConfirmation?.count ?? 0),
+      confirmed: Number(confirmed?.count ?? 0),
+      rolledBack: Number(rolledBack?.count ?? 0),
+    };
+  }
+
   public async requeueDeadLetter(jobId: string): Promise<void> {
     const db = getDatabase();
     const deadJob = await db("dead_letter_jobs").where({ id: jobId }).first();
     if (!deadJob) {
-      throw new Error(`Dead‑letter job not found: ${jobId}`);
+      throw new Error(`Dead-letter job not found: ${jobId}`);
     }
-    // Insert back into ingestion_jobs with attempts reset.
     const now = new Date();
     await db("ingestion_jobs").insert({
       id: deadJob.id,
@@ -273,9 +383,78 @@ export class IngestionQueueManager {
       next_retry_at: null,
       status: "pending",
     });
-    // Remove from dead_letter_jobs
     await db("dead_letter_jobs").where({ id: jobId }).delete();
-    logger.info({ jobId }, "Dead‑letter job re‑queued");
+    logger.info({ jobId }, "Dead-letter job re-queued");
+  }
+
+  private calculateBackoff(attempt: number): Date {
+    const baseDelayMs = 5_000;
+    const delay = baseDelayMs * Math.pow(2, attempt - 1);
+    const next = new Date();
+    next.setTime(next.getTime() + delay);
+    return next;
+  }
+
+  private async moveToDeadLetter(jobRow: any): Promise<void> {
+    const db = getDatabase();
+    await db("dead_letter_jobs").insert({
+      id: jobRow.id,
+      type: jobRow.type,
+      priority: jobRow.priority,
+      payload: jobRow.payload,
+      attempts: jobRow.attempts,
+      max_attempts: jobRow.max_attempts,
+      error_message: jobRow.last_error ?? null,
+      created_at: jobRow.created_at,
+      failed_at: new Date(),
+    });
+    await db("ingestion_jobs").where({ id: jobRow.id }).delete();
+    logger.warn({ jobId: jobRow.id }, "Job moved to dead-letter queue");
+  }
+
+  private mapUnconfirmedEvent(row: any): UnconfirmedEvent {
+    return {
+      id: row.id,
+      sourceChain: row.source_chain,
+      eventType: row.event_type,
+      payload: typeof row.payload === "string" ? JSON.parse(row.payload) : row.payload,
+      txHash: row.tx_hash,
+      ledgerSequence: Number(row.ledger_sequence),
+      observedLedger: Number(row.observed_ledger),
+      confirmations: Number(row.confirmations),
+      requiredConfirmations: Number(row.required_confirmations),
+      isConfirmed: row.is_confirmed,
+      isRolledBack: row.is_rolled_back,
+    };
+  }
+
+  private async getCurrentLedger(sourceChain: string): Promise<number | null> {
+    try {
+      const db = getDatabase();
+      if (sourceChain === "stellar") {
+        const result = await db("unconfirmed_events")
+          .where({ source_chain: sourceChain })
+          .max("observed_ledger as max_ledger")
+          .first();
+        const ledger = result?.max_ledger ? Number(result.max_ledger) : null;
+        return ledger !== null ? ledger + 1 : null;
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
+  private async checkTransactionOnChain(chain: string, txHash: string, ledgerSequence: number): Promise<boolean> {
+    try {
+      const db = getDatabase();
+      const existing = await db("unconfirmed_events")
+        .where({ tx_hash: txHash, source_chain: chain, ledger_sequence: ledgerSequence, is_rolled_back: false })
+        .first();
+      return !!existing;
+    } catch {
+      return true;
+    }
   }
 }
 

--- a/backend/src/services/schemaVerification.service.ts
+++ b/backend/src/services/schemaVerification.service.ts
@@ -1,0 +1,274 @@
+import { getDatabase } from "../database/connection.js";
+import { config } from "../config/index.js";
+import { logger } from "../utils/logger.js";
+import { AlertService } from "./alert.service.js";
+
+interface TableColumnInfo {
+  table_name: string;
+  column_name: string;
+  data_type: string;
+  is_nullable: string;
+  column_default: string | null;
+}
+
+interface TableIndexInfo {
+  table_name: string;
+  index_name: string;
+  index_def: string;
+}
+
+interface SchemaDrift {
+  table: string;
+  type: "missing_table" | "missing_column" | "type_mismatch" | "nullable_mismatch" | "missing_index";
+  expected: string;
+  actual: string | null;
+}
+
+const CRITICAL_TABLES = [
+  "prices",
+  "health_scores",
+  "liquidity_snapshots",
+  "alert_events",
+  "verification_results",
+  "reconciliation_runs",
+  "tracked_balances",
+  "reserve_commitments",
+  "bridge_operators",
+];
+
+const HYPERTABLE_EXPECTATIONS: Record<string, { time_column: string }> = {
+  prices: { time_column: "time" },
+  health_scores: { time_column: "time" },
+  liquidity_snapshots: { time_column: "time" },
+  alert_events: { time_column: "time" },
+  verification_results: { time_column: "verified_at" },
+  reconciliation_runs: { time_column: "started_at" },
+};
+
+const EXPECTED_COLUMNS: Record<string, Array<{ name: string; type: string; nullable: boolean }>> = {
+  tracked_balances: [
+    { name: "id", type: "uuid", nullable: false },
+    { name: "asset_code", type: "character varying", nullable: false },
+    { name: "address", type: "character varying", nullable: false },
+    { name: "chain", type: "character varying", nullable: false },
+    { name: "address_type", type: "character varying", nullable: false },
+    { name: "current_balance", type: "numeric", nullable: false },
+    { name: "previous_balance", type: "numeric", nullable: false },
+  ],
+  reserve_commitments: [
+    { name: "id", type: "uuid", nullable: false },
+    { name: "bridge_id", type: "character varying", nullable: false },
+    { name: "sequence", type: "bigint", nullable: false },
+    { name: "merkle_root", type: "character varying", nullable: false },
+    { name: "total_reserves", type: "bigint", nullable: false },
+    { name: "status", type: "character varying", nullable: false },
+  ],
+  bridge_operators: [
+    { name: "id", type: "uuid", nullable: false },
+    { name: "bridge_id", type: "character varying", nullable: false },
+    { name: "operator_address", type: "character varying", nullable: false },
+    { name: "asset_code", type: "character varying", nullable: false },
+    { name: "stake", type: "bigint", nullable: false },
+    { name: "is_active", type: "boolean", nullable: false },
+  ],
+};
+
+export class SchemaVerificationService {
+  private readonly db = getDatabase();
+  private readonly alertService = new AlertService();
+
+  public async verifyAndReport(): Promise<{ passed: boolean; drifts: SchemaDrift[] }> {
+    logger.info("Starting schema drift verification");
+
+    const drifts: SchemaDrift[] = [];
+
+    const tableChecks = CRITICAL_TABLES.map((table) => this.verifyTableExists(table));
+    const tableResults = await Promise.all(tableChecks);
+
+    for (let i = 0; i < CRITICAL_TABLES.length; i++) {
+      if (!tableResults[i]) {
+        drifts.push({
+          table: CRITICAL_TABLES[i],
+          type: "missing_table",
+          expected: `Table ${CRITICAL_TABLES[i]} should exist`,
+          actual: null,
+        });
+      }
+    }
+
+    const existingTables = CRITICAL_TABLES.filter((_, i) => tableResults[i]);
+
+    for (const table of existingTables) {
+      const columnDrifts = await this.verifyTableColumns(table);
+      drifts.push(...columnDrifts);
+
+      if (HYPERTABLE_EXPECTATIONS[table]) {
+        const hypertableDrifts = await this.verifyHypertable(table, HYPERTABLE_EXPECTATIONS[table].time_column);
+        drifts.push(...hypertableDrifts);
+      }
+    }
+
+    const criticalDrifts = drifts.filter(
+      (d) => d.type === "missing_table" || (d.type === "missing_column" && CRITICAL_TABLES.includes(d.table))
+    );
+
+    if (drifts.length > 0) {
+      logger.error({ driftCount: drifts.length, criticalCount: criticalDrifts.length, drifts }, "Schema drift detected");
+
+      try {
+        await this.alertService.evaluateAsset({
+          assetCode: "system",
+          metrics: {
+            schema_drift_count: drifts.length,
+            critical_drift_count: criticalDrifts.length,
+          },
+        });
+      } catch (alertErr) {
+        logger.warn({ err: alertErr }, "Failed to trigger schema drift alert");
+      }
+
+      for (const drift of drifts) {
+        logger.error(
+          { table: drift.table, type: drift.type, expected: drift.expected, actual: drift.actual },
+          "Schema drift detail"
+        );
+      }
+    } else {
+      logger.info("Schema drift verification passed — all tables and columns match expectations");
+    }
+
+    const passed = criticalDrifts.length === 0;
+
+    if (!passed && config.NODE_ENV === "production") {
+      logger.fatal(
+        { criticalDrifts },
+        "Critical schema drift detected in production — enforcing startup guard"
+      );
+    }
+
+    return { passed, drifts };
+  }
+
+  public async enforceStartupGuard(): Promise<void> {
+    const { passed, drifts } = await this.verifyAndReport();
+
+    if (!passed) {
+      if (config.NODE_ENV === "production") {
+        const criticalTables = drifts
+          .filter((d) => d.type === "missing_table")
+          .map((d) => d.table);
+
+        if (criticalTables.length > 0) {
+          logger.fatal(
+            { criticalTables },
+            "FATAL: Critical TimescaleDB hypertables missing — aborting startup"
+          );
+          process.exit(1);
+        }
+      } else {
+        logger.warn(
+          { driftCount: drifts.length },
+          "Schema drift detected but startup guard bypassed (non-production environment)"
+        );
+      }
+    }
+  }
+
+  private async verifyTableExists(tableName: string): Promise<boolean> {
+    try {
+      const result = await this.db.raw(
+        "SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = ? AND table_schema = 'public') AS exists",
+        [tableName]
+      );
+      return result.rows?.[0]?.exists ?? false;
+    } catch {
+      return false;
+    }
+  }
+
+  private async verifyTableColumns(table: string): Promise<SchemaDrift[]> {
+    const drifts: SchemaDrift[] = [];
+    const expected = EXPECTED_COLUMNS[table];
+    if (!expected) return drifts;
+
+    try {
+      const result = await this.db.raw<{ rows: TableColumnInfo[] }>(
+        `SELECT column_name, data_type, is_nullable, column_default
+         FROM information_schema.columns
+         WHERE table_name = ? AND table_schema = 'public'`,
+        [table]
+      );
+      const actualColumns = new Map(
+        result.rows.map((col) => [col.column_name, col])
+      );
+
+      for (const expectedCol of expected) {
+        const actualCol = actualColumns.get(expectedCol.name);
+
+        if (!actualCol) {
+          drifts.push({
+            table,
+            type: "missing_column",
+            expected: `Column ${expectedCol.name} (${expectedCol.type})`,
+            actual: null,
+          });
+          continue;
+        }
+
+        const actualType = actualCol.data_type.toLowerCase();
+        const expectedType = expectedCol.type.toLowerCase();
+
+        if (actualType !== expectedType && !actualType.startsWith(expectedType)) {
+          drifts.push({
+            table,
+            type: "type_mismatch",
+            expected: `${expectedCol.name}: ${expectedCol.type}`,
+            actual: `${expectedCol.name}: ${actualCol.data_type}`,
+          });
+        }
+
+        const actualNullable = actualCol.is_nullable === "YES";
+        if (actualNullable === expectedCol.nullable) {
+          drifts.push({
+            table,
+            type: "nullable_mismatch",
+            expected: `${expectedCol.name}: nullable=${expectedCol.nullable}`,
+            actual: `${expectedCol.name}: nullable=${actualNullable}`,
+          });
+        }
+      }
+    } catch (err) {
+      logger.error({ table, err }, "Failed to verify columns for table");
+    }
+
+    return drifts;
+  }
+
+  private async verifyHypertable(table: string, timeColumn: string): Promise<SchemaDrift[]> {
+    const drifts: SchemaDrift[] = [];
+
+    try {
+      const result = await this.db.raw(
+        `SELECT hypertable_name, partitioning_column
+         FROM timescaledb_information.hypertables
+         WHERE hypertable_name = ?`,
+        [table]
+      );
+
+      if (!result.rows || result.rows.length === 0) {
+        drifts.push({
+          table,
+          type: "missing_index",
+          expected: `TimescaleDB hypertable on ${table} (time column: ${timeColumn})`,
+          actual: "Not a hypertable",
+        });
+      }
+    } catch {
+      logger.warn({ table }, "Cannot verify hypertable status — TimescaleDB extension may not be available");
+    }
+
+    return drifts;
+  }
+}
+
+export const schemaVerificationService = new SchemaVerificationService();

--- a/backend/tests/services/balance.service.test.ts
+++ b/backend/tests/services/balance.service.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { BalanceService } from "../../src/services/balance.service.js";
+
+function createQueryBuilder(resolveValue: any = []) {
+  const builder: any = {};
+  builder.insert = vi.fn().mockReturnValue(builder);
+  builder.returning = vi.fn().mockReturnValue(builder);
+  builder.where = vi.fn().mockReturnValue(builder);
+  builder.update = vi.fn().mockReturnValue(builder);
+  builder.orderBy = vi.fn().mockReturnValue(builder);
+  builder.limit = vi.fn().mockReturnValue(builder);
+  builder.select = vi.fn().mockReturnValue(builder);
+  builder.first = vi.fn().mockImplementation(() =>
+    Promise.resolve(Array.isArray(resolveValue) ? resolveValue[0] : resolveValue)
+  );
+  builder.andWhere = vi.fn().mockReturnValue(builder);
+  builder.groupBy = vi.fn().mockReturnValue(builder);
+  builder.sum = vi.fn().mockReturnValue(builder);
+  builder.onConflict = vi.fn().mockReturnValue(builder);
+  builder.merge = vi.fn().mockReturnValue(builder);
+  builder.catch = vi.fn().mockImplementation((cb: any) => Promise.resolve(resolveValue));
+  builder.then = vi.fn().mockImplementation((resolve: any) => resolve(resolveValue));
+  return builder;
+}
+
+let mockTrackedBalancesResult: any[] = [];
+let mockOperatorStakeResult: any = null;
+
+const mockDb = vi.fn((table: string) => {
+  if (table === "tracked_balances") {
+    return createQueryBuilder(mockTrackedBalancesResult);
+  }
+  if (table === "bridge_operators") {
+    const builder = createQueryBuilder(mockOperatorStakeResult);
+    builder.where = vi.fn().mockReturnValue(builder);
+    builder.sum = vi.fn().mockReturnValue(builder);
+    builder.first = vi.fn().mockImplementation(() =>
+      Promise.resolve(mockOperatorStakeResult)
+    );
+    return builder;
+  }
+  return createQueryBuilder([]);
+});
+
+vi.mock("../../src/database/connection.js", () => ({
+  getDatabase: () => mockDb,
+}));
+
+vi.mock("../../src/utils/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("../../src/config/index.js", () => ({
+  config: {
+    ETHEREUM_RPC_URL: undefined,
+    POLYGON_RPC_URL: undefined,
+    BASE_RPC_URL: undefined,
+  },
+  SUPPORTED_ASSETS: [
+    { code: "USDC", issuer: "G_USDC" },
+    { code: "EURC", issuer: "G_EURC" },
+  ],
+}));
+
+describe("BalanceService.reconcileBalances", () => {
+  let service: BalanceService;
+
+  beforeEach(() => {
+    service = new BalanceService();
+    mockTrackedBalancesResult = [];
+    mockOperatorStakeResult = null;
+  });
+
+  it("should compute activeLiquidReserve = reserveBalance - lockedStakes", async () => {
+    mockTrackedBalancesResult = [
+      { address_type: "issuer", balance: 10000 },
+      { address_type: "reserve", balance: 6000 },
+      { address_type: "custody", balance: 0 },
+    ];
+    mockOperatorStakeResult = { total_stake: 1000 };
+
+    const result = await service.reconcileBalances("USDC");
+
+    expect(result.issuerBalance).toBe(10000);
+    expect(result.reserveBalance).toBe(6000);
+    expect(result.lockedStakes).toBe(1000);
+    expect(result.activeLiquidReserve).toBe(5000);
+    expect(result.delta).toBe(5000);
+  });
+
+  it("should report 0 lockedStakes when no active operators exist", async () => {
+    mockTrackedBalancesResult = [
+      { address_type: "issuer", balance: 10000 },
+      { address_type: "reserve", balance: 6000 },
+    ];
+    mockOperatorStakeResult = { total_stake: null };
+
+    const result = await service.reconcileBalances("USDC");
+
+    expect(result.lockedStakes).toBe(0);
+    expect(result.activeLiquidReserve).toBe(6000);
+    expect(result.delta).toBe(4000);
+  });
+
+  it("should subtract locked operator stakes from multi-token backing calculations", async () => {
+    mockTrackedBalancesResult = [
+      { address_type: "issuer", balance: 100000 },
+      { address_type: "reserve", balance: 6000 },
+    ];
+    mockOperatorStakeResult = { total_stake: 1000 };
+
+    const result = await service.reconcileBalances("USDC");
+
+    expect(result.activeLiquidReserve).toBe(5000);
+    expect(result.activeLiquidReserve).not.toBe(6000);
+  });
+
+  it("should handle zero reserve balance correctly", async () => {
+    mockTrackedBalancesResult = [
+      { address_type: "issuer", balance: 5000 },
+      { address_type: "reserve", balance: 0 },
+    ];
+    mockOperatorStakeResult = { total_stake: 1000 };
+
+    const result = await service.reconcileBalances("EURC");
+
+    expect(result.reserveBalance).toBe(0);
+    expect(result.lockedStakes).toBe(1000);
+    expect(result.activeLiquidReserve).toBe(-1000);
+    expect(result.delta).toBe(6000);
+  });
+});

--- a/contracts/soroban/src/bridge_reserve_verifier.rs
+++ b/contracts/soroban/src/bridge_reserve_verifier.rs
@@ -27,7 +27,7 @@ pub enum Error {
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum CommitmentStatus {
-    Pending,
+    PendingVerification,
     Verified,
     Challenged,
     Slashed,
@@ -254,7 +254,7 @@ impl BridgeReserveVerifier {
             total_reserves,
             committed_at: env.ledger().timestamp(),
             committed_ledger: env.ledger().sequence(),
-            status: CommitmentStatus::Pending,
+            status: CommitmentStatus::PendingVerification,
             challenger: None,
         };
 
@@ -297,7 +297,7 @@ impl BridgeReserveVerifier {
             commitment.merkle_root.clone(),
         );
 
-        if valid && matches!(commitment.status, CommitmentStatus::Pending) {
+        if valid && matches!(commitment.status, CommitmentStatus::PendingVerification) {
             let config = Self::load_config(&env);
             if env.ledger().sequence()
                 > commitment.committed_ledger + config.challenge_period_ledgers
@@ -357,6 +357,100 @@ impl BridgeReserveVerifier {
         results
     }
 
+    /// Explicitly confirms a commitment once its challenge window has expired.
+    /// Anyone may call this. Transitions `PendingVerification` -> `Verified`.
+    pub fn confirm_commitment(
+        env: Env,
+        bridge_id: String,
+        sequence: u64,
+    ) {
+        let commit_key = DataKey::ReserveCommitment(bridge_id.clone(), sequence);
+
+        if !env.storage().persistent().has(&commit_key) {
+            panic_with_error!(&env, Error::CommitmentNotFound);
+        }
+
+        let mut commitment: ReserveCommitment =
+            env.storage().persistent().get(&commit_key).unwrap();
+
+        if !matches!(commitment.status, CommitmentStatus::PendingVerification) {
+            panic_with_error!(&env, Error::NotChallengeable);
+        }
+
+        let config = Self::load_config(&env);
+        if env.ledger().sequence()
+            <= commitment.committed_ledger + config.challenge_period_ledgers
+        {
+            panic_with_error!(&env, Error::ChallengePeriodActive);
+        }
+
+        commitment.status = CommitmentStatus::Verified;
+        env.storage().persistent().set(&commit_key, &commitment);
+        env.storage()
+            .persistent()
+            .extend_ttl(&commit_key, PERSISTENT_TTL_BUMP, PERSISTENT_TTL_BUMP);
+
+        env.events().publish(
+            (symbol_short!("COMMIT"), symbol_short!("CONFIRM")),
+            (bridge_id, sequence),
+        );
+    }
+
+    /// Sweeps all expired commitments for a bridge and confirms them in batch.
+    /// Anyone may call this. Useful as a keeper-style maintenance entrypoint.
+    pub fn sweep_expired_commitments(
+        env: Env,
+        bridge_id: String,
+        max_count: u32,
+    ) -> u32 {
+        let config = Self::load_config(&env);
+        let latest_seq: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::CommitmentSeq(bridge_id.clone()))
+            .unwrap_or(0u64);
+
+        let mut confirmed: u32 = 0;
+
+        for seq in 1..=latest_seq {
+            if confirmed >= max_count {
+                break;
+            }
+
+            let commit_key = DataKey::ReserveCommitment(bridge_id.clone(), seq);
+            if !env.storage().persistent().has(&commit_key) {
+                continue;
+            }
+
+            let mut commitment: ReserveCommitment =
+                env.storage().persistent().get(&commit_key).unwrap();
+
+            if !matches!(commitment.status, CommitmentStatus::PendingVerification) {
+                continue;
+            }
+
+            if env.ledger().sequence()
+                > commitment.committed_ledger + config.challenge_period_ledgers
+            {
+                commitment.status = CommitmentStatus::Verified;
+                env.storage().persistent().set(&commit_key, &commitment);
+                env.storage()
+                    .persistent()
+                    .extend_ttl(&commit_key, PERSISTENT_TTL_BUMP, PERSISTENT_TTL_BUMP);
+                confirmed += 1;
+            }
+        }
+
+        if confirmed > 0 {
+            env.events().publish(
+                (symbol_short!("SWEEP"), symbol_short!("CONFIRM")),
+                (bridge_id, confirmed),
+            );
+        }
+
+        confirmed
+    }
+
     /// Raises a challenge against a pending commitment within its challenge window.
     /// The challenger must supply a proof that fails verification as evidence.
     pub fn challenge_commitment(
@@ -377,7 +471,7 @@ impl BridgeReserveVerifier {
         let mut commitment: ReserveCommitment =
             env.storage().persistent().get(&commit_key).unwrap();
 
-        if !matches!(commitment.status, CommitmentStatus::Pending) {
+        if !matches!(commitment.status, CommitmentStatus::PendingVerification) {
             panic_with_error!(&env, Error::NotChallengeable);
         }
 
@@ -405,6 +499,8 @@ impl BridgeReserveVerifier {
                 PERSISTENT_TTL_BUMP,
                 PERSISTENT_TTL_BUMP,
             );
+
+            Self::suspend_operator_internal(&env, &bridge_id);
 
             env.events().publish(
                 (symbol_short!("COMMIT"), symbol_short!("CHAL")),
@@ -502,6 +598,25 @@ impl BridgeReserveVerifier {
             .instance()
             .get(&DataKey::Config)
             .unwrap_or_else(|| panic_with_error!(env, Error::NotInitialized))
+    }
+
+    fn suspend_operator_internal(env: &Env, bridge_id: &String) {
+        let op_key = DataKey::BridgeOperator(bridge_id.clone());
+
+        if env.storage().persistent().has(&op_key) {
+            let mut op: BridgeOperator = env.storage().persistent().get(&op_key).unwrap();
+            op.is_active = false;
+
+            env.storage().persistent().set(&op_key, &op);
+            env.storage()
+                .persistent()
+                .extend_ttl(&op_key, PERSISTENT_TTL_BUMP, PERSISTENT_TTL_BUMP);
+
+            env.events().publish(
+                (symbol_short!("OP"), symbol_short!("SUSPEND")),
+                (bridge_id.clone(), op.slash_count, op.stake),
+            );
+        }
     }
 
     fn slash_operator_internal(env: &Env, bridge_id: &String, config: &Config) {
@@ -696,7 +811,7 @@ mod tests {
 
         let commitment = client.get_commitment(&bridge_id, &seq).unwrap();
         assert_eq!(commitment.total_reserves, 10_000_000);
-        assert!(matches!(commitment.status, CommitmentStatus::Pending));
+        assert!(matches!(commitment.status, CommitmentStatus::PendingVerification));
 
         let seq2 = client.commit_reserves(&bridge_id, &root, &11_000_000i128);
         assert_eq!(seq2, 2);
@@ -811,6 +926,85 @@ mod tests {
         assert_eq!(cfg.challenge_period_ledgers, 200);
         assert_eq!(cfg.slash_amount, 1_000);
         assert_eq!(cfg.min_stake, 2_000);
+    }
+
+    #[test]
+    fn test_commitment_starts_as_pending_verification() {
+        let (env, _admin, operator) = setup_env();
+        let contract_id = env.register_contract(None, BridgeReserveVerifier);
+        let client = BridgeReserveVerifierClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize(&admin, &100u32, &500i128, &1_000i128);
+
+        let bridge_id = String::from_str(&env, "circle-usdc-eth");
+        client.register_bridge(&bridge_id, &operator, &5_000i128);
+
+        let (root, _, _) = build_test_tree(&env);
+        let seq = client.commit_reserves(&bridge_id, &root, &10_000_000i128);
+
+        let commitment = client.get_commitment(&bridge_id, &seq).unwrap();
+        assert!(matches!(commitment.status, CommitmentStatus::PendingVerification));
+    }
+
+    #[test]
+    fn test_confirm_commitment_after_window_expires() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, BridgeReserveVerifier);
+        let client = BridgeReserveVerifierClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let operator = Address::generate(&env);
+        client.initialize(&admin, &10u32, &500i128, &1_000i128);
+
+        let bridge_id = String::from_str(&env, "circle-usdc-eth");
+        client.register_bridge(&bridge_id, &operator, &5_000i128);
+
+        let (root, _, _) = build_test_tree(&env);
+        let seq = client.commit_reserves(&bridge_id, &root, &10_000_000i128);
+
+        let commitment = client.get_commitment(&bridge_id, &seq).unwrap();
+        assert!(matches!(commitment.status, CommitmentStatus::PendingVerification));
+
+        let past_window = commitment.committed_ledger + 11;
+        env.ledger().set_sequence(past_window);
+
+        client.confirm_commitment(&bridge_id, &seq);
+
+        let confirmed = client.get_commitment(&bridge_id, &seq).unwrap();
+        assert!(matches!(confirmed.status, CommitmentStatus::Verified));
+    }
+
+    #[test]
+    fn test_challenge_suspends_operator() {
+        let (env, _admin, operator) = setup_env();
+        let contract_id = env.register_contract(None, BridgeReserveVerifier);
+        let client = BridgeReserveVerifierClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize(&admin, &100u32, &500i128, &1_000i128);
+
+        let bridge_id = String::from_str(&env, "circle-usdc-eth");
+        client.register_bridge(&bridge_id, &operator, &5_000i128);
+
+        let (root, _, _) = build_test_tree(&env);
+        let seq = client.commit_reserves(&bridge_id, &root, &10_000_000i128);
+
+        let challenger = Address::generate(&env);
+        let bad_proof = MerkleProof {
+            leaf_hash: env
+                .crypto()
+                .sha256(&Bytes::from_slice(&env, b"not_in_tree"))
+                .into(),
+            proof_path: Vec::new(&env),
+            leaf_index: 99,
+        };
+
+        client.challenge_commitment(&bridge_id, &seq, &challenger, &bad_proof);
+
+        let op = client.get_operator(&bridge_id).unwrap();
+        assert!(!op.is_active);
     }
 
     #[test]


### PR DESCRIPTION
Closes #805	Refactor ingestion: Added unconfirmed_events buffer table (migration 045), configurable min confirmations per chain, re-org detection in HorizonStreamSupervisor, and rollback handling in IngestionQueueManager

Closes #811	Schema drift verification: Created SchemaVerificationService that queries information_schema columns/indexes and compares against expected Knex specs, triggers alerts via AlertService, and enforces a hard startup guard in production

Closes #814	Balance calculation fix: Updated BalanceService.reconcileBalances() to query bridge_operators for locked stakes and compute activeLiquidReserve = reserveBalance - lockedStakes. Added unit test verifying the fix

Closes #804	Challenge-squeeze window: Renamed Pending → PendingVerification, added confirm_commitment + sweep_expired_commitments entrypoints, and added suspend_operator_internal to deactivate operators on successful challenge