### PR TITLE
feat: navbar critical alert dot, HealthScoreCard responsive fix, RuleEvaluator AND/OR tests, WebSocket config constants

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -266,6 +266,22 @@ RATE_LIMIT_ENDPOINT_HEALTH=1000
 REDIS_PRICE_CACHE_PREFIX=price:aggregated
 # Secret token required to subscribe to private WebSocket channels (e.g. "alerts")
 WS_AUTH_SECRET=${WS_AUTH_SECRET_PLACEHOLDER}   # [SENSITIVE]
+# Interval between heartbeat pings sent to connected clients (ms)
+WS_HEARTBEAT_INTERVAL_MS=30000
+# Grace period after a missed pong before a connection is terminated (ms)
+WS_HEARTBEAT_TIMEOUT_MS=10000
+# How often queued messages are flushed to clients (ms)
+WS_BATCH_INTERVAL_MS=120
+# Max messages delivered per batch / replay
+WS_MAX_BATCH_SIZE=20
+# Sliding window used for per-client outbound rate limiting (ms)
+WS_RATE_LIMIT_WINDOW_MS=1000
+# Max messages allowed per client within WS_RATE_LIMIT_WINDOW_MS
+WS_RATE_LIMIT_MAX_MESSAGES=20
+# Max messages retained per topic for replay
+WS_MAX_HISTORY_PER_TOPIC=50
+# Max age of a retained replay message before it expires (ms)
+WS_MAX_HISTORY_AGE_MS=300000
 
 # -----------------------------------------------------------------------------
 # Discord Bot Integration

