### PR TITLE
[codex] improve dashboard tokens, latency metrics, and mobile selects

### DIFF
--- a/backend/src/api/middleware/metrics.ts
+++ b/backend/src/api/middleware/metrics.ts
@@ -2,6 +2,13 @@ import type { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
 import { getMetricsService } from "../../services/metrics.service.js";
 import { logger } from "../../utils/logger.js";
 
+/** Prevent query strings and concrete IDs from exploding Prometheus labels. */
+export function metricRoute(request: FastifyRequest): string {
+  const registeredRoute = request.routeOptions?.url;
+  if (registeredRoute) return registeredRoute;
+  return request.url.split("?", 1)[0] || "/unknown";
+}
+
 /**
  * Metrics Middleware
  * Automatically collects HTTP request/response metrics
@@ -23,7 +30,7 @@ export async function registerMetrics(server: FastifyInstance): Promise<void> {
     try {
       const duration = reply.elapsedTime / 1000; // Convert ms to seconds
       const method = request.method;
-      const route = request.routeOptions?.url || request.url;
+      const route = metricRoute(request);
       const statusCode = reply.statusCode;
 
       // Get request and response sizes

--- a/backend/tests/api/metrics.middleware.test.ts
+++ b/backend/tests/api/metrics.middleware.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import type { FastifyRequest } from "fastify";
+import { metricRoute } from "../../src/api/middleware/metrics.js";
+
+describe("metricRoute", () => {
+  it("uses the registered route pattern for stable labels", () => {
+    const request = {
+      routeOptions: { url: "/api/bridges/:bridgeId" },
+      url: "/api/bridges/abc?verbose=true",
+    } as unknown as FastifyRequest;
+    expect(metricRoute(request)).toBe("/api/bridges/:bridgeId");
+  });
+
+  it("removes query strings when no route pattern is available", () => {
+    const request = {
+      routeOptions: {},
+      url: "/health?source=probe",
+    } as unknown as FastifyRequest;
+    expect(metricRoute(request)).toBe("/health");
+  });
+});

--- a/backend/tests/services/telegram.bot.service.test.ts
+++ b/backend/tests/services/telegram.bot.service.test.ts
@@ -131,6 +131,45 @@ describe("TelegramBotService", () => {
     }
   });
 
+  describe("Command routing", () => {
+    const commandHandler = (service: TelegramBotService, name: string) => {
+      const bot = (service as any).bot;
+      const registration = bot.command.mock.calls.find(
+        ([registeredName]: [string]) => registeredName === name,
+      );
+      expect(registration, `/${name} should be registered`).toBeDefined();
+      return registration![1];
+    };
+
+    it("routes /help and returns the command list", async () => {
+      const replyWithMarkdown = vi.fn();
+      await commandHandler(telegramService, "help")({ replyWithMarkdown });
+      expect(replyWithMarkdown).toHaveBeenCalledWith(
+        expect.stringContaining("/status"),
+      );
+    });
+
+    it("routes /status to the system status response", async () => {
+      vi.spyOn(telegramService as any, "getSystemStatus").mockResolvedValue(
+        "Bridge Watch is healthy",
+      );
+      const replyWithMarkdown = vi.fn();
+      await commandHandler(telegramService, "status")({ replyWithMarkdown });
+      expect(replyWithMarkdown).toHaveBeenCalledWith("Bridge Watch is healthy");
+    });
+
+    it("rejects /broadcast from an unauthorized chat", async () => {
+      vi.spyOn(telegramService as any, "isAdminChat").mockResolvedValue(false);
+      const reply = vi.fn();
+      await commandHandler(telegramService, "broadcast")({
+        chat: { id: 999 },
+        message: { text: "/broadcast maintenance" },
+        reply,
+      });
+      expect(reply).toHaveBeenCalledWith(expect.stringContaining("Unauthorized"));
+    });
+  });
+
   describe("Message Formatting", () => {
     it("should escape special Markdown V2 characters", () => {
       const input = "Test *bold* and _italic_ [link](url)";

--- a/frontend/src/components/EntitySwitcher.tsx
+++ b/frontend/src/components/EntitySwitcher.tsx
@@ -147,14 +147,48 @@ export default function EntitySwitcher() {
   useEffect(() => {
     if (!open) return;
 
+    let touchStart: { x: number; y: number } | null = null;
+    let touchDragged = false;
+    let suppressMouseUntil = 0;
+
     const onPointerDown = (event: MouseEvent) => {
+      if (Date.now() < suppressMouseUntil) return;
       if (!panelRef.current?.contains(event.target as Node)) {
         setOpen(false);
       }
     };
 
+    const onTouchStart = (event: TouchEvent) => {
+      const touch = event.touches[0];
+      touchStart = touch ? { x: touch.clientX, y: touch.clientY } : null;
+      touchDragged = false;
+    };
+
+    const onTouchMove = (event: TouchEvent) => {
+      const touch = event.touches[0];
+      if (!touch || !touchStart) return;
+      touchDragged =
+        Math.hypot(touch.clientX - touchStart.x, touch.clientY - touchStart.y) > 8;
+    };
+
+    const onTouchEnd = (event: TouchEvent) => {
+      suppressMouseUntil = Date.now() + 500;
+      if (!touchDragged && !panelRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+      touchStart = null;
+    };
+
     document.addEventListener("mousedown", onPointerDown);
-    return () => document.removeEventListener("mousedown", onPointerDown);
+    document.addEventListener("touchstart", onTouchStart, { passive: true });
+    document.addEventListener("touchmove", onTouchMove, { passive: true });
+    document.addEventListener("touchend", onTouchEnd, { passive: true });
+    return () => {
+      document.removeEventListener("mousedown", onPointerDown);
+      document.removeEventListener("touchstart", onTouchStart);
+      document.removeEventListener("touchmove", onTouchMove);
+      document.removeEventListener("touchend", onTouchEnd);
+    };
   }, [open]);
 
   function selectItem(item: EntityItem) {

--- a/frontend/src/pages/ApiDocs/CodeSnippet.tsx
+++ b/frontend/src/pages/ApiDocs/CodeSnippet.tsx
@@ -16,7 +16,7 @@ export default function CodeSnippet({ code, lang }: Props) {
   }
 
   return (
-    <div className="relative rounded-md bg-[#0d1117] border border-stellar-border overflow-hidden">
+    <div className="relative rounded-md bg-neutral-950 border border-stellar-border overflow-hidden">
       <div className="flex items-center justify-between px-4 py-2 border-b border-stellar-border">
         <span className="text-xs text-stellar-text-secondary font-mono">{lang}</span>
         <button

--- a/frontend/src/pages/ApiDocs/EndpointCard.tsx
+++ b/frontend/src/pages/ApiDocs/EndpointCard.tsx
@@ -34,7 +34,7 @@ export default function EndpointCard({ endpoint }: Props) {
       {/* Header — always visible */}
       <button
         onClick={() => setOpen((o) => !o)}
