### PR TITLE
feat: add configurable token decimals display in EVM lock balances table

### DIFF
--- a/frontend/src/components/EvmLockDetailsPanel.test.tsx
+++ b/frontend/src/components/EvmLockDetailsPanel.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * Tests for EvmLockDetailsPanel component
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import EvmLockDetailsPanel from "./EvmLockDetailsPanel";
+import { useBridgeStats } from "../hooks/useBridges";
+import type { BridgeStats } from "../types";
+
+vi.mock("../hooks/useBridges");
+
+const mockUseBridgeStats = vi.mocked(useBridgeStats);
+
+const baseStats: BridgeStats = {
+  name: "Wormhole",
+  volume24h: 0,
+  volume7d: 0,
+  volume30d: 0,
+  totalTransactions: 0,
+  averageTransferTime: 0,
+  uptime30d: 0,
+  evmLockDetails: [
+    {
+      chain: "ethereum",
+      contractAddress: "0xabc123",
+      tokenAddress: "0xdef456",
+      assetSymbol: "USDC",
+      lockedAmount: "1234567.0000034",
+      isPaused: false,
+      blockNumber: 100,
+      timestamp: Date.now(),
+      error: null,
+    },
+    {
+      chain: "polygon",
+      contractAddress: "0xerr000",
+      tokenAddress: "0xdef456",
+      assetSymbol: "USDC",
+      lockedAmount: "0",
+      isPaused: false,
+      blockNumber: 100,
+      timestamp: Date.now(),
+      error: "RPC timeout",
+    },
+  ],
+};
+
+function mockStats(overrides: Partial<ReturnType<typeof useBridgeStats>> = {}) {
+  mockUseBridgeStats.mockReturnValue({
+    data: baseStats,
+    isLoading: false,
+    ...overrides,
+  } as ReturnType<typeof useBridgeStats>);
+}
+
+describe("EvmLockDetailsPanel", () => {
+  it("renders nothing while loading", () => {
+    mockUseBridgeStats.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    } as ReturnType<typeof useBridgeStats>);
+
+    const { container } = render(<EvmLockDetailsPanel bridgeName="Wormhole" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when there are no EVM lock details", () => {
+    mockUseBridgeStats.mockReturnValue({
+      data: { ...baseStats, evmLockDetails: [] },
+      isLoading: false,
+    } as ReturnType<typeof useBridgeStats>);
+
+    const { container } = render(<EvmLockDetailsPanel bridgeName="Wormhole" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("defaults to 4 decimal places for the locked amount", () => {
+    mockStats();
+    render(<EvmLockDetailsPanel bridgeName="Wormhole" />);
+
+    expect(screen.getByText("1,234,567.0000")).toBeInTheDocument();
+  });
+
+  it("shows an em dash for rows with an error instead of a formatted amount", () => {
+    mockStats();
+    render(<EvmLockDetailsPanel bridgeName="Wormhole" />);
+
+    expect(screen.getByText("Unavailable")).toBeInTheDocument();
+  });
+
+  it("reformats the locked amount to 7 decimal places when selected, revealing micro-amount precision", async () => {
+    mockStats();
+    render(<EvmLockDetailsPanel bridgeName="Wormhole" />);
+
+    const user = userEvent.setup();
+    await user.selectOptions(
+      screen.getByLabelText("Locked amount decimal precision"),
+      "7",
+    );
+
+    expect(screen.getByText("1,234,567.0000034")).toBeInTheDocument();
+    expect(screen.queryByText("1,234,567.0000")).not.toBeInTheDocument();
+  });
+
+  it("reformats the locked amount to 2 decimal places when selected", async () => {
+    mockStats();
+    render(<EvmLockDetailsPanel bridgeName="Wormhole" />);
+
+    const user = userEvent.setup();
+    await user.selectOptions(
+      screen.getByLabelText("Locked amount decimal precision"),
+      "2",
+    );
+
+    expect(screen.getByText("1,234,567.00")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/EvmLockDetailsPanel.tsx
+++ b/frontend/src/components/EvmLockDetailsPanel.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useBridgeStats } from "../hooks/useBridges";
 
 interface EvmLockDetailsPanelProps {
@@ -10,9 +11,24 @@ const CHAIN_LABELS: Record<string, string> = {
   base: "Base",
 };
 
+type AmountPrecision = 2 | 4 | 7;
+
+const PRECISION_OPTIONS: AmountPrecision[] = [2, 4, 7];
+
+function formatLockedAmount(rawAmount: string, precision: AmountPrecision): string {
+  const value = Number(rawAmount);
+  if (!Number.isFinite(value)) return "—";
+
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: precision,
+    maximumFractionDigits: precision,
+  });
+}
+
 export default function EvmLockDetailsPanel({ bridgeName }: EvmLockDetailsPanelProps) {
   const { data, isLoading } = useBridgeStats(bridgeName);
   const evmLockDetails = data?.evmLockDetails ?? [];
+  const [precision, setPrecision] = useState<AmountPrecision>(4);
 
   if (isLoading || evmLockDetails.length === 0) {
     return null;
@@ -23,14 +39,32 @@ export default function EvmLockDetailsPanel({ bridgeName }: EvmLockDetailsPanelP
       aria-labelledby="evm-lock-details-heading"
       className="rounded-xl border border-stellar-border bg-stellar-card p-6 space-y-4"
     >
-      <div>
-        <h2 id="evm-lock-details-heading" className="text-lg font-semibold text-white">
-          EVM Lock Details
-        </h2>
-        <p className="mt-0.5 text-sm text-stellar-text-secondary">
-          Live lock contract balances per chain for{" "}
-          <span className="font-medium text-white">{bridgeName}</span>
-        </p>
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h2 id="evm-lock-details-heading" className="text-lg font-semibold text-white">
+            EVM Lock Details
+          </h2>
+          <p className="mt-0.5 text-sm text-stellar-text-secondary">
+            Live lock contract balances per chain for{" "}
+            <span className="font-medium text-white">{bridgeName}</span>
+          </p>
+        </div>
+
+        <label className="flex items-center gap-2 text-xs text-stellar-text-secondary">
+          <span>Decimals</span>
+          <select
+            value={precision}
+            onChange={(event) => setPrecision(Number(event.target.value) as AmountPrecision)}
+            className="min-h-9 rounded-md border border-stellar-border bg-stellar-card px-2 py-1 text-xs text-white focus:outline-none focus:ring-2 focus:ring-stellar-blue"
+            aria-label="Locked amount decimal precision"
+          >
+            {PRECISION_OPTIONS.map((option) => (
+              <option key={option} value={option}>
+                {option} decimals
+              </option>
+            ))}
+          </select>
+        </label>
       </div>
 
       <div className="overflow-x-auto">
@@ -50,8 +84,8 @@ export default function EvmLockDetailsPanel({ bridgeName }: EvmLockDetailsPanelP
               <tr key={`${detail.chain}-${detail.contractAddress}`} className="border-b border-stellar-border/50 last:border-0">
                 <td className="py-3 pr-4">{CHAIN_LABELS[detail.chain] ?? detail.chain}</td>
                 <td className="py-3 pr-4">{detail.assetSymbol}</td>
-                <td className="py-3 pr-4 font-medium">
-                  {detail.error ? "—" : Number(detail.lockedAmount).toLocaleString()}
+                <td className="py-3 pr-4 font-medium font-mono">
+                  {detail.error ? "—" : formatLockedAmount(detail.lockedAmount, precision)}
                 </td>
                 <td className="py-3 pr-4">
                   {detail.error ? (


### PR DESCRIPTION
Closes #932

### Which table this targets
No component in the codebase is literally named or labeled "Asset Table". I searched the frontend for anywhere asset *balances* (not prices -- those are already handled separately with `toFixed(4)` throughout the app) are rendered in a table. The closest and most concrete match is `EvmLockDetailsPanel.tsx` (rendered on the `/bridges` page), which shows a "Locked Amount" column per chain per asset -- exactly the "micro-amount bridged assets" scenario the issue describes. It previously used `Number(detail.lockedAmount).toLocaleString()` with no explicit fraction-digit control, which defaults to a max of 3 decimal places and can silently round small bridged amounts down to looking like zero.

### What changed
- Added a "Decimals" `<select>` control (2 / 4 / 7 decimals) to the panel header, styled to match the existing select pattern already used in `ChartLegendControls.tsx`.
- Replaced the uncontrolled `toLocaleString()` call with a `formatLockedAmount()` helper that applies `minimumFractionDigits`/`maximumFractionDigits` based on the selected precision, defaulting to 4 (consistent with price formatting used elsewhere in the app).
- Added `src/components/EvmLockDetailsPanel.test.tsx` -- no test file previously existed for this component: loading state, empty state, default 4-decimal formatting, error-row handling, and switching to 2 and 7 decimals.

### Verification (actually run, not just written)
- All 6 new tests pass: `npx vitest run src/components/EvmLockDetailsPanel.test.tsx`.
- `npx eslint` on both files: clean.
- `npx tsc -b --noEmit`: no errors attributable to these files.
- Confirmed the component is actually live (imported and rendered in `src/pages/Bridges.tsx`), not orphaned.
- There's a benign "not wrapped in act()" console warning from `userEvent.selectOptions` in two of the new tests. I confirmed this is a pre-existing pattern already present in this repo's own `Tabs.test.tsx` using the identical `userEvent.setup()` style -- not something this PR introduces.