### PR TITLE
fix: Prevent UI layout shift when loading dynamic sparkline charts

### DIFF
--- a/frontend/src/components/Sparkline.test.tsx
+++ b/frontend/src/components/Sparkline.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { http, HttpResponse, delay } from "msw";
+import { server } from "../test/mocks/server";
+import Sparkline from "./Sparkline";
+
+class MockIntersectionObserver implements IntersectionObserver {
+  readonly root = null;
+  readonly rootMargin = "";
+  readonly thresholds: ReadonlyArray<number> = [];
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+}
+
+class MockResizeObserver implements ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeAll(() => {
+  global.IntersectionObserver = MockIntersectionObserver as unknown as typeof IntersectionObserver;
+  global.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
+});
+
+const HEALTH_POINTS = Array.from({ length: 10 }, (_, i) => ({
+  timestamp: new Date(Date.now() - (9 - i) * 3_600_000).toISOString(),
+  score: 80 + i,
+}));
+
+function renderSparkline() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <Sparkline symbol="XLM" metric="health" lazy={false} />
+    </QueryClientProvider>
+  );
+}
+
+describe("Sparkline loading skeleton", () => {
+  it("reserves a fixed-height placeholder while data is loading, preventing layout shift", async () => {
+    server.use(
+      http.get("/api/v1/assets/XLM/health/history", async () => {
+        await delay(50);
+        return HttpResponse.json({ symbol: "XLM", period: "7d", points: HEALTH_POINTS });
+      })
+    );
+
+    renderSparkline();
+
+    const skeleton = screen.getByRole("status", { name: /loading sparkline/i });
+    expect(skeleton).toBeInTheDocument();
+    expect(skeleton).toHaveStyle({ height: "32px" });
+
+    await waitFor(() =>
+      expect(screen.queryByRole("status", { name: /loading sparkline/i })).not.toBeInTheDocument()
+    );
+  });
+});

--- a/frontend/src/components/Sparkline.tsx
+++ b/frontend/src/components/Sparkline.tsx
@@ -16,6 +16,8 @@ import {
 
 type TrendDirection = "up" | "down" | "flat";
 
+const SPARKLINE_SKELETON_HEIGHT = 32;
+
 function stellarVarRgb(varName: string, fallbackRgb: string): string {
   try {
     const raw = getComputedStyle(document.documentElement).getPropertyValue(varName).trim();
@@ -148,8 +150,16 @@ function SparklineImpl({
 
   return (
     <div ref={ref} style={{ width }} aria-label={ariaLabel}>
-      <div style={{ height }}>
-        {emptyState ? (
+      <div style={{ height }} className="flex items-center">
+        {isLoading ? (
+          <div
+            className="skeleton w-full rounded bg-stellar-border/40"
+            style={{ height: SPARKLINE_SKELETON_HEIGHT }}
+            role="status"
+            aria-busy="true"
+            aria-label="Loading sparkline"
+          />
+        ) : emptyState ? (
           <div
             className="w-full h-full bg-stellar-border/30 rounded"
             aria-hidden="true"


### PR DESCRIPTION
## Summary
- Reserve a fixed-height (32px) skeleton placeholder while sparkline data queries are loading, preventing vertical content shift when sparklines finish rendering.

Closes #882
Closes #883
Closes #884
Closes #885

## Test plan
- [x] `npx vitest run src/components/Sparkline.test.tsx` — new test asserting the loading skeleton reserves 32px and is replaced once data resolves
- [x] `npx vitest run src/hooks/useSparklineData.test.ts` — existing hook tests still pass
- [x] `npx eslint src/components/Sparkline.tsx src/components/Sparkline.test.tsx`