-        className="w-full flex items-center gap-3 px-4 py-3 bg-stellar-card hover:bg-[#1a1f35] transition-colors text-left"
+        className="w-full flex items-center gap-3 px-4 py-3 bg-stellar-card hover:bg-neutral-850 transition-colors text-left"
         aria-expanded={open}
       >
         <span className={`text-xs font-bold px-2 py-0.5 rounded font-mono shrink-0 ${METHOD_COLORS[endpoint.method]}`}>

--- a/frontend/src/pages/ApiDocs/ResponseViewer.tsx
+++ b/frontend/src/pages/ApiDocs/ResponseViewer.tsx
@@ -4,7 +4,7 @@ interface Props {
 
 export default function ResponseViewer({ json }: Props) {
   return (
-    <div className="rounded-md bg-[#0d1117] border border-stellar-border overflow-hidden">
+    <div className="rounded-md bg-neutral-950 border border-stellar-border overflow-hidden">
       <div className="px-4 py-2 border-b border-stellar-border">
         <span className="text-xs text-stellar-text-secondary font-mono">Response</span>
       </div>

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -5,6 +5,21 @@ export default {
   theme: {
     extend: {
       colors: {
+        brand: {
+          DEFAULT: "#0057FF",
+          hover: "#1d6dff",
+        },
+        status: {
+          success: "#22c55e",
+          warning: "#f59e0b",
+          danger: "#ef4444",
+        },
+        neutral: {
+          950: "#0d1117",
+          900: "#141829",
+          850: "#1a1f35",
+          800: "#1e2340",
+        },
         stellar: {
           blue: "#0057FF",
           dark: "rgb(var(--stellar-bg) / <alpha-value>)",


### PR DESCRIPTION
## Summary
- semantic Tailwind palette tokens
- stable route-pattern API latency labels and tests
- Telegram help/status/admin authorization routing tests
- touch-drag-safe mobile dropdown dismissal

## Validation
- `git diff --check` passed
- targeted tests added; dependency installation hit a Windows directory-lock error

Closes #897
Closes #898
Closes #899
Closes #900