### PR TITLE
feat: distributed job lock, horizon stream leak fix, websocket QoS, a…

### DIFF
--- a/backend/src/jobs/batchReconciliation.job.ts
+++ b/backend/src/jobs/batchReconciliation.job.ts
@@ -1,5 +1,6 @@
 import { SUPPORTED_ASSETS } from "../config/index.js";
 import { ReconciliationService } from "../services/reconciliation.service.js";
+import { distributedLockService } from "../services/distributedLock.service.js";
 import { logger } from "../utils/logger.js";
 
 const RECONCILIATION_INTERVAL_MS = Number(process.env.RECONCILIATION_INTERVAL_MS) || 600000; // 10 min default
@@ -106,15 +107,21 @@ export async function runBatchReconciliation(): Promise<BatchReconciliationRepor
   return report;
 }
 
+const LOCK_KEY = "batch-reconciliation";
+
+function runLocked(): Promise<unknown> {
+  return distributedLockService.withLock(LOCK_KEY, RECONCILIATION_INTERVAL_MS, runBatchReconciliation);
+}
+
 export function startBatchReconciliationJob(): void {
   logger.info({ intervalMs: RECONCILIATION_INTERVAL_MS }, "Starting batch reconciliation job scheduler");
 
-  runBatchReconciliation().catch((err) => {
+  runLocked().catch((err) => {
     logger.error({ error: err }, "Initial batch reconciliation run failed");
   });
 
   reconciliationInterval = setInterval(() => {
-    runBatchReconciliation().catch((err) => {
+    runLocked().catch((err) => {
       logger.error({ error: err }, "Scheduled batch reconciliation run failed");
     });
   }, RECONCILIATION_INTERVAL_MS);

--- a/backend/src/jobs/providerCircuitBreaker.job.ts
+++ b/backend/src/jobs/providerCircuitBreaker.job.ts
@@ -1,4 +1,5 @@
 import { providerCircuitBreakerService } from "../services/providerCircuitBreaker.service.js";
+import { distributedLockService } from "../services/distributedLock.service.js";
 import { logger } from "../utils/logger.js";
 
 const PROBE_SWEEP_INTERVAL_MS = Number(process.env.PROVIDER_BREAKER_PROBE_INTERVAL_MS) || 30_000; // 30s default
@@ -18,11 +19,17 @@ export async function runRecoveryProbeSweep(): Promise<number> {
   }
 }
 
+const LOCK_KEY = "provider-circuit-breaker-sweep";
+
+function runLocked(): Promise<unknown> {
+  return distributedLockService.withLock(LOCK_KEY, PROBE_SWEEP_INTERVAL_MS, runRecoveryProbeSweep);
+}
+
 export function startProviderCircuitBreakerJob(): void {
   logger.info({ intervalMs: PROBE_SWEEP_INTERVAL_MS }, "Starting provider circuit breaker recovery probe job");
 
   probeSweepInterval = setInterval(() => {
-    runRecoveryProbeSweep().catch((err) => {
+    runLocked().catch((err) => {
       logger.error({ error: err }, "Scheduled provider circuit breaker probe sweep failed");
     });
   }, PROBE_SWEEP_INTERVAL_MS);

--- a/backend/src/jobs/sourceDecommission.job.ts
+++ b/backend/src/jobs/sourceDecommission.job.ts
@@ -1,4 +1,5 @@
 import { sourceDecommissionService } from "../services/sourceDecommission.service.js";
+import { distributedLockService } from "../services/distributedLock.service.js";
 import { logger } from "../utils/logger.js";
 
 const CHECK_INTERVAL_MS = Number(process.env.SOURCE_DECOMMISSION_CHECK_INTERVAL_MS) || 3_600_000; // 1 hour default
@@ -18,15 +19,21 @@ export async function runSourceDecommissionCheck(): Promise<number> {
   }
 }
 
+const LOCK_KEY = "source-decommission";
+
+function runLocked(): Promise<unknown> {
+  return distributedLockService.withLock(LOCK_KEY, CHECK_INTERVAL_MS, runSourceDecommissionCheck);
+}
+
 export function startSourceDecommissionJob(): void {
   logger.info({ intervalMs: CHECK_INTERVAL_MS }, "Starting source decommission readiness job scheduler");
 
-  runSourceDecommissionCheck().catch((err) => {
+  runLocked().catch((err) => {
     logger.error({ error: err }, "Initial source decommission readiness check failed");
   });
 
   decommissionCheckInterval = setInterval(() => {
-    runSourceDecommissionCheck().catch((err) => {
+    runLocked().catch((err) => {
       logger.error({ error: err }, "Scheduled source decommission readiness check failed");
     });
   }, CHECK_INTERVAL_MS);

--- a/backend/src/services/distributedLock.service.ts
+++ b/backend/src/services/distributedLock.service.ts
@@ -1,0 +1,43 @@
+import { randomUUID } from "crypto";
+import { redis } from "../utils/redis.js";
+import { logger } from "../utils/logger.js";
+
+const RELEASE_SCRIPT = `
+if redis.call("get", KEYS[1]) == ARGV[1] then
+  return redis.call("del", KEYS[1])
+else
+  return 0
+end
+`;
+
+export class DistributedLockService {
+  async acquire(key: string, ttlMs: number): Promise<string | null> {
+    const token = randomUUID();
+    const result = await redis.set(`lock:${key}`, token, "PX", ttlMs, "NX");
+    return result === "OK" ? token : null;
+  }
+
+  async release(key: string, token: string): Promise<void> {
+    try {
+      await redis.eval(RELEASE_SCRIPT, 1, `lock:${key}`, token);
+    } catch (err) {
+      logger.warn({ err, key }, "Failed to release distributed lock");
+    }
+  }
+
+  async withLock<T>(key: string, ttlMs: number, fn: () => Promise<T>): Promise<T | null> {
+    const token = await this.acquire(key, ttlMs);
+    if (!token) {
+      logger.info({ key }, "Skipping job run — distributed lock held by another instance");
+      return null;
+    }
+
+    try {
+      return await fn();
+    } finally {
+      await this.release(key, token);
+    }
+  }
+}
+
+export const distributedLockService = new DistributedLockService();

--- a/backend/src/services/horizonStreamSupervisor.service.ts
+++ b/backend/src/services/horizonStreamSupervisor.service.ts
@@ -86,6 +86,7 @@ export class HorizonStreamSupervisor extends EventEmitter {
     if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
     if (this.gapCheckTimer) clearInterval(this.gapCheckTimer);
     this.abortController?.abort();
+    this.removeAllListeners();
     logger.info({ streamId: this.streamId }, "Horizon stream supervisor stopped");
   }
 
@@ -131,13 +132,12 @@ export class HorizonStreamSupervisor extends EventEmitter {
     this.setStatus("connecting");
     logger.info({ streamId: this.streamId, url: streamUrl }, "Connecting to Horizon stream");
 
+    const timeoutId = setTimeout(() => this.abortController?.abort(), this.timeoutMs);
     try {
-      const timeoutId = setTimeout(() => this.abortController?.abort(), this.timeoutMs);
       const response = await fetch(streamUrl, {
         headers: { Accept: "text/event-stream" },
         signal,
       });
-      clearTimeout(timeoutId);
 
       if (!response.ok || !response.body) {
         throw new Error(`HTTP ${response.status} ${response.statusText}`);
@@ -182,6 +182,8 @@ export class HorizonStreamSupervisor extends EventEmitter {
       logger.warn({ streamId: this.streamId, error: errMsg }, "Horizon stream error");
       this.setStatus("error");
       this._scheduleReconnect();
+    } finally {
+      clearTimeout(timeoutId);
     }
   }
 


### PR DESCRIPTION

- Add Redis-backed DistributedLockService (SET NX PX + safe Lua release) and wrap batch reconciliation, source decommission, and provider circuit breaker job schedulers with it so only one backend replica runs each job.
- Fix horizonStreamSupervisor memory leak: clear the connect timeout on every exit path (not just the success path) and remove all listeners on stop() so re-created streams don't hold onto prior references.
 — WebSocket connection recovery / message acknowledgment queue.
 — Arbitrage index indicator and divergence charts.

Closes #792
Closes #795
Closes #793
Closes #827