--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -131,6 +131,22 @@ const envSchema = z.object({
    * any token is rejected.  Set this to a strong random string in production.
    */
   WS_AUTH_SECRET: z.string().optional(),
+  // Interval between heartbeat pings sent to connected clients (ms)
+  WS_HEARTBEAT_INTERVAL_MS: z.coerce.number().default(30_000),
+  // Grace period after a missed pong before a connection is terminated (ms)
+  WS_HEARTBEAT_TIMEOUT_MS: z.coerce.number().default(10_000),
+  // How often queued messages are flushed to clients (ms)
+  WS_BATCH_INTERVAL_MS: z.coerce.number().default(120),
+  // Max messages delivered per batch / replay
+  WS_MAX_BATCH_SIZE: z.coerce.number().default(20),
+  // Sliding window used for per-client outbound rate limiting (ms)
+  WS_RATE_LIMIT_WINDOW_MS: z.coerce.number().default(1000),
+  // Max messages allowed per client within WS_RATE_LIMIT_WINDOW_MS
+  WS_RATE_LIMIT_MAX_MESSAGES: z.coerce.number().default(20),
+  // Max messages retained per topic for replay
+  WS_MAX_HISTORY_PER_TOPIC: z.coerce.number().default(50),
+  // Max age of a retained replay message before it expires (ms)
+  WS_MAX_HISTORY_AGE_MS: z.coerce.number().default(5 * 60 * 1000),
 
   // Health Score Weights
   HEALTH_WEIGHT_LIQUIDITY: z.coerce.number().default(0.25),

--- a/backend/src/services/websocket.ts
+++ b/backend/src/services/websocket.ts
@@ -1,13 +1,14 @@
 import { randomUUID } from "crypto";
+import { config } from "../config/index.js";
 
-const MAX_HISTORY_PER_TOPIC = 50;
-const MAX_HISTORY_AGE_MS = 5 * 60 * 1000;
-const BATCH_INTERVAL_MS = 120;
-const MAX_BATCH_SIZE = 20;
-const MESSAGE_RATE_LIMIT_WINDOW_MS = 1000;
-const MAX_MESSAGES_PER_WINDOW = 20;
-const HEARTBEAT_INTERVAL_MS = 30_000;
-const HEARTBEAT_TIMEOUT_MS = 10_000;
+const MAX_HISTORY_PER_TOPIC = config.WS_MAX_HISTORY_PER_TOPIC;
+const MAX_HISTORY_AGE_MS = config.WS_MAX_HISTORY_AGE_MS;
+const BATCH_INTERVAL_MS = config.WS_BATCH_INTERVAL_MS;
+const MAX_BATCH_SIZE = config.WS_MAX_BATCH_SIZE;
+const MESSAGE_RATE_LIMIT_WINDOW_MS = config.WS_RATE_LIMIT_WINDOW_MS;
+const MAX_MESSAGES_PER_WINDOW = config.WS_RATE_LIMIT_MAX_MESSAGES;
+const HEARTBEAT_INTERVAL_MS = config.WS_HEARTBEAT_INTERVAL_MS;
+const HEARTBEAT_TIMEOUT_MS = config.WS_HEARTBEAT_TIMEOUT_MS;
 
 export type WebsocketMessageType =
   | "price_update"

--- a/backend/tests/services/ruleEvaluatorConditions.test.ts
+++ b/backend/tests/services/ruleEvaluatorConditions.test.ts
@@ -1,0 +1,299 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { RuleEvaluatorService } from "../../src/services/ruleEvaluator.service.js";
+
+vi.mock("../../src/utils/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("../../src/database/connection.js", () => ({
+  getDatabase: vi.fn(() => {
+    const b: any = {};
+    b.then = (resolve: any) => Promise.resolve([]).then(resolve);
+    b.where = vi.fn().mockReturnValue(b);
+    b.orderBy = vi.fn().mockReturnValue(b);
+    b.insert = vi.fn().mockReturnValue(b);
+    b.returning = vi.fn().mockResolvedValue([]);
+    b.first = vi.fn().mockResolvedValue(null);
+    b.limit = vi.fn().mockReturnValue(b);
+    b.offset = vi.fn().mockResolvedValue([]);
+    b.count = vi.fn().mockReturnValue(b);
+    const fn = (_t: string) => b;
+    return fn;
+  }),
+}));
+
+describe("RuleEvaluatorService - AND/OR condition combinations", () => {
+  let service: RuleEvaluatorService;
+
+  beforeEach(() => {
+    (RuleEvaluatorService as any).instance = undefined;
+    service = RuleEvaluatorService.getInstance();
+  });
+
+  describe("flat AND groups across varied operator types", () => {
+    it("triggers when every operator variant in the group passes", () => {
+      const result = service.evaluate(
+        {
+          ruleName: "multi-operator-and",
+          assetCode: "USDC",
+          conditions: [
+            { field: "price", operator: "gte", value: 100 },
+            { field: "supply", operator: "lte", value: 1_000_000 },
+            { field: "peg", operator: "eq", value: 1 },
+            { field: "status", operator: "ne", value: 0 },
+            { field: "reserve_ratio", operator: "between", value: 90, valueHigh: 110 },
+          ],
+          logicOperator: "AND",
+        },
+        { price: 100, supply: 1_000_000, peg: 1, status: 1, reserve_ratio: 100 }
+      );
+
+      expect(result.triggered).toBe(true);
+      expect(result.conditionResults).toHaveLength(5);
+      expect(result.conditionResults.every((c) => c.passed)).toBe(true);
+    });
+
+    it("does not trigger when a single condition among many fails, short-circuiting after the failure", () => {
+      const result = service.evaluate(
+        {
+          ruleName: "multi-operator-and-fail",
+          assetCode: "USDC",
+          conditions: [
+            { field: "price", operator: "gte", value: 100 },
+            { field: "supply", operator: "lte", value: 1_000_000 },
+            { field: "peg", operator: "eq", value: 1 },
+          ],
+          logicOperator: "AND",
+        },
+        { price: 100, supply: 2_000_000, peg: 1 }
+      );
+
+      expect(result.triggered).toBe(false);
+      // AND uses Array.prototype.every, which short-circuits at the first
+      // failing condition - "peg" is never evaluated.
+      expect(result.conditionResults).toHaveLength(2);
+      expect(result.conditionResults[0].passed).toBe(true);
+      expect(result.conditionResults[1].passed).toBe(false);
+    });
+
+    it("treats a missing metric field as 0 for evaluation purposes", () => {
+      const result = service.evaluate(
+        {
+          ruleName: "missing-field-and",
+          assetCode: "USDC",
+          conditions: [
+            { field: "price", operator: "gt", value: 100 },
+            { field: "unknown_metric", operator: "eq", value: 0 },
+          ],
+          logicOperator: "AND",
+        },
+        { price: 150 }
+      );
+
+      expect(result.conditionResults[1].actualValue).toBe(0);
+      expect(result.conditionResults[1].passed).toBe(true);
+      expect(result.triggered).toBe(true);
+    });
+  });
+
+  describe("flat OR groups across varied metric snapshots", () => {
+    const conditions = [
+      { field: "price_deviation", operator: "gt" as const, value: 5 },
+      { field: "volume_drop_pct", operator: "gte" as const, value: 50 },
+      { field: "bridge_downtime_min", operator: "gt" as const, value: 30 },
+    ];
+
+    it.each([
+      { metrics: { price_deviation: 6, volume_drop_pct: 0, bridge_downtime_min: 0 }, expected: true },
+      { metrics: { price_deviation: 0, volume_drop_pct: 50, bridge_downtime_min: 0 }, expected: true },
+      { metrics: { price_deviation: 0, volume_drop_pct: 0, bridge_downtime_min: 31 }, expected: true },
+      { metrics: { price_deviation: 1, volume_drop_pct: 10, bridge_downtime_min: 5 }, expected: false },
+    ])("resolves to $expected for metrics $metrics", ({ metrics, expected }) => {
+      const result = service.evaluate(
+        { ruleName: "or-snapshot", assetCode: "USDC", conditions, logicOperator: "OR" },
+        metrics
+      );
+      expect(result.triggered).toBe(expected);
+    });
+
+    it("records every evaluated condition outcome when the passing condition is last", () => {
+      const result = service.evaluate(
+        { ruleName: "or-collect", assetCode: "USDC", conditions, logicOperator: "OR" },
+        { price_deviation: 1, volume_drop_pct: 10, bridge_downtime_min: 35 }
+      );
+      expect(result.triggered).toBe(true);
+      expect(result.conditionResults).toHaveLength(3);
+      expect(result.conditionResults[0].passed).toBe(false);
+      expect(result.conditionResults[1].passed).toBe(false);
+      expect(result.conditionResults[2].passed).toBe(true);
+    });
+  });
+
+  describe("nested AND/OR AST combinations", () => {
+    it("evaluates (A OR B) AND (C OR D) across passing and failing snapshots", () => {
+      const astCondition: any = {
+        op: "AND",
+        conditions: [
+          {
+            op: "OR",
+            conditions: [
+              { field: "price_deviation", operator: "gt", value: 5 },
+              { field: "volume_drop_pct", operator: "gte", value: 50 },
+            ],
+          },
+          {
+            op: "OR",
+            conditions: [
+              { field: "tvl", operator: "lt", value: 500_000 },
+              { field: "bridge_downtime_min", operator: "gt", value: 30 },
+            ],
+          },
+        ],
+      };
+
+      const bothGroupsPass = service.evaluate(
+        { ruleName: "and-of-or", assetCode: "USDC", astCondition },
+        { price_deviation: 6, volume_drop_pct: 0, tvl: 600_000, bridge_downtime_min: 45 }
+      );
+      expect(bothGroupsPass.triggered).toBe(true);
+
+      const onlyFirstGroupPasses = service.evaluate(
+        { ruleName: "and-of-or", assetCode: "USDC", astCondition },
+        { price_deviation: 6, volume_drop_pct: 0, tvl: 600_000, bridge_downtime_min: 0 }
+      );
+      expect(onlyFirstGroupPasses.triggered).toBe(false);
+    });
+
+    it("evaluates (A AND B) OR (C AND D) across passing and failing snapshots", () => {
+      const astCondition: any = {
+        op: "OR",
+        conditions: [
+          {
+            op: "AND",
+            conditions: [
+              { field: "price_deviation", operator: "gt", value: 2 },
+              { field: "tvl", operator: "lt", value: 500_000 },
+            ],
+          },
+          {
+            op: "AND",
+            conditions: [
+              { field: "volume", operator: "lt", value: 10_000 },
+              { field: "bridge_downtime_min", operator: "gt", value: 30 },
+            ],
+          },
+        ],
+      };
+
+      const secondGroupPasses = service.evaluate(
+        { ruleName: "or-of-and", assetCode: "USDC", astCondition },
+        { price_deviation: 1, tvl: 800_000, volume: 5_000, bridge_downtime_min: 40 }
+      );
+      expect(secondGroupPasses.triggered).toBe(true);
+
+      const neitherGroupPasses = service.evaluate(
+        { ruleName: "or-of-and", assetCode: "USDC", astCondition },
+        { price_deviation: 1, tvl: 800_000, volume: 5_000, bridge_downtime_min: 0 }
+      );
+      expect(neitherGroupPasses.triggered).toBe(false);
+    });
+
+    it("evaluates three-level nested AND(OR(AND)) combinations", () => {
+      const astCondition: any = {
+        op: "AND",
+        conditions: [
+          { field: "peg", operator: "eq", value: 1 },
+          {
+            op: "OR",
+            conditions: [
+              { field: "price_deviation", operator: "gt", value: 5 },
+              {
+                op: "AND",
+                conditions: [
+                  { field: "volume", operator: "lt", value: 10_000 },
+                  { field: "tvl", operator: "lt", value: 500_000 },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const deepOrPathPasses = service.evaluate(
+        { ruleName: "deep-nested", assetCode: "USDC", astCondition },
+        { peg: 1, price_deviation: 0, volume: 5_000, tvl: 400_000 }
+      );
+      expect(deepOrPathPasses.triggered).toBe(true);
+
+      const topLevelFails = service.evaluate(
+        { ruleName: "deep-nested", assetCode: "USDC", astCondition },
+        { peg: 0, price_deviation: 10, volume: 5_000, tvl: 400_000 }
+      );
+      expect(topLevelFails.triggered).toBe(false);
+    });
+
+    it("combines changes_by_pct with AND/OR groups given previous metric snapshots", () => {
+      const astCondition: any = {
+        op: "OR",
+        conditions: [
+          { field: "price", operator: "changes_by_pct", value: 10 },
+          {
+            op: "AND",
+            conditions: [
+              { field: "volume", operator: "gt", value: 1000 },
+              { field: "tvl", operator: "lt", value: 500_000 },
+            ],
+          },
+        ],
+      };
+
+      const changePctTriggers = service.evaluate(
+        { ruleName: "changes-or", assetCode: "USDC", astCondition },
+        { price: 120, volume: 0, tvl: 900_000 },
+        { price: 100, volume: 0, tvl: 900_000 }
+      );
+      expect(changePctTriggers.triggered).toBe(true);
+
+      const noPreviousMetricsFallsBackToOtherBranch = service.evaluate(
+        { ruleName: "changes-or", assetCode: "USDC", astCondition },
+        { price: 120, volume: 2000, tvl: 400_000 }
+      );
+      expect(noPreviousMetricsFallsBackToOtherBranch.triggered).toBe(true);
+      expect(noPreviousMetricsFallsBackToOtherBranch.conditionResults[0].passed).toBe(false);
+    });
+  });
+
+  describe("evaluateBatch with mixed AND/OR rules", () => {
+    it("evaluates independent AND and OR rules against a single metric snapshot", () => {
+      const metrics = { price: 150, volume: 200, tvl: 600_000 };
+      const results = service.evaluateBatch(
+        [
+          {
+            ruleName: "and-rule",
+            assetCode: "USDC",
+            logicOperator: "AND",
+            conditions: [
+              { field: "price", operator: "gt", value: 100 },
+              { field: "tvl", operator: "gt", value: 500_000 },
+            ],
+          },
+          {
+            ruleName: "or-rule",
+            assetCode: "USDC",
+            logicOperator: "OR",
+            conditions: [
+              { field: "volume", operator: "gt", value: 10_000 },
+              { field: "tvl", operator: "gt", value: 500_000 },
+            ],
+          },
+        ],
+        metrics
+      );
+
+      expect(results[0].triggered).toBe(true);
+      expect(results[0].logicOperator).toBe("AND");
+      expect(results[1].triggered).toBe(true);
+      expect(results[1].logicOperator).toBe("OR");
+    });
+  });
+});

--- a/frontend/src/components/HealthScoreCard.tsx
+++ b/frontend/src/components/HealthScoreCard.tsx
@@ -236,16 +236,16 @@ export default function HealthScoreCard({
               return (
                 <div
                   key={key}
-                  className="flex items-center justify-between gap-2"
+                  className="grid grid-cols-1 gap-1 xs:flex xs:items-center xs:justify-between xs:gap-2"
                   role="listitem"
                   aria-label={`${FACTOR_LABELS[key]}: ${value} out of 100`}
                 >
-                  <span className="text-sm text-stellar-text-secondary flex-shrink-0">
+                  <span className="text-sm text-stellar-text-secondary xs:flex-shrink-0">
                     {FACTOR_LABELS[key]}
                   </span>
-                  <div className="flex items-center gap-2 flex-1 justify-end">
+                  <div className="flex items-center gap-2 xs:flex-1 xs:justify-end">
                     <div
-                      className="w-20 h-1.5 bg-stellar-border rounded-full overflow-hidden"
+                      className="flex-1 xs:w-20 xs:flex-none h-1.5 bg-stellar-border rounded-full overflow-hidden"
                       role="progressbar"
                       aria-valuenow={value}
                       aria-valuemin={0}

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -2,7 +2,11 @@ import { useEffect, useRef, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { useNotificationLiveUpdates } from "../hooks/useNotificationLiveUpdates";
 import { useWatchlist } from "../hooks/useWatchlist";
-import { selectUnreadCount, useNotificationStore } from "../stores/notificationStore";
+import {
+  selectCriticalCount,
+  selectUnreadCount,
+  useNotificationStore,
+} from "../stores/notificationStore";
 import EntitySwitcher from "./EntitySwitcher";
 import HamburgerButton from "./MobileNav/HamburgerButton";
 import MobileMenu from "./MobileNav/MobileMenu";
@@ -21,6 +25,7 @@ export default function Navbar() {
   const notificationTriggerRef = useRef<HTMLButtonElement | null>(null);
   const previousDrawerOpen = useRef(false);
   const unreadCount = useNotificationStore(selectUnreadCount);
+  const criticalCount = useNotificationStore(selectCriticalCount);
 
   useNotificationLiveUpdates();
 
@@ -126,6 +131,22 @@ export default function Navbar() {
                   />
                 </svg>
                 <UnreadCountBadge unreadCount={unreadCount} />
+                {criticalCount > 0 && (
+                  <span
+                    className="absolute top-1 left-1 flex h-2.5 w-2.5"
+                    role="status"
+                    aria-label={`${criticalCount} unacknowledged critical alerts`}
+                  >
+                    <span
+                      className="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-500 opacity-75"
+                      aria-hidden="true"
+                    />
+                    <span
+                      className="relative inline-flex h-2.5 w-2.5 rounded-full bg-red-500"
+                      aria-hidden="true"
+                    />
+                  </span>
+                )}
               </button>
 
               <HamburgerButton

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -4,6 +4,9 @@ export default {
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
     extend: {
+      screens: {
+        xs: "380px",
+      },
       colors: {
         brand: {
           DEFAULT: "#0057FF",


### PR DESCRIPTION
## Summary
This PR bundles four assigned issues:

- **#941** — Connects the `Navbar.tsx` bell icon to `notificationStore`'s critical count and renders an animated red dot indicator when unacknowledged critical notifications exist.
- **#940** — Fixes `HealthScoreCard.tsx` factor row overflow on screens below 380px by adding a new `xs` Tailwind breakpoint and stacking each factor row (label above progress bar) below that width.
- **#939** — Adds `backend/tests/services/ruleEvaluatorConditions.test.ts` with dedicated unit tests for `RuleEvaluatorService` AND/OR condition logic: flat groups across operator types, varied metric snapshots, nested AND/OR/mixed combinations, and `evaluateBatch` with mixed logic operators.
- **#938** — Moves previously hardcoded WebSocket heartbeat/batch/rate-limit/history constants in `backend/src/services/websocket.ts` into `backend/src/config/index.ts`, exposing environment overrides (`WS_HEARTBEAT_INTERVAL_MS`, `WS_HEARTBEAT_TIMEOUT_MS`, `WS_BATCH_INTERVAL_MS`, `WS_MAX_BATCH_SIZE`, `WS_RATE_LIMIT_WINDOW_MS`, `WS_RATE_LIMIT_MAX_MESSAGES`, `WS_MAX_HISTORY_PER_TOPIC`, `WS_MAX_HISTORY_AGE_MS`) and documenting them in `.env.example`.

Closes #941
Closes #940 
Closes #939 
Closes #938

## Test plan
- [ ] Verify navbar bell icon shows an animated red dot when a critical notification arrives via WebSocket, and that it's independent from the existing unread-count badge
- [ ] Resize `HealthScoreCard` below 380px and confirm factor rows no longer overflow the card
- [ ] Run backend test suite and confirm `ruleEvaluatorConditions.test.ts` passes
- [ ] Confirm WebSocket service still starts with defaults, and that setting `WS_HEARTBEAT_INTERVAL_MS`/`WS_RATE_LIMIT_WINDOW_MS` env vars overrides behavior