### PR TITLE
feat: implement webhook delivery circuit breaker

### DIFF
--- a/backend/src/api/routes/webhooks.ts
+++ b/backend/src/api/routes/webhooks.ts
@@ -264,6 +264,42 @@ export async function webhooksRoutes(server: FastifyInstance) {
   );
 
   // ---------------------------------------------------------------------------
+  // CIRCUIT BREAKER
+  // ---------------------------------------------------------------------------
+
+  // Get circuit breaker status for an endpoint
+  server.get<{ Params: EndpointParams }>(
+    "/endpoints/:id/circuit-breaker",
+    async (request: FastifyRequest<{ Params: EndpointParams }>, reply: FastifyReply) => {
+      const endpoint = await webhookService.getEndpoint(request.params.id);
+      if (!endpoint) {
+        return reply.code(404).send({ error: "Webhook endpoint not found" });
+      }
+      return webhookService.getCircuitBreakerState(endpoint);
+    }
+  );
+
+  // Manually reset the circuit breaker for an endpoint
+  server.post<{ Params: EndpointParams }>(
+    "/endpoints/:id/circuit-breaker/reset",
+    async (request: FastifyRequest<{ Params: EndpointParams }>, reply: FastifyReply) => {
+      try {
+        const endpoint = await webhookService.resetCircuitBreaker(request.params.id);
+        if (!endpoint) {
+          return reply.code(404).send({ error: "Webhook endpoint not found" });
+        }
+        return {
+          message: "Circuit breaker reset successfully",
+          endpoint,
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Failed to reset circuit breaker";
+        return reply.code(400).send({ error: message });
+      }
+    }
+  );
+
+  // ---------------------------------------------------------------------------
   // BATCH BUFFER
   // ---------------------------------------------------------------------------
 

--- a/backend/src/api/websocket/types.ts
+++ b/backend/src/api/websocket/types.ts
@@ -236,11 +236,29 @@ export interface BridgeUpdateMessage {
   timestamp: string;
 }
 
+export interface WebhookSystemEventData {
+  event: "circuit_breaker_tripped" | "circuit_breaker_reset";
+  webhookEndpointId: string;
+  endpointName: string;
+  endpointUrl: string;
+  ownerAddress: string;
+  consecutiveFailures?: number;
+  threshold?: number;
+}
+
+export interface WebhookSystemEventMessage {
+  type: "webhook_system_event";
+  channel: "events";
+  data: WebhookSystemEventData;
+  timestamp: string;
+}
+
 export type OutboundDataMessage =
   | PriceUpdateMessage
   | HealthUpdateMessage
   | AlertTriggeredMessage
-  | BridgeUpdateMessage;
+  | BridgeUpdateMessage
+  | WebhookSystemEventMessage;
 
 export type OutboundMessage =
   | WelcomeMessage

--- a/backend/src/database/migrations/046_webhook_circuit_breaker.ts
+++ b/backend/src/database/migrations/046_webhook_circuit_breaker.ts
@@ -1,0 +1,29 @@
+import type { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  // Add circuit breaker columns to webhook_endpoints
+  await knex.schema.alterTable("webhook_endpoints", (table) => {
+    table.integer("consecutive_failures").notNullable().defaultTo(0);
+    table.string("circuit_breaker_status").notNullable().defaultTo("closed");
+    table.timestamp("circuit_breaker_tripped_at", { useTz: true }).nullable();
+    table.timestamp("circuit_breaker_reset_at", { useTz: true }).nullable();
+  });
+
+  // Create index for quick lookups of tripped breakers
+  await knex.raw(`
+    CREATE INDEX idx_webhook_endpoints_cb_status
+      ON webhook_endpoints (circuit_breaker_status)
+      WHERE circuit_breaker_status != 'closed'
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw("DROP INDEX IF EXISTS idx_webhook_endpoints_cb_status");
+
+  await knex.schema.alterTable("webhook_endpoints", (table) => {
+    table.dropColumn("consecutive_failures");
+    table.dropColumn("circuit_breaker_status");
+    table.dropColumn("circuit_breaker_tripped_at");
+    table.dropColumn("circuit_breaker_reset_at");
+  });
+}

--- a/backend/src/database/schema.sql
+++ b/backend/src/database/schema.sql
@@ -292,11 +292,17 @@ CREATE TABLE webhook_endpoints (
   filter_event_types      JSONB       NOT NULL DEFAULT '[]',
   is_batch_delivery_enabled BOOLEAN   NOT NULL DEFAULT FALSE,
   batch_window_ms         INTEGER     NOT NULL DEFAULT 5000,
+  consecutive_failures    INTEGER     NOT NULL DEFAULT 0,
+  circuit_breaker_status  TEXT        NOT NULL DEFAULT 'closed',  -- closed | open | half_open
+  circuit_breaker_tripped_at TIMESTAMPTZ,
+  circuit_breaker_reset_at   TIMESTAMPTZ,
   created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at              TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 CREATE INDEX webhook_endpoints_owner_idx       ON webhook_endpoints (owner_address);
 CREATE INDEX webhook_endpoints_active_idx      ON webhook_endpoints (is_active);
+CREATE INDEX idx_webhook_endpoints_cb_status   ON webhook_endpoints (circuit_breaker_status)
+  WHERE circuit_breaker_status != 'closed';
 
 -- webhook_deliveries
 -- Individual webhook delivery attempts.

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -23,6 +23,8 @@ import { initJobSystem } from "./workers/index.js";
 import { JobQueue } from "./workers/queue.js";
 import { initWebhookWorker, stopWebhookWorker } from "./workers/webhookDelivery.worker.js";
 import { initNotificationQueueWorker, stopNotificationQueueWorker } from "./workers/notificationQueue.worker.js";
+import { webhookService } from "./services/webhook.service.js";
+import type { WebhookSystemEventData } from "./api/websocket/types.js";
 import { getSupplyVerificationQueue } from "./jobs/supplyVerification.job.js";
 import { swaggerOptions, swaggerUiOptions } from "./config/openapi.js";
 import { registerCorrelationMiddleware } from "./api/middleware/correlation.middleware.js";
@@ -223,6 +225,39 @@ async function start() {
 
     // Initialize webhook delivery worker
     await initWebhookWorker();
+
+    // Wire up webhook circuit breaker events to WebSocket broadcast
+    webhookService.on("webhook:circuit_breaker:tripped", (data: WebhookSystemEventData & { consecutiveFailures: number; threshold: number }) => {
+      wsServer.broadcastToChannel("events", {
+        type: "webhook_system_event",
+        channel: "events",
+        data: {
+          event: "circuit_breaker_tripped",
+          webhookEndpointId: data.webhookEndpointId,
+          endpointName: data.endpointName,
+          endpointUrl: data.endpointUrl,
+          ownerAddress: data.ownerAddress,
+          consecutiveFailures: data.consecutiveFailures,
+          threshold: data.threshold,
+        },
+        timestamp: new Date().toISOString(),
+      }).catch((err) => logger.error({ err }, "Failed to broadcast webhook circuit breaker tripped event"));
+    });
+
+    webhookService.on("webhook:circuit_breaker:reset", (data: WebhookSystemEventData) => {
+      wsServer.broadcastToChannel("events", {
+        type: "webhook_system_event",
+        channel: "events",
+        data: {
+          event: "circuit_breaker_reset",
+          webhookEndpointId: data.webhookEndpointId,
+          endpointName: data.endpointName,
+          endpointUrl: data.endpointUrl,
+          ownerAddress: data.ownerAddress,
+        },
+        timestamp: new Date().toISOString(),
+      }).catch((err) => logger.error({ err }, "Failed to broadcast webhook circuit breaker reset event"));
+    });
 
     // Initialize notification queue worker
     await initNotificationQueueWorker();

--- a/backend/src/services/webhook.service.outbox.ts
+++ b/backend/src/services/webhook.service.outbox.ts
@@ -341,6 +341,10 @@ export class OutboxWebhookService {
       filterEventTypes: JSON.parse(row.filter_event_types || "[]"),
       isBatchDeliveryEnabled: row.is_batch_delivery_enabled,
       batchWindowMs: row.batch_window_ms,
+      consecutiveFailures: row.consecutive_failures ?? 0,
+      circuitBreakerStatus: row.circuit_breaker_status ?? "closed",
+      circuitBreakerTrippedAt: row.circuit_breaker_tripped_at ?? null,
+      circuitBreakerResetAt: row.circuit_breaker_reset_at ?? null,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
     };

--- a/backend/src/services/webhook.service.ts
+++ b/backend/src/services/webhook.service.ts
@@ -1,4 +1,5 @@
 import crypto from "crypto";
+import { EventEmitter } from "events";
 import { getDatabase } from "../database/connection.js";
 import { logger } from "../utils/logger.js";
 import { Queue, Job, ConnectionOptions } from "bullmq";
@@ -26,6 +27,8 @@ export type WebhookEventType =
 
 export type WebhookDeliveryStatus = "pending" | "buffered" | "success" | "failed" | "retrying";
 
+export type WebhookCircuitBreakerStatus = "closed" | "open" | "half_open";
+
 export interface WebhookEndpoint {
   id: string;
   ownerAddress: string;
@@ -40,6 +43,10 @@ export interface WebhookEndpoint {
   filterEventTypes: WebhookEventType[];
   isBatchDeliveryEnabled: boolean;
   batchWindowMs: number;
+  consecutiveFailures: number;
+  circuitBreakerStatus: WebhookCircuitBreakerStatus;
+  circuitBreakerTrippedAt: Date | null;
+  circuitBreakerResetAt: Date | null;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -102,17 +109,21 @@ const WEBHOOK_CONNECTION: ConnectionOptions = {
 const RETRY_DELAYS = [1000, 5000, 15000, 60000, 300000, 900000, 3600000];
 const MAX_RETRY_ATTEMPTS = 7;
 
+// Circuit breaker: trip after this many consecutive failures per endpoint
+const CONSECUTIVE_FAILURE_THRESHOLD = 10;
+
 // =============================================================================
 // WEBHOOK SERVICE CLASS
 // =============================================================================
 
-export class WebhookService {
+export class WebhookService extends EventEmitter {
   private static instance: WebhookService;
   private deliveryQueue: Queue;
   private rateLimitMap: Map<string, RateLimitEntry> = new Map();
   public readonly batchBuffer: WebhookBatchBufferService;
 
   private constructor() {
+    super();
     this.batchBuffer = new WebhookBatchBufferService(async (params) => {
       try {
         await this.queueBatchDelivery({
@@ -302,6 +313,172 @@ export class WebhookService {
 
     entry.count++;
     return true;
+  }
+
+  // ---------------------------------------------------------------------------
+  // CIRCUIT BREAKER
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Record a successful delivery. Resets the consecutive failure counter.
+   */
+  public async recordSuccess(webhookEndpointId: string): Promise<void> {
+    const db = getDatabase();
+    const endpoint = await this.getEndpoint(webhookEndpointId);
+    if (!endpoint) return;
+
+    if (endpoint.consecutiveFailures === 0 && endpoint.circuitBreakerStatus === "closed") {
+      return; // Nothing to reset
+    }
+
+    const updateData: Record<string, any> = {
+      consecutive_failures: 0,
+      updated_at: new Date(),
+    };
+
+    // If we were in half_open state and now succeed, fully close the breaker
+    if (endpoint.circuitBreakerStatus === "half_open") {
+      updateData.circuit_breaker_status = "closed";
+      updateData.circuit_breaker_reset_at = new Date();
+
+      logger.info(
+        { webhookEndpointId },
+        "Webhook circuit breaker recovered (half_open → closed)"
+      );
+    }
+
+    await db("webhook_endpoints").where("id", webhookEndpointId).update(updateData);
+  }
+
+  /**
+   * Record a failed delivery. Increments the consecutive failure counter
+   * and trips the circuit breaker when the threshold is reached.
+   */
+  public async recordFailure(webhookEndpointId: string): Promise<void> {
+    const db = getDatabase();
+    const endpoint = await this.getEndpoint(webhookEndpointId);
+    if (!endpoint) return;
+
+    // If the breaker is already open, don't count further
+    if (endpoint.circuitBreakerStatus === "open") {
+      return;
+    }
+
+    const newCount = endpoint.consecutiveFailures + 1;
+
+    if (newCount >= CONSECUTIVE_FAILURE_THRESHOLD) {
+      await this.tripCircuitBreaker(webhookEndpointId, newCount);
+    } else {
+      await db("webhook_endpoints")
+        .where("id", webhookEndpointId)
+        .update({
+          consecutive_failures: newCount,
+          updated_at: new Date(),
+        });
+
+      logger.debug(
+        { webhookEndpointId, consecutiveFailures: newCount, threshold: CONSECUTIVE_FAILURE_THRESHOLD },
+        "Webhook consecutive failure recorded"
+      );
+    }
+  }
+
+  /**
+   * Trip the circuit breaker: mark the endpoint as open, deactivate it,
+   * and broadcast a WebSocket system event.
+   */
+  private async tripCircuitBreaker(
+    webhookEndpointId: string,
+    failureCount: number,
+  ): Promise<void> {
+    const db = getDatabase();
+
+    await db("webhook_endpoints")
+      .where("id", webhookEndpointId)
+      .update({
+        consecutive_failures: failureCount,
+        circuit_breaker_status: "open",
+        circuit_breaker_tripped_at: new Date(),
+        is_active: false,
+        updated_at: new Date(),
+      });
+
+    const endpoint = await this.getEndpoint(webhookEndpointId);
+
+    logger.warn(
+      { webhookEndpointId, consecutiveFailures: failureCount },
+      "Webhook circuit breaker tripped — endpoint suspended"
+    );
+
+    // Broadcast system event via WebSocket (events channel)
+    this.emit("webhook:circuit_breaker:tripped", {
+      webhookEndpointId,
+      endpointName: endpoint?.name ?? "unknown",
+      endpointUrl: endpoint?.url ?? "unknown",
+      ownerAddress: endpoint?.ownerAddress ?? "unknown",
+      consecutiveFailures: failureCount,
+      threshold: CONSECUTIVE_FAILURE_THRESHOLD,
+      trippedAt: new Date().toISOString(),
+    });
+  }
+
+  /**
+   * Manually reset the circuit breaker from the settings UI.
+   * Re-activates the endpoint and clears the failure counter.
+   */
+  public async resetCircuitBreaker(webhookEndpointId: string): Promise<WebhookEndpoint | null> {
+    const db = getDatabase();
+    const endpoint = await this.getEndpoint(webhookEndpointId);
+    if (!endpoint) return null;
+
+    if (endpoint.circuitBreakerStatus === "closed" && endpoint.consecutiveFailures === 0) {
+      return endpoint; // Already closed, no-op
+    }
+
+    await db("webhook_endpoints")
+      .where("id", webhookEndpointId)
+      .update({
+        consecutive_failures: 0,
+        circuit_breaker_status: "closed",
+        circuit_breaker_reset_at: new Date(),
+        is_active: true,
+        updated_at: new Date(),
+      });
+
+    logger.info(
+      { webhookEndpointId },
+      "Webhook circuit breaker manually reset"
+    );
+
+    // Broadcast system event
+    this.emit("webhook:circuit_breaker:reset", {
+      webhookEndpointId,
+      endpointName: endpoint.name,
+      endpointUrl: endpoint.url,
+      ownerAddress: endpoint.ownerAddress,
+      resetAt: new Date().toISOString(),
+    });
+
+    return this.getEndpoint(webhookEndpointId);
+  }
+
+  /**
+   * Get the current circuit breaker state for an endpoint.
+   */
+  public getCircuitBreakerState(endpoint: WebhookEndpoint): {
+    status: WebhookCircuitBreakerStatus;
+    consecutiveFailures: number;
+    threshold: number;
+    trippedAt: Date | null;
+    resetAt: Date | null;
+  } {
+    return {
+      status: endpoint.circuitBreakerStatus,
+      consecutiveFailures: endpoint.consecutiveFailures,
+      threshold: CONSECUTIVE_FAILURE_THRESHOLD,
+      trippedAt: endpoint.circuitBreakerTrippedAt,
+      resetAt: endpoint.circuitBreakerResetAt,
+    };
   }
 
   // ---------------------------------------------------------------------------
@@ -609,6 +786,14 @@ export class WebhookService {
       throw new Error(`Webhook endpoint is not active: ${webhookEndpointId}`);
     }
 
+    // Refuse delivery if circuit breaker is tripped
+    if (endpoint.circuitBreakerStatus === "open") {
+      throw new Error(
+        `Webhook endpoint circuit breaker is open: ${webhookEndpointId}. ` +
+        `Reset the circuit breaker in endpoint settings to resume deliveries.`
+      );
+    }
+
     const payloadString = JSON.stringify(payload);
     const signatureHeaders = this.generateSignatureHeaders(payloadString, endpoint.secret);
 
@@ -894,6 +1079,10 @@ export class WebhookService {
       filterEventTypes: typeof row.filter_event_types === "string" ? JSON.parse(row.filter_event_types) : row.filter_event_types || [],
       isBatchDeliveryEnabled: row.is_batch_delivery_enabled,
       batchWindowMs: row.batch_window_ms,
+      consecutiveFailures: row.consecutive_failures ?? 0,
+      circuitBreakerStatus: row.circuit_breaker_status ?? "closed",
+      circuitBreakerTrippedAt: row.circuit_breaker_tripped_at ?? null,
+      circuitBreakerResetAt: row.circuit_breaker_reset_at ?? null,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
     };

--- a/backend/src/workers/webhookDelivery.worker.ts
+++ b/backend/src/workers/webhookDelivery.worker.ts
@@ -42,6 +42,17 @@ export async function initWebhookWorker(): Promise<void> {
 
       try {
         const result = await webhookService.processDelivery(job);
+
+        // Record success — resets the consecutive failure counter
+        try {
+          await webhookService.recordSuccess(job.data.webhookEndpointId);
+        } catch (cbError) {
+          logger.error(
+            { jobId: job.id, error: cbError instanceof Error ? cbError.message : String(cbError) },
+            "Failed to record webhook success for circuit breaker"
+          );
+        }
+
         return result;
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : "Unknown error";
@@ -97,6 +108,17 @@ export async function initWebhookWorker(): Promise<void> {
         await webhookService.updateDeliveryStatus(job.data.deliveryId, "failed", undefined, errorMessage);
       } catch (updateError) {
         logger.error({ jobId: job.id }, "Failed to update delivery status after max retries");
+      }
+
+      // Record failure for circuit breaker tracking
+      try {
+        const { webhookService } = await import("../services/webhook.service.js");
+        await webhookService.recordFailure(job.data.webhookEndpointId);
+      } catch (cbError) {
+        logger.error(
+          { jobId: job.id, error: cbError instanceof Error ? cbError.message : String(cbError) },
+          "Failed to record webhook failure for circuit breaker"
+        );
       }
     }
   });

--- a/backend/tests/services/webhook.service.test.ts
+++ b/backend/tests/services/webhook.service.test.ts
@@ -82,6 +82,10 @@ function makeEndpointRow(overrides: Partial<Record<string, unknown>> = {}) {
     filter_event_types: "[]",
     is_batch_delivery_enabled: false,
     batch_window_ms: 5000,
+    consecutive_failures: 0,
+    circuit_breaker_status: "closed",
+    circuit_breaker_tripped_at: null,
+    circuit_breaker_reset_at: null,
     created_at: new Date(),
     updated_at: new Date(),
     ...overrides,
@@ -217,5 +221,71 @@ describe("WebhookService — singleton", () => {
     const a = WebhookService.getInstance();
     const b = WebhookService.getInstance();
     expect(a).toBe(b);
+  });
+});
+
+describe("WebhookService — circuit breaker", () => {
+  let service: WebhookService;
+
+  beforeEach(() => {
+    (WebhookService as any).instance = undefined;
+    service = WebhookService.getInstance();
+    service.removeAllListeners();
+  });
+
+  it("getCircuitBreakerState returns correct state for a closed breaker", () => {
+    const endpoint = (service as any).mapToEndpoint(makeEndpointRow({
+      consecutive_failures: 0,
+      circuit_breaker_status: "closed",
+    }));
+    const state = service.getCircuitBreakerState(endpoint);
+    expect(state.status).toBe("closed");
+    expect(state.consecutiveFailures).toBe(0);
+    expect(state.threshold).toBe(10);
+    expect(state.trippedAt).toBeNull();
+    expect(state.resetAt).toBeNull();
+  });
+
+  it("getCircuitBreakerState returns correct state for an open breaker", () => {
+    const trippedAt = new Date();
+    const endpoint = (service as any).mapToEndpoint(makeEndpointRow({
+      consecutive_failures: 10,
+      circuit_breaker_status: "open",
+      circuit_breaker_tripped_at: trippedAt,
+    }));
+    const state = service.getCircuitBreakerState(endpoint);
+    expect(state.status).toBe("open");
+    expect(state.consecutiveFailures).toBe(10);
+    expect(state.trippedAt).toBe(trippedAt);
+  });
+
+  it("mapToEndpoint parses new circuit breaker fields", () => {
+    const trippedAt = new Date();
+    const resetAt = new Date();
+    const row = makeEndpointRow({
+      consecutive_failures: 5,
+      circuit_breaker_status: "half_open",
+      circuit_breaker_tripped_at: trippedAt,
+      circuit_breaker_reset_at: resetAt,
+    });
+    const endpoint = (service as any).mapToEndpoint(row);
+    expect(endpoint.consecutiveFailures).toBe(5);
+    expect(endpoint.circuitBreakerStatus).toBe("half_open");
+    expect(endpoint.circuitBreakerTrippedAt).toBe(trippedAt);
+    expect(endpoint.circuitBreakerResetAt).toBe(resetAt);
+  });
+
+  it("mapToEndpoint defaults circuit breaker fields when missing", () => {
+    const row = makeEndpointRow({
+      consecutive_failures: undefined,
+      circuit_breaker_status: undefined,
+      circuit_breaker_tripped_at: undefined,
+      circuit_breaker_reset_at: undefined,
+    });
+    const endpoint = (service as any).mapToEndpoint(row);
+    expect(endpoint.consecutiveFailures).toBe(0);
+    expect(endpoint.circuitBreakerStatus).toBe("closed");
+    expect(endpoint.circuitBreakerTrippedAt).toBeNull();
+    expect(endpoint.circuitBreakerResetAt).toBeNull();
   });
 });


### PR DESCRIPTION
## Track consecutive failures per webhook endpoint and automatically suspend delivery when the threshold (10) is reached. This prevents wasted worker resources, locked DB connections, and job queue backlogs when custom endpoints fail repeatedly.

Changes:
- Add migration 046 for circuit breaker columns on webhook_endpoints
- Add WebhookCircuitBreakerStatus type and circuit breaker logic to WebhookService (recordSuccess, recordFailure, tripCircuitBreaker, resetCircuitBreaker, getCircuitBreakerState)
- Integrate circuit breaker tracking in webhookDelivery.worker.ts (recordSuccess on delivery complete, recordFailure after max retries)
- Add WebSocket webhook_system_event message type for real-time notifications on the events channel
- Wire up tripped/reset events from WebhookService to wsServer broadcast
- Add REST endpoints: GET/POST /endpoints/:id/circuit-breaker[/reset]
- Add unit tests for circuit breaker mapper and state resolution
- Update webhook.service.outbox.ts mapToEndpoint for new fields


## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Dependency update

## Related Issue


Closes #806 
Closes #812 
Closes #813 
Closes #816 
