### PR TITLE
fix: prevent flash of unauthenticated state during session validation

### DIFF
--- a/frontend/src/components/ProtectedRoute.test.tsx
+++ b/frontend/src/components/ProtectedRoute.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { http, HttpResponse } from "msw";
+import { server } from "../test/mocks/server";
+import ProtectedRoute from "./ProtectedRoute";
+
+function renderProtected() {
+  return render(
+    <MemoryRouter initialEntries={["/dashboard"]}>
+      <Routes>
+        <Route path="/" element={<div>Landing page</div>} />
+        <Route element={<ProtectedRoute />}>
+          <Route path="/dashboard" element={<div>Dashboard content</div>} />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("ProtectedRoute", () => {
+  afterEach(() => {
+    server.resetHandlers();
+    window.localStorage.clear();
+  });
+
+  it("shows a full-page loading skeleton instead of the landing page while session validation is in flight", () => {
+    window.localStorage.setItem("bridge_watch_session_token", "some-token");
+    // No handler override for a resolved response -- the request will hang, keeping status "loading".
+    server.use(http.post("/api/v1/sessions/validate", () => new Promise(() => {})));
+
+    renderProtected();
+
+    expect(screen.getByRole("status", { name: /verifying session/i })).toBeInTheDocument();
+    expect(screen.queryByText("Landing page")).not.toBeInTheDocument();
+    expect(screen.queryByText("Dashboard content")).not.toBeInTheDocument();
+  });
+
+  it("renders the protected route content once a session is confirmed valid", async () => {
+    window.localStorage.setItem("bridge_watch_session_token", "good-token");
+    server.use(
+      http.post("/api/v1/sessions/validate", () =>
+        HttpResponse.json({
+          success: true,
+          data: {
+            id: "sess-1",
+            userId: "user-1",
+            status: "active",
+            expiresAt: "2026-08-01T00:00:00.000Z",
+            lastActiveAt: "2026-07-27T00:00:00.000Z",
+          },
+        }),
+      ),
+    );
+
+    renderProtected();
+
+    expect(await screen.findByText("Dashboard content")).toBeInTheDocument();
+    expect(screen.queryByRole("status", { name: /verifying session/i })).not.toBeInTheDocument();
+  });
+
+  it("redirects to the landing page instead of flashing protected content when there's no valid session", async () => {
+    // No stored token at all.
+    renderProtected();
+
+    expect(await screen.findByText("Landing page")).toBeInTheDocument();
+    expect(screen.queryByText("Dashboard content")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,0 +1,48 @@
+import { Navigate, Outlet } from "react-router-dom";
+import { useSessionValidation } from "../hooks/useSessionValidation";
+
+/**
+ * Gates its child routes on initial session-token verification
+ * (useSessionValidation). While that check is in flight, renders a
+ * full-page loading skeleton instead of the route tree -- this is what
+ * prevents the brief flash of unauthenticated/landing content described
+ * in issue #931. Once verification resolves, either renders the nested
+ * routes (Outlet) or redirects to "/" if there's no valid session.
+ */
+export default function ProtectedRoute() {
+  const { status } = useSessionValidation();
+
+  if (status === "loading") {
+    return <FullPageLoadingSkeleton />;
+  }
+
+  if (status === "unauthenticated") {
+    return <Navigate to="/" replace />;
+  }
+
+  return <Outlet />;
+}
+
+function FullPageLoadingSkeleton() {
+  return (
+    <div
+      role="status"
+      aria-label="Verifying session"
+      className="min-h-screen bg-stellar-dark flex flex-col"
+    >
+      <div className="h-16 border-b border-stellar-border bg-stellar-card flex items-center px-6">
+        <div className="h-6 w-32 rounded bg-stellar-border animate-pulse" />
+      </div>
+      <div className="flex-1 p-6 space-y-4">
+        <div className="h-8 w-64 rounded bg-stellar-border animate-pulse" />
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div className="h-24 rounded-xl bg-stellar-card border border-stellar-border animate-pulse" />
+          <div className="h-24 rounded-xl bg-stellar-card border border-stellar-border animate-pulse" />
+          <div className="h-24 rounded-xl bg-stellar-card border border-stellar-border animate-pulse" />
+        </div>
+        <div className="h-64 rounded-xl bg-stellar-card border border-stellar-border animate-pulse" />
+      </div>
+      <span className="sr-only">Verifying your session…</span>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useSessionValidation.test.tsx
+++ b/frontend/src/hooks/useSessionValidation.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "../test/mocks/server";
+import { useSessionValidation } from "./useSessionValidation";
+import { setStoredSessionToken } from "../services/session";
+
+describe("useSessionValidation", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  it("stays in the loading state while a stored token's validation request is in flight", () => {
+    setStoredSessionToken("some-token");
+    // Never-resolving handler keeps the hook in "loading".
+    server.use(http.post("/api/v1/sessions/validate", () => new Promise(() => {})));
+
+    const { result } = renderHook(() => useSessionValidation());
+    expect(result.current.status).toBe("loading");
+  });
+
+  it("resolves synchronously to unauthenticated when there is no stored token to validate", () => {
+    const { result } = renderHook(() => useSessionValidation());
+    expect(result.current.status).toBe("unauthenticated");
+    expect(result.current.session).toBeNull();
+  });
+
+  it("resolves to authenticated when the stored token validates successfully", async () => {
+    setStoredSessionToken("good-token");
+    server.use(
+      http.post("/api/v1/sessions/validate", () =>
+        HttpResponse.json({
+          success: true,
+          data: {
+            id: "sess-1",
+            userId: "user-1",
+            status: "active",
+            expiresAt: "2026-08-01T00:00:00.000Z",
+            lastActiveAt: "2026-07-27T00:00:00.000Z",
+          },
+        }),
+      ),
+    );
+
+    const { result } = renderHook(() => useSessionValidation());
+
+    await waitFor(() => expect(result.current.status).toBe("authenticated"));
+    expect(result.current.session).toMatchObject({ id: "sess-1", userId: "user-1" });
+  });
+
+  it("resolves to unauthenticated when the stored token is rejected", async () => {
+    setStoredSessionToken("stale-token");
+    server.use(
+      http.post("/api/v1/sessions/validate", () =>
+        HttpResponse.json({ success: false, error: "Invalid or expired session" }, { status: 401 }),
+      ),
+    );
+
+    const { result } = renderHook(() => useSessionValidation());
+
+    await waitFor(() => expect(result.current.status).toBe("unauthenticated"));
+    expect(result.current.session).toBeNull();
+  });
+});

--- a/frontend/src/hooks/useSessionValidation.ts
+++ b/frontend/src/hooks/useSessionValidation.ts
@@ -1,0 +1,60 @@
+import { useEffect, useState } from "react";
+import {
+  getStoredSessionToken,
+  validateSessionToken,
+  type ValidatedSession,
+} from "../services/session";
+
+export type SessionValidationStatus = "loading" | "authenticated" | "unauthenticated";
+
+export interface SessionValidationResult {
+  status: SessionValidationStatus;
+  session: ValidatedSession | null;
+}
+
+/**
+ * Runs the initial session-token verification exactly once per mount and
+ * exposes the current status. Starts as "loading" so callers (e.g.
+ * ProtectedRoute) can withhold rendering protected content until this
+ * resolves, instead of briefly rendering an unauthenticated state first.
+ */
+export function useSessionValidation(): SessionValidationResult {
+  const [status, setStatus] = useState<SessionValidationStatus>("loading");
+  const [session, setSession] = useState<ValidatedSession | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function checkSession() {
+      const token = getStoredSessionToken();
+
+      if (!token) {
+        if (!cancelled) {
+          setStatus("unauthenticated");
+          setSession(null);
+        }
+        return;
+      }
+
+      const validated = await validateSessionToken(token);
+
+      if (cancelled) return;
+
+      if (validated && validated.status === "active") {
+        setSession(validated);
+        setStatus("authenticated");
+      } else {
+        setSession(null);
+        setStatus("unauthenticated");
+      }
+    }
+
+    void checkSession();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { status, session };
+}

--- a/frontend/src/services/session.test.ts
+++ b/frontend/src/services/session.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../test/mocks/server";
+import {
+  SESSION_TOKEN_STORAGE_KEY,
+  getStoredSessionToken,
+  setStoredSessionToken,
+  clearStoredSessionToken,
+  validateSessionToken,
+} from "./session";
+
+describe("session token storage", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("returns null when no token is stored", () => {
+    expect(getStoredSessionToken()).toBeNull();
+  });
+
+  it("stores and retrieves a token", () => {
+    setStoredSessionToken("abc123");
+    expect(getStoredSessionToken()).toBe("abc123");
+    expect(window.localStorage.getItem(SESSION_TOKEN_STORAGE_KEY)).toBe("abc123");
+  });
+
+  it("clears a stored token", () => {
+    setStoredSessionToken("abc123");
+    clearStoredSessionToken();
+    expect(getStoredSessionToken()).toBeNull();
+  });
+});
+
+describe("validateSessionToken", () => {
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  it("returns the session data when the backend confirms the token is valid", async () => {
+    server.use(
+      http.post("/api/v1/sessions/validate", () =>
+        HttpResponse.json({
+          success: true,
+          data: {
+            id: "sess-1",
+            userId: "user-1",
+            status: "active",
+            expiresAt: "2026-08-01T00:00:00.000Z",
+            lastActiveAt: "2026-07-27T00:00:00.000Z",
+          },
+        }),
+      ),
+    );
+
+    const result = await validateSessionToken("good-token");
+    expect(result).toMatchObject({ id: "sess-1", userId: "user-1", status: "active" });
+  });
+
+  it("returns null when the backend responds 401 (invalid/expired/revoked)", async () => {
+    server.use(
+      http.post("/api/v1/sessions/validate", () =>
+        HttpResponse.json({ success: false, error: "Invalid or expired session" }, { status: 401 }),
+      ),
+    );
+
+    const result = await validateSessionToken("bad-token");
+    expect(result).toBeNull();
+  });
+
+  it("returns null instead of throwing on a network error", async () => {
+    server.use(
+      http.post("/api/v1/sessions/validate", () => HttpResponse.error()),
+    );
+
+    const result = await validateSessionToken("any-token");
+    expect(result).toBeNull();
+  });
+});

--- a/frontend/src/services/session.ts
+++ b/frontend/src/services/session.ts
@@ -1,0 +1,73 @@
+/**
+ * Frontend session-token storage and validation.
+ *
+ * Talks to the backend's real session service (backend/src/services/session.service.ts,
+ * mounted at /api/v1/sessions). POST /api/v1/sessions/validate is intentionally
+ * unauthenticated on the backend -- it's the endpoint a browser calls with
+ * whatever token it's holding to find out whether that token is still good.
+ *
+ * There is currently no login UI that calls POST /api/v1/sessions to obtain a
+ * token in the first place (see issue #931 discussion) -- this module only
+ * covers reading whatever token may already be stored and validating it.
+ */
+
+const API_BASE_URL = "/api/v1";
+
+export const SESSION_TOKEN_STORAGE_KEY = "bridge_watch_session_token";
+
+export interface ValidatedSession {
+  id: string;
+  userId: string;
+  status: "active" | "expired" | "revoked";
+  expiresAt: string;
+  lastActiveAt: string;
+}
+
+export function getStoredSessionToken(): string | null {
+  try {
+    return window.localStorage.getItem(SESSION_TOKEN_STORAGE_KEY);
+  } catch {
+    // localStorage can throw in privacy modes / disabled-storage environments.
+    return null;
+  }
+}
+
+export function setStoredSessionToken(token: string): void {
+  try {
+    window.localStorage.setItem(SESSION_TOKEN_STORAGE_KEY, token);
+  } catch {
+    // Ignore write failures (e.g. storage disabled); session simply won't persist.
+  }
+}
+
+export function clearStoredSessionToken(): void {
+  try {
+    window.localStorage.removeItem(SESSION_TOKEN_STORAGE_KEY);
+  } catch {
+    // Nothing to do if storage is unavailable.
+  }
+}
+
+/**
+ * Calls POST /api/v1/sessions/validate with the given token.
+ * Returns the session if the token is valid, or null if it's missing,
+ * invalid, expired, or revoked (i.e. any 401), or on any other request error.
+ */
+export async function validateSessionToken(token: string): Promise<ValidatedSession | null> {
+  try {
+    const response = await fetch(`${API_BASE_URL}/sessions/validate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token }),
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const body = await response.json();
+    return body?.data ?? null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Closes #933

---

Addresses #931

### Correcting my earlier read of this issue
I initially commented on this issue saying there was no session-gated auth in the codebase at all to have this bug in. That was wrong -- I'd missed a real, fully implemented backend session system:

- `backend/src/services/session.service.ts`: `createSession`, `validateSession`, `revokeSession`, audit log, expiry -- all real and working.
- `POST /api/v1/sessions/validate` is mounted and intentionally unauthenticated (see `core-routes.ts`) -- exactly the endpoint a browser is meant to call with a stored token to check whether it's still good.

What's still genuinely missing (confirmed by search): no login page/form anywhere calls `POST /api/v1/sessions` to obtain a token in the first place, there's no credential verification (`createSession` takes a `userId` directly, no username/password check), and nothing in the frontend ever stores a token. A full login flow is a separate, larger concern outside this issue's scope -- but what #931 actually asks for (don't flash unauthenticated content while checking a session) is buildable now against the real validate endpoint.

### What this PR adds
- `frontend/src/services/session.ts` -- token storage helpers (localStorage, with try/catch for privacy-mode environments) and `validateSessionToken()`, which POSTs to `/api/v1/sessions/validate`.
- `frontend/src/hooks/useSessionValidation.ts` -- exposes `loading | authenticated | unauthenticated`, starting at `"loading"` and resolving once the stored token (if any) has been checked.
- `frontend/src/components/ProtectedRoute.tsx` -- renders a full-page loading skeleton while validation is in flight (this is the literal "Expected behavior" from the issue), then either renders its children via `<Outlet />` or redirects to `/` if there's no valid session.
- Full test coverage for all three (13 tests): token storage, validate-endpoint success/401/network-error handling, all three hook states, and all three `ProtectedRoute` render paths.

### What this PR deliberately does NOT do
It does not wire `ProtectedRoute` into `App.tsx`'s live route tree yet. I built that wiring first, then caught a real problem before committing: `e2e/tests/*.spec.ts` navigate directly to `/dashboard`, `/bridges`, etc. with zero session setup -- no `storageState`, no auth fixture, nothing (confirmed by reading `playwright.config.ts` and the spec files). Flipping route gating on live would silently break that entire e2e suite. Fixing that properly means seeding a real session in e2e setup, which itself requires an API-key credential (the backend's `POST /sessions` create endpoint requires `authMiddleware({ requiredScopes: ["sessions:write"] })`) -- a coordinated change I didn't want to bundle into this PR unverified.

### To finish wiring this up (suggested follow-up, not in this PR)
In `App.tsx`, wrap the existing `<Route element={<Layout />}>` group with `<Route element={<ProtectedRoute />}>`, and update e2e test setup to seed a valid session token (via the backend's session-create endpoint, using an e2e-scoped API key) before navigating to any route under that group. Happy to take this on as a follow-up PR once there's agreement on the e2e fixture approach.

### Verification (actually run)
- All 13 new tests pass: `npx vitest run src/services/session.test.ts src/hooks/useSessionValidation.test.tsx src/components/ProtectedRoute.test.tsx`.
- `eslint` and `tsc -b --noEmit` are clean on all six files (there's one pre-existing, unrelated `tsconfig` project-reference error present on `main` itself -- confirmed via `git stash` -- not introduced by this PR).
- Confirmed `POST /api/v1/sessions/validate`'s mount path and unauthenticated access by reading `backend/src/api/routes/route-groups/core-routes.ts` and `backend/src/api/routes/sessions.ts` directly.