### PR TITLE
fix: rate limit warning, API error standardization, fee distribution tests, calendar view

### DIFF
--- a/backend/src/api/middleware/rateLimit.middleware.ts
+++ b/backend/src/api/middleware/rateLimit.middleware.ts
@@ -392,6 +392,23 @@ export async function registerRateLimiting(server: FastifyInstance): Promise<voi
     );
     reply.header("X-RateLimit-Tier", tier);
 
+    // ---- Warn when approaching the rate limit threshold (≤10% remaining) --
+    if (!denied && bindingResult.remaining <= Math.ceil(bindingResult.limit * 0.1)) {
+      logger.warn(
+        {
+          ip,
+          hasApiKey: apiKey !== undefined,
+          tier,
+          routeGroup,
+          remaining: bindingResult.remaining,
+          limit: bindingResult.limit,
+          threshold: "10%",
+          resetAt: new Date(bindingResult.resetMs).toISOString(),
+        },
+        "Rate limit threshold approaching"
+      );
+    }
+
     // ---- Reject if over limit --------------------------------------------
     if (denied) {
       metrics.blockedRequests++;

--- a/backend/src/api/routes/externalDependencies.routes.ts
+++ b/backend/src/api/routes/externalDependencies.routes.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { authMiddleware } from "../middleware/auth.js";
 import { ExternalDependencyMonitorService } from "../../services/externalDependencyMonitor.service.js";
 import { logger } from "../../utils/logger.js";
+import { sendApiError } from "../utils/response.js";
 
 const monitorService = new ExternalDependencyMonitorService();
 
@@ -32,8 +33,7 @@ export async function externalDependenciesRoutes(server: FastifyInstance) {
         return await monitorService.listDependencies(query);
       } catch (error) {
         logger.error(error, "Failed to list external dependencies");
-        reply.code(500);
-        return { error: "Failed to list external dependencies" };
+        return sendApiError(reply, 500, "Failed to list external dependencies");
       }
     }
   );
@@ -56,8 +56,7 @@ export async function externalDependenciesRoutes(server: FastifyInstance) {
         return { providerKey: request.params.providerKey, history };
       } catch (error) {
         logger.error(error, "Failed to load dependency history");
-        reply.code(500);
-        return { error: "Failed to load dependency history" };
+        return sendApiError(reply, 500, "Failed to load dependency history");
       }
     }
   );
@@ -73,8 +72,7 @@ export async function externalDependenciesRoutes(server: FastifyInstance) {
         return { success: true, results };
       } catch (error) {
         logger.error(error, "Failed to run external dependency checks");
-        reply.code(500);
-        return { success: false, error: "Failed to run external dependency checks" };
+        return sendApiError(reply, 500, "Failed to run external dependency checks");
       }
     }
   );
@@ -100,15 +98,13 @@ export async function externalDependenciesRoutes(server: FastifyInstance) {
         );
 
         if (!dependency) {
-          reply.code(404);
-          return { error: "Dependency not found" };
+          return sendApiError(reply, 404, "Dependency not found");
         }
 
         return { success: true, dependency };
       } catch (error) {
         logger.error(error, "Failed to update dependency maintenance mode");
-        reply.code(500);
-        return { success: false, error: "Failed to update dependency maintenance mode" };
+        return sendApiError(reply, 500, "Failed to update dependency maintenance mode");
       }
     }
   );

--- a/backend/src/api/routes/provenance.routes.ts
+++ b/backend/src/api/routes/provenance.routes.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance } from "fastify";
 import { provenanceService } from "../../services/provenance.service.js";
+import { sendApiError } from "../utils/response.js";
 
 export async function provenanceRoutes(server: FastifyInstance) {
   server.get<{
@@ -93,7 +94,7 @@ export async function provenanceRoutes(server: FastifyInstance) {
       const { metric, asset, bridge } = request.query;
       const graph = provenanceService.getLineage(metric, asset, bridge);
       if (!graph) {
-        return reply.code(404).send({ error: "No provenance graph found for the given parameters" });
+        return sendApiError(reply, 404, "No provenance graph found for the given parameters");
       }
       return graph;
     },

--- a/backend/src/api/utils/response.ts
+++ b/backend/src/api/utils/response.ts
@@ -1,0 +1,51 @@
+import type { FastifyReply } from "fastify";
+
+const HTTP_STATUS_TEXTS: Record<number, string> = {
+  400: "Bad Request",
+  401: "Unauthorized",
+  403: "Forbidden",
+  404: "Not Found",
+  409: "Conflict",
+  422: "Unprocessable Entity",
+  429: "Too Many Requests",
+  500: "Internal Server Error",
+  502: "Bad Gateway",
+  503: "Service Unavailable",
+};
+
+function statusText(code: number): string {
+  return HTTP_STATUS_TEXTS[code] ?? "Error";
+}
+
+export interface ApiErrorBody {
+  statusCode: number;
+  error: string;
+  message: string;
+  details?: Record<string, unknown>;
+}
+
+/**
+ * Send a standardized JSON error response across all Fastify routes.
+ *
+ * Replaces the mix of `{ error: string }` and `{ message, statusCode }`
+ * shapes that existed in various route handlers. All error responses now
+ * follow the same envelope so API consumers can handle errors uniformly.
+ *
+ * @example
+ * sendApiError(reply, 404, "Metric not found");
+ * sendApiError(reply, 400, "Invalid payload", { field: "name" });
+ */
+export function sendApiError(
+  reply: FastifyReply,
+  statusCode: number,
+  message: string,
+  details?: Record<string, unknown>
+): ReturnType<FastifyReply["send"]> {
+  const body: ApiErrorBody = {
+    statusCode,
+    error: statusText(statusCode),
+    message,
+    ...(details !== undefined && { details }),
+  };
+  return reply.status(statusCode).send(body);
+}

--- a/contracts/soroban/Cargo.toml
+++ b/contracts/soroban/Cargo.toml
@@ -41,3 +41,7 @@ path = "tests/threshold_window.test.rs"
 [[test]]
 name = "acl_test"
 path = "tests/acl.test.rs"
+
+[[test]]
+name = "fee_distribution_test"
+path = "tests/fee_distribution_test.rs"

--- a/contracts/soroban/tests/fee_distribution_test.rs
+++ b/contracts/soroban/tests/fee_distribution_test.rs
@@ -1,0 +1,294 @@
+#![cfg(test)]
+
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token, vec, Address, Env, Vec,
+};
+use bridge_watch_contracts::fee_distribution::{
+    DistributionRatios, FeeDistributionContract, FeeDistributionContractClient,
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+fn setup() -> (
+    Env,
+    FeeDistributionContractClient<'static>,
+    Address, // admin
+    Address, // treasury
+    Address, // staking_token address
+    Address, // fee_token address
+) {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let contract_id = env.register_contract(None, FeeDistributionContract);
+    let client = FeeDistributionContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+
+    let staking_token = env.register_stellar_asset_contract(admin.clone());
+    let fee_token = env.register_stellar_asset_contract(admin.clone());
+
+    let ratios = DistributionRatios {
+        stakers_bps: 7000,    // 70%
+        governance_bps: 2000, // 20%
+        treasury_bps: 1000,   // 10%
+    };
+
+    client.initialize(
+        &admin,
+        &treasury,
+        &staking_token,
+        &ratios,
+        &0u64, // no auto-distribution interval
+    );
+
+    client.add_fee_token(&fee_token);
+
+    (env, client, admin, treasury, staking_token, fee_token)
+}
+
+fn mint(env: &Env, token: &Address, admin: &Address, to: &Address, amount: i128) {
+    token::StellarAssetClient::new(env, token).mint(to, &amount);
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+/// Two stakers with equal stakes receive equal shares of the stakers' portion.
+#[test]
+fn test_equal_stakes_receive_equal_rewards() {
+    let (env, client, admin, treasury, staking_token, fee_token) = setup();
+    let staker_a = Address::generate(&env);
+    let staker_b = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    // Mint staking tokens and stake equal amounts
+    mint(&env, &staking_token, &admin, &staker_a, 1_000);
+    mint(&env, &staking_token, &admin, &staker_b, 1_000);
+    client.stake_for_fees(&staker_a, &1_000, &false);
+    client.stake_for_fees(&staker_b, &1_000, &false);
+
+    // Collect 10_000 fee tokens
+    client.add_collector(&collector);
+    mint(&env, &fee_token, &admin, &collector, 10_000);
+    client.collect_fees(&collector, &fee_token, &10_000);
+
+    // Distribute
+    client.distribute_fees(&vec![&env]);
+
+    // stakers_bps = 7000 → 7_000 tokens for stakers total
+    // Each staker gets 3_500 (50/50 split)
+    let pending_a = client.get_pending_rewards(&staker_a, &fee_token);
+    let pending_b = client.get_pending_rewards(&staker_b, &fee_token);
+    assert_eq!(pending_a, 3_500);
+    assert_eq!(pending_b, 3_500);
+
+    // Treasury slice = 10% = 1_000
+    let treasury_client = token::Client::new(&env, &fee_token);
+    assert_eq!(treasury_client.balance(&treasury), 1_000);
+
+    // Governance pool = 20% = 2_000
+    let pool = client.get_fee_pool(&fee_token).unwrap();
+    assert_eq!(pool.governance_pool, 2_000);
+}
+
+/// Proportional stake weighting: a 3:1 stake ratio produces a 3:1 reward ratio.
+#[test]
+fn test_proportional_reward_split_by_stake_weight() {
+    let (env, client, admin, _treasury, staking_token, fee_token) = setup();
+    let staker_a = Address::generate(&env);
+    let staker_b = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    mint(&env, &staking_token, &admin, &staker_a, 3_000);
+    mint(&env, &staking_token, &admin, &staker_b, 1_000);
+    client.stake_for_fees(&staker_a, &3_000, &false);
+    client.stake_for_fees(&staker_b, &1_000, &false);
+
+    client.add_collector(&collector);
+    mint(&env, &fee_token, &admin, &collector, 8_000);
+    client.collect_fees(&collector, &fee_token, &8_000);
+    client.distribute_fees(&vec![&env]);
+
+    // stakers_bps = 70% → 5_600 for stakers
+    // staker_a stake = 3/4 → 4_200; staker_b = 1/4 → 1_400
+    let pending_a = client.get_pending_rewards(&staker_a, &fee_token);
+    let pending_b = client.get_pending_rewards(&staker_b, &fee_token);
+    assert_eq!(pending_a, 4_200);
+    assert_eq!(pending_b, 1_400);
+    assert_eq!(pending_a, pending_b * 3);
+}
+
+/// When no one is staked, the staker portion overflows to the governance pool.
+#[test]
+fn test_no_stakers_routes_orphan_fees_to_governance() {
+    let (env, client, admin, _treasury, _staking_token, fee_token) = setup();
+    let collector = Address::generate(&env);
+
+    client.add_collector(&collector);
+    mint(&env, &fee_token, &admin, &collector, 10_000);
+    client.collect_fees(&collector, &fee_token, &10_000);
+    client.distribute_fees(&vec![&env]);
+
+    let pool = client.get_fee_pool(&fee_token).unwrap();
+    // governance gets its own 20% + orphan staker 70% = 90%
+    assert_eq!(pool.governance_pool, 9_000);
+    assert_eq!(pool.acc_fee_per_share, 0);
+}
+
+/// A staker with zero balance gets zero rewards.
+#[test]
+fn test_zero_stake_yields_zero_rewards() {
+    let (env, client, admin, _treasury, staking_token, fee_token) = setup();
+    let staker = Address::generate(&env);
+    let real_staker = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    // Only real_staker stakes; `staker` never stakes.
+    mint(&env, &staking_token, &admin, &real_staker, 500);
+    client.stake_for_fees(&real_staker, &500, &false);
+
+    client.add_collector(&collector);
+    mint(&env, &fee_token, &admin, &collector, 5_000);
+    client.collect_fees(&collector, &fee_token, &5_000);
+    client.distribute_fees(&vec![&env]);
+
+    let pending = client.get_pending_rewards(&staker, &fee_token);
+    assert_eq!(pending, 0, "unstaked address should receive no rewards");
+}
+
+/// Late stakers do not receive fees distributed before their entry.
+#[test]
+fn test_late_staker_excluded_from_past_distribution() {
+    let (env, client, admin, _treasury, staking_token, fee_token) = setup();
+    let early = Address::generate(&env);
+    let late = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    mint(&env, &staking_token, &admin, &early, 1_000);
+    client.stake_for_fees(&early, &1_000, &false);
+
+    client.add_collector(&collector);
+    mint(&env, &fee_token, &admin, &collector, 10_000);
+    client.collect_fees(&collector, &fee_token, &10_000);
+
+    // Distribute before late staker joins
+    client.distribute_fees(&vec![&env]);
+
+    // Late staker joins after distribution
+    mint(&env, &staking_token, &admin, &late, 1_000);
+    client.stake_for_fees(&late, &1_000, &false);
+
+    let pending_early = client.get_pending_rewards(&early, &fee_token);
+    let pending_late = client.get_pending_rewards(&late, &fee_token);
+
+    assert_eq!(pending_early, 7_000, "early staker gets full staker slice");
+    assert_eq!(pending_late, 0, "late staker excluded from past round");
+}
+
+/// Claiming rewards resets pending balance to zero.
+#[test]
+fn test_claim_fees_clears_pending_balance() {
+    let (env, client, admin, _treasury, staking_token, fee_token) = setup();
+    let staker = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    mint(&env, &staking_token, &admin, &staker, 1_000);
+    client.stake_for_fees(&staker, &1_000, &false);
+
+    client.add_collector(&collector);
+    mint(&env, &fee_token, &admin, &collector, 10_000);
+    client.collect_fees(&collector, &fee_token, &10_000);
+    client.distribute_fees(&vec![&env]);
+
+    assert!(client.get_pending_rewards(&staker, &fee_token) > 0);
+
+    client.claim_fees(&staker, &fee_token);
+
+    assert_eq!(
+        client.get_pending_rewards(&staker, &fee_token),
+        0,
+        "pending balance should be zero after claim"
+    );
+}
+
+/// Multiple consecutive distributions accumulate correctly.
+#[test]
+fn test_multiple_distributions_accumulate() {
+    let (env, client, admin, _treasury, staking_token, fee_token) = setup();
+    let staker = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    mint(&env, &staking_token, &admin, &staker, 1_000);
+    client.stake_for_fees(&staker, &1_000, &false);
+    client.add_collector(&collector);
+
+    for _ in 0..3u32 {
+        mint(&env, &fee_token, &admin, &collector, 1_000);
+        client.collect_fees(&collector, &fee_token, &1_000);
+        client.distribute_fees(&vec![&env]);
+    }
+
+    // 3 rounds × 1_000 fees × 70% staker share = 2_100
+    let pending = client.get_pending_rewards(&staker, &fee_token);
+    assert_eq!(pending, 2_100);
+}
+
+/// Ratios must sum to 10000 bps; invalid ratios panic.
+#[test]
+#[should_panic(expected = "ratios must sum to 10000")]
+fn test_invalid_ratios_panic() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, FeeDistributionContract);
+    let client = FeeDistributionContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let staking_token = env.register_stellar_asset_contract(admin.clone());
+
+    // stakers_bps + governance_bps + treasury_bps = 11000, not 10000
+    let bad_ratios = DistributionRatios {
+        stakers_bps: 5000,
+        governance_bps: 4000,
+        treasury_bps: 2000,
+    };
+
+    client.initialize(&admin, &treasury, &staking_token, &bad_ratios, &0u64);
+}
+
+/// Emergency mode blocks fee collection and distribution.
+#[test]
+#[should_panic(expected = "contract is in emergency mode")]
+fn test_emergency_mode_blocks_collect_fees() {
+    let (env, client, admin, _treasury, _staking_token, fee_token) = setup();
+    let collector = Address::generate(&env);
+
+    client.add_collector(&collector);
+    client.set_emergency(&true);
+
+    mint(&env, &fee_token, &admin, &collector, 1_000);
+    client.collect_fees(&collector, &fee_token, &1_000);
+}
+
+/// get_pending_rewards returns zero for an address that has never staked,
+/// regardless of how many distributions have occurred.
+#[test]
+fn test_pending_rewards_for_never_staked_address_is_zero() {
+    let (env, client, admin, _treasury, staking_token, fee_token) = setup();
+    let staker = Address::generate(&env);
+    let outsider = Address::generate(&env);
+    let collector = Address::generate(&env);
+
+    mint(&env, &staking_token, &admin, &staker, 500);
+    client.stake_for_fees(&staker, &500, &false);
+    client.add_collector(&collector);
+    mint(&env, &fee_token, &admin, &collector, 10_000);
+    client.collect_fees(&collector, &fee_token, &10_000);
+    client.distribute_fees(&vec![&env]);
+
+    assert_eq!(client.get_pending_rewards(&outsider, &fee_token), 0);
+}

--- a/frontend/src/pages/ExportScheduler.tsx
+++ b/frontend/src/pages/ExportScheduler.tsx
@@ -1,8 +1,202 @@
 import { useState } from "react";
 import { ScheduleForm, ScheduleList } from "../components/ExportScheduler";
+import { useExportSchedulerStore } from "../stores/exportSchedulerStore";
+import type { ScheduledExport } from "../services/api";
+
+// ── Calendar helpers ──────────────────────────────────────────────────────────
+
+function getDaysInMonth(year: number, month: number): number {
+  return new Date(year, month + 1, 0).getDate();
+}
+
+function getFirstDayOfWeek(year: number, month: number): number {
+  return new Date(year, month, 1).getDay();
+}
+
+function getScheduledDaysForMonth(
+  schedules: ScheduledExport[],
+  year: number,
+  month: number
+): Map<number, ScheduledExport[]> {
+  const map = new Map<number, ScheduledExport[]>();
+  const daysInMonth = getDaysInMonth(year, month);
+
+  for (const s of schedules) {
+    if (!s.isActive) continue;
+
+    if (s.frequency === "daily") {
+      for (let d = 1; d <= daysInMonth; d++) {
+        const list = map.get(d) ?? [];
+        list.push(s);
+        map.set(d, list);
+      }
+    } else if (s.frequency === "weekly" && s.dayOfWeek !== undefined) {
+      for (let d = 1; d <= daysInMonth; d++) {
+        if (new Date(year, month, d).getDay() === s.dayOfWeek) {
+          const list = map.get(d) ?? [];
+          list.push(s);
+          map.set(d, list);
+        }
+      }
+    } else if (s.frequency === "monthly") {
+      const day = s.dayOfMonth ?? 1;
+      if (day <= daysInMonth) {
+        const list = map.get(day) ?? [];
+        list.push(s);
+        map.set(day, list);
+      }
+    }
+  }
+
+  return map;
+}
+
+const MONTH_NAMES = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+];
+const DAY_HEADERS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+// ── Calendar component ────────────────────────────────────────────────────────
+
+function ScheduleCalendar({ schedules }: { schedules: ScheduledExport[] }) {
+  const today = new Date();
+  const [calYear, setCalYear] = useState(today.getFullYear());
+  const [calMonth, setCalMonth] = useState(today.getMonth());
+
+  const scheduledDays = getScheduledDaysForMonth(schedules, calYear, calMonth);
+  const daysInMonth = getDaysInMonth(calYear, calMonth);
+  const firstDow = getFirstDayOfWeek(calYear, calMonth);
+
+  function prevMonth() {
+    if (calMonth === 0) {
+      setCalYear((y) => y - 1);
+      setCalMonth(11);
+    } else {
+      setCalMonth((m) => m - 1);
+    }
+  }
+
+  function nextMonth() {
+    if (calMonth === 11) {
+      setCalYear((y) => y + 1);
+      setCalMonth(0);
+    } else {
+      setCalMonth((m) => m + 1);
+    }
+  }
+
+  const cells: Array<{ day: number | null }> = [];
+  for (let i = 0; i < firstDow; i++) cells.push({ day: null });
+  for (let d = 1; d <= daysInMonth; d++) cells.push({ day: d });
+  while (cells.length % 7 !== 0) cells.push({ day: null });
+
+  const isToday = (d: number) =>
+    d === today.getDate() &&
+    calMonth === today.getMonth() &&
+    calYear === today.getFullYear();
+
+  return (
+    <div className="bg-stellar-card border border-stellar-border rounded-lg p-5">
+      {/* Month navigation */}
+      <div className="flex items-center justify-between mb-4">
+        <button
+          type="button"
+          onClick={prevMonth}
+          className="p-1.5 rounded hover:bg-stellar-border transition-colors text-stellar-text-secondary hover:text-white"
+          aria-label="Previous month"
+        >
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+          </svg>
+        </button>
+        <h3 className="text-white font-semibold text-sm">
+          {MONTH_NAMES[calMonth]} {calYear}
+        </h3>
+        <button
+          type="button"
+          onClick={nextMonth}
+          className="p-1.5 rounded hover:bg-stellar-border transition-colors text-stellar-text-secondary hover:text-white"
+          aria-label="Next month"
+        >
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+          </svg>
+        </button>
+      </div>
+
+      {/* Day-of-week headers */}
+      <div className="grid grid-cols-7 mb-1">
+        {DAY_HEADERS.map((h) => (
+          <div
+            key={h}
+            className="text-center text-xs font-medium text-stellar-text-muted py-1"
+          >
+            {h}
+          </div>
+        ))}
+      </div>
+
+      {/* Calendar grid */}
+      <div className="grid grid-cols-7 gap-px bg-stellar-border rounded overflow-hidden">
+        {cells.map((cell, idx) => {
+          const scheduled = cell.day !== null ? (scheduledDays.get(cell.day) ?? []) : [];
+          return (
+            <div
+              key={idx}
+              className={`min-h-[56px] p-1 flex flex-col bg-stellar-dark ${
+                cell.day === null ? "opacity-0 pointer-events-none" : ""
+              }`}
+            >
+              {cell.day !== null && (
+                <>
+                  <span
+                    className={`text-xs font-medium self-end w-5 h-5 flex items-center justify-center rounded-full ${
+                      isToday(cell.day)
+                        ? "bg-stellar-blue text-white"
+                        : "text-stellar-text-secondary"
+                    }`}
+                  >
+                    {cell.day}
+                  </span>
+                  <div className="mt-0.5 space-y-0.5 overflow-hidden">
+                    {scheduled.slice(0, 2).map((s) => (
+                      <div
+                        key={s.id}
+                        title={`${s.name} · ${s.timeOfDay}`}
+                        className="text-[10px] leading-tight bg-stellar-blue/20 text-stellar-blue rounded px-1 truncate"
+                      >
+                        {s.name}
+                      </div>
+                    ))}
+                    {scheduled.length > 2 && (
+                      <div className="text-[10px] text-stellar-text-muted px-1">
+                        +{scheduled.length - 2} more
+                      </div>
+                    )}
+                  </div>
+                </>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {schedules.filter((s) => s.isActive).length === 0 && (
+        <p className="text-center text-sm text-stellar-text-muted mt-4">
+          No active schedules to display.
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────────
 
 export default function ExportScheduler() {
   const [showForm, setShowForm] = useState(false);
+  const [view, setView] = useState<"list" | "calendar">("list");
+  const schedules = useExportSchedulerStore((s) => s.schedules);
 
   return (
     <div className="space-y-8">
@@ -34,10 +228,55 @@ export default function ExportScheduler() {
       )}
 
       <section aria-label="Scheduled exports">
-        <div className="flex items-center gap-3 mb-4">
+        <div className="flex items-center justify-between gap-3 mb-4">
           <h2 className="text-lg font-semibold text-white">Scheduled Exports</h2>
+
+          {/* View toggle */}
+          <div
+            className="flex items-center rounded-lg border border-stellar-border overflow-hidden text-sm"
+            role="group"
+            aria-label="View mode"
+          >
+            <button
+              type="button"
+              onClick={() => setView("list")}
+              className={`flex items-center gap-1.5 px-3 py-1.5 transition-colors ${
+                view === "list"
+                  ? "bg-stellar-blue text-white"
+                  : "text-stellar-text-secondary hover:text-white"
+              }`}
+              aria-pressed={view === "list"}
+            >
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                  d="M4 6h16M4 10h16M4 14h16M4 18h16" />
+              </svg>
+              List
+            </button>
+            <button
+              type="button"
+              onClick={() => setView("calendar")}
+              className={`flex items-center gap-1.5 px-3 py-1.5 transition-colors ${
+                view === "calendar"
+                  ? "bg-stellar-blue text-white"
+                  : "text-stellar-text-secondary hover:text-white"
+              }`}
+              aria-pressed={view === "calendar"}
+            >
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                  d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+              </svg>
+              Calendar
+            </button>
+          </div>
         </div>
-        <ScheduleList />
+
+        {view === "list" ? (
+          <ScheduleList />
+        ) : (
+          <ScheduleCalendar schedules={schedules} />
+        )}
       </section>
 
       {/* Info panel */}


### PR DESCRIPTION
Closes #873
Closes #874
Closes #875
Closes #877

## Summary

- **#875 — Rate limit threshold warning**: adds a `logger.warn` in `rateLimit.middleware.ts` when remaining requests drop to ≤10% of the limit; log includes `ip`, `tier`, `routeGroup`, `remaining`, `limit`, `threshold: "10%"`, and `resetAt` as ISO-8601 timestamp.
- **#877 — API error standardization**: introduces `sendApiError(reply, statusCode, message, details?)` in `backend/src/api/utils/response.ts`; migrates `externalDependencies.routes.ts` (4 call sites) and `provenance.routes.ts` (1 call site) to produce a consistent `{ statusCode, error, message }` shape.
- **#874 — Fee distribution tests**: adds `contracts/soroban/tests/fee_distribution_test.rs` with 9 tests: equal-stake split, proportional 3:1 split, orphan-fee routing to governance, zero-stake guard, late-staker exclusion, claim-clears-pending, multi-round accumulation, invalid-ratios panic, emergency-mode block. Registered as `[[test]]` entry in `Cargo.toml`.
- **#873 — Calendar view**: adds a List/Calendar toggle to `ExportScheduler.tsx`; the `ScheduleCalendar` component renders a navigable monthly grid, placing each active `ScheduledExport` on its run days (daily every day, weekly by `dayOfWeek`, monthly by `dayOfMonth`), with today highlighted and overflow chips showing "+N more".

## Test plan

- [ ] Rate limit warning fires when `remaining ≤ ceil(limit * 0.1)` and contains ISO `resetAt`
- [ ] Error responses from external-dependencies and provenance routes have `statusCode`, `error`, `message` fields
- [ ] Fee distribution test file compiles and all 9 tests pass (`cargo test --test fee_distribution_test`)
- [ ] Calendar toggle renders a monthly grid; prev/next navigation changes the displayed month; today is highlighted; schedules appear on correct days