### PR TITLE
refactor(types): consolidate duplicate domain interface declarations …

### DIFF
--- a/frontend/src/components/AlertConfigSection.tsx
+++ b/frontend/src/components/AlertConfigSection.tsx
@@ -1,13 +1,6 @@
 import AlertSnoozeControls from "./alerts/AlertSnoozeControls";
 import { useAlertSnoozes } from "../hooks/useAlertSnoozes";
-
-interface Alert {
-  id: string;
-  type: string;
-  severity: "info" | "warning" | "critical";
-  message: string;
-  createdAt: string;
-}
+import type { Alert } from "../types";
 
 interface AlertConfigSectionProps {
   alerts: Alert[] | null | undefined;

--- a/frontend/src/components/QuickStats/types.ts
+++ b/frontend/src/components/QuickStats/types.ts
@@ -1,3 +1,5 @@
+import type { AssetWithHealth, Bridge } from "../../types";
+
 export interface StatItem {
   id: string;
   label: string;
@@ -11,34 +13,11 @@ export interface StatItem {
   href?: string;
 }
 
+export type AssetData = AssetWithHealth;
+export type BridgeData = Bridge;
+
 export interface QuickStatsProps {
   assets: AssetData[];
   bridges: BridgeData[];
   isLoading?: boolean;
-}
-
-export interface AssetData {
-  symbol: string;
-  name: string;
-  health: {
-    overallScore: number;
-    factors: {
-      liquidityDepth: number;
-      priceStability: number;
-      bridgeUptime: number;
-      reserveBacking: number;
-      volumeTrend: number;
-    };
-    trend: "improving" | "stable" | "deteriorating";
-    lastUpdated: string;
-  } | null;
-}
-
-export interface BridgeData {
-  name: string;
-  status: "healthy" | "degraded" | "down" | "unknown";
-  totalValueLocked: number;
-  supplyOnStellar: number;
-  supplyOnSource: number;
-  mismatchPercentage: number;
 }

--- a/frontend/src/components/SupplyChainViz/FilterBar.tsx
+++ b/frontend/src/components/SupplyChainViz/FilterBar.tsx
@@ -1,5 +1,5 @@
 const ASSETS = ["USDC", "USDT", "WBTC", "WETH", "XLM"] as const;
-type Asset = (typeof ASSETS)[number];
+type SupportedAssetSymbol = (typeof ASSETS)[number];
 
 interface Props {
   activeAssets: Set<string>;
@@ -11,7 +11,7 @@ interface Props {
   zoomLevel: number;
 }
 
-const ASSET_COLORS: Record<Asset, string> = {
+const ASSET_COLORS: Record<SupportedAssetSymbol, string> = {
   USDC: "#2775CA",
   USDT: "#26A17B",
   WBTC: "#F7931A",

--- a/frontend/src/components/watchlist/WatchlistWidget.tsx
+++ b/frontend/src/components/watchlist/WatchlistWidget.tsx
@@ -6,14 +6,14 @@ import AlertSnoozeControls from "../alerts/AlertSnoozeControls";
 import { useAlertSnoozes } from "../../hooks/useAlertSnoozes";
 import { CollapsibleWidget } from "../dashboard/CollapsibleWidget";
 
-interface AssetAlert {
+interface WatchlistWsAlert {
   symbol: string;
   message: string;
   severity?: "info" | "warning" | "error";
   timestamp?: string;
 }
 
-function asAssetAlert(value: unknown): AssetAlert | null {
+function asAssetAlert(value: unknown): WatchlistWsAlert | null {
   if (!value || typeof value !== "object") {
     return null;
   }
@@ -36,7 +36,7 @@ function asAssetAlert(value: unknown): AssetAlert | null {
 
 export default function WatchlistWidget() {
   const { activeWatchlist, activeSymbols } = useWatchlist();
-  const [alerts, setAlerts] = useState<AssetAlert[]>([]);
+  const [alerts, setAlerts] = useState<WatchlistWsAlert[]>([]);
   const { snooze, unsnooze, getStatus, snoozeMany } = useAlertSnoozes();
 
   const symbolsSet = useMemo(() => new Set(activeSymbols), [activeSymbols]);

--- a/frontend/src/hooks/useAssetInsightsTray.ts
+++ b/frontend/src/hooks/useAssetInsightsTray.ts
@@ -1,13 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
 import { getAssetHealth, getAssetAlerts, getAssetVolume, getAssetHealthHistory } from "../services/api";
+import type { AssetAlert } from "../types";
 
-export interface AssetAlert {
-  id: string;
-  type: string;
-  severity: "info" | "warning" | "critical";
-  message: string;
-  createdAt: string;
-}
+export type { AssetAlert };
 
 export function useAssetInsightsTray(symbol: string | null) {
   const enabled = !!symbol;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -12,7 +12,7 @@ export interface HealthFactors {
 }
 
 export interface HealthScore {
-  symbol: string;
+  symbol?: string;
   overallScore: number;
   factors: HealthFactors;
   trend: "improving" | "stable" | "deteriorating";
@@ -405,6 +405,49 @@ export interface DependencyGraph {
   }>;
   edges: Array<{ from: string; to: string; kind: string }>;
 }
+
+export type RuleThresholdOperator = "gt" | "gte" | "lt" | "lte" | "eq" | "neq" | "between";
+export type RuleLogicOperator = "AND" | "OR";
+export type RulePriority = "low" | "medium" | "high" | "critical";
+export type AlertRuleStatus = "active" | "paused" | "disabled";
+
+export interface RuleCondition {
+  metric: string;
+  operator: RuleThresholdOperator;
+  threshold: number;
+  thresholdHigh?: number;
+  label?: string;
+}
+
+export interface AlertRule {
+  id: string;
+  ownerAddress: string;
+  name: string;
+  description?: string | null;
+  assetCode: string;
+  conditions: RuleCondition[];
+  logicOperator: RuleLogicOperator;
+  priority: RulePriority;
+  status: AlertRuleStatus;
+  cooldownSeconds: number;
+  timeWindow?: string | null;
+  version?: number;
+  templateId?: string | null;
+  webhookUrl?: string | null;
+  lastTriggeredAt?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Alert {
+  id: string;
+  type: string;
+  severity: "info" | "warning" | "critical";
+  message: string;
+  createdAt: string;
+}
+
+export type AssetAlert = Alert;
 
 export type AlertRoutingSeverity = "critical" | "high" | "medium" | "low";
 export type AlertRoutingChannel = "in_app" | "webhook" | "email";


### PR DESCRIPTION
## refactor(types): Consolidate duplicate TypeScript interface declarations (#893)
Motivation
Closes #893

Core domain types — Asset, Bridge, Alert, and AlertRule — were declared independently across multiple frontend component and hook files, creating duplicated interface definitions that could easily drift out of sync. This made it harder to refactor shared data shapes and increased the risk of subtle type mismatches between components consuming the same domain entities.

What changed
All core domain interfaces are now centralized in frontend/src/types/index.ts as the single source of truth. Redundant duplicate definitions in individual component/hook files have been removed and replaced with imports from the canonical location.

New types added to frontend/src/types/index.ts
AlertRule — full alert rule entity with supporting types (RuleCondition, RuleThresholdOperator, RuleLogicOperator, RulePriority, AlertRuleStatus)
Alert — base alert entity (id, type, severity, message, createdAt)
AssetAlert — type alias for Alert, preserving the existing public API