### PR TITLE
feat(db): add composite index on reserve_commitments(bridge_id, committed_at)

### DIFF
--- a/backend/src/database/migrations/048_reserve_commitments_bridge_time_index.ts
+++ b/backend/src/database/migrations/048_reserve_commitments_bridge_time_index.ts
@@ -1,0 +1,23 @@
+import type { Knex } from "knex";
+
+/**
+ * reserve_commitments previously had `index(["bridge_id", "status"])` and a
+ * standalone `index(["committed_at"])` (see 002_reserve_verification.ts),
+ * but nothing covering the common "commitment history for a given bridge
+ * within a time range, most recent first" access pattern -- e.g.
+ * `WHERE bridge_id = ? AND committed_at BETWEEN ? AND ? ORDER BY committed_at DESC`.
+ *
+ * Without this, the planner has to pick one of the two existing indexes and
+ * either scan the committed_at range and filter out non-matching bridge_ids
+ * row by row, or scan all of a bridge's rows and sort them in memory.
+ */
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    CREATE INDEX idx_reserve_commitments_bridge_time
+      ON reserve_commitments (bridge_id, committed_at DESC)
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw("DROP INDEX IF EXISTS idx_reserve_commitments_bridge_time");
+}


### PR DESCRIPTION
Closes #933

`reserve_commitments` (see `002_reserve_verification.ts`) has:
- `unique(["bridge_id", "sequence"])`
- `index(["bridge_id", "status"])`
- `index(["committed_at"])`

...but nothing covering the "commitment history for bridge X within a time range, most recent first" access pattern:
```sql
WHERE bridge_id = ? AND committed_at BETWEEN ? AND ?
ORDER BY committed_at DESC
```

Added migration `048` creating `idx_reserve_commitments_bridge_time` on `(bridge_id, committed_at DESC)`, exactly as specified in the issue scope, following the same `knex.raw(CREATE INDEX ...)` pattern already used in `047_event_source_keys.ts` / `032_reconciliation_dashboard.ts`.

### Verification -- actually run against real PostgreSQL, not assumed

The issue's scope explicitly asks to "verify query execution plan performance," so I installed PostgreSQL locally, built a standalone table matching production's `reserve_commitments` schema exactly, seeded it with 250k rows, and ran `EXPLAIN (ANALYZE, BUFFERS)` for the query pattern above before and after the change:

**Before** (existing `committed_at`-only index): the planner scans the `committed_at` range and filters `bridge_id` row-by-row *after* the index scan -- for a `LIMIT 50` query it had to discard 1,944 non-matching rows via a `Filter` step just to find 50 matches.

**After**, with the new composite index and a realistic bridge cardinality (300 distinct `bridge_id`s): the planner naturally switches to `idx_reserve_commitments_bridge_time` with zero filter waste (both predicates folded into a single `Index Cond`) and no separate sort step -- **0.090ms vs the prior plan's 0.374ms** for the identical query.

I also isolated the new index (temporarily dropping the other two inside a transaction, then rolling back) to directly confirm it alone correctly serves both a `LIMIT`-bound query (pure `Index Scan`, already sorted, no `Filter`, no `Sort` node) and an unbounded range query (`Bitmap Index Scan` using both predicates directly).

Separately, I ran the actual migration file's `up()`/`down()` exports through the project's own Knex instance (not just my hand-typed raw SQL) against that same test database:
- `up()` creates exactly: `CREATE INDEX idx_reserve_commitments_bridge_time ON public.reserve_commitments USING btree (bridge_id, committed_at DESC)`
- `down()` cleanly removes it.

`npm run migrate:validate` passes on the new file. `eslint` and `tsc --noEmit` are both clean.

**One limitation worth noting**: I could not run this through the project's full migration chain end-to-end (`npm run migrate:up` from a fresh database), because migration `002` requires TimescaleDB's `create_hypertable()`, and TimescaleDB isn't installable via this sandbox's allowed apt sources (only stock `postgresql-contrib`). That's an environment limitation on my end, not something specific to this migration -- I verified correctness directly against a schema-accurate standalone table instead, as described above, and would recommend a maintainer do one real `npm run migrate:up` against a proper TimescaleDB instance as a final sanity check before merging.