### PR TITLE
Liquidity CSV export, UTC-safe chart dates, watchlist bulk actions, HorizonStream reconnect tests

### DIFF
--- a/backend/tests/integration/horizonStreamSupervisor.test.ts
+++ b/backend/tests/integration/horizonStreamSupervisor.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  HorizonStreamSupervisor,
+  type HorizonStreamConfig,
+} from "../../src/services/horizonStreamSupervisor.service.js";
+
+vi.mock("../../src/utils/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("../../src/services/metrics.service.js", () => ({
+  getMetricsService: vi.fn(() => null),
+}));
+
+vi.mock("../../src/services/ingestionQueueManager.service.js", () => ({
+  ingestionQueueManager: { detectReorgAndRollback: vi.fn().mockResolvedValue([]) },
+}));
+
+type ReaderStep = { value?: string; error?: Error };
+
+function createSseReader(steps: ReaderStep[]) {
+  let i = 0;
+  return {
+    read: vi.fn(async () => {
+      const step = steps[i++];
+      if (!step) return { done: true, value: undefined };
+      if (step.error) throw step.error;
+      return { done: false, value: new TextEncoder().encode(step.value) };
+    }),
+  };
+}
+
+function okResponse(steps: ReaderStep[]) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    body: { getReader: () => createSseReader(steps) },
+  } as unknown as Response;
+}
+
+async function waitUntil(condition: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (!condition()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error("Timed out waiting for condition");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+function baseConfig(overrides: Partial<HorizonStreamConfig> = {}): HorizonStreamConfig {
+  return {
+    streamId: "test-stream",
+    url: "https://horizon.stellar.org/transactions",
+    baseBackoffMs: 5,
+    maxBackoffMs: 20,
+    gapThresholdMs: 100_000,
+    timeoutMs: 5_000,
+    ...overrides,
+  };
+}
+
+describe("HorizonStreamSupervisor reconnect (integration)", () => {
+  let supervisor: HorizonStreamSupervisor | null = null;
+
+  afterEach(() => {
+    supervisor?.stop();
+    supervisor = null;
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("reconnects and resets reconnectCount after a stream error", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("network down"))
+      .mockResolvedValueOnce(okResponse([]));
+    vi.stubGlobal("fetch", fetchMock);
+
+    supervisor = new HorizonStreamSupervisor(baseConfig());
+    supervisor.start();
+
+    await waitUntil(() => fetchMock.mock.calls.length >= 2);
+    await waitUntil(() => supervisor!.getHealthMetrics().status === "connected");
+
+    expect(supervisor.getHealthMetrics().reconnectCount).toBe(0);
+  });
+
+  it("resumes from the last checkpointed cursor after reconnecting", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        okResponse([
+          { value: 'data: {"id":"cursor-100","ledger":"5"}\n\n' },
+          { error: new Error("stream broken") },
+        ])
+      )
+      .mockResolvedValueOnce(okResponse([]));
+    vi.stubGlobal("fetch", fetchMock);
+
+    supervisor = new HorizonStreamSupervisor(baseConfig());
+    supervisor.start();
+
+    await waitUntil(() => fetchMock.mock.calls.length >= 2);
+
+    const secondCallUrl = fetchMock.mock.calls[1][0] as string;
+    expect(secondCallUrl).toContain("cursor=cursor-100");
+    expect(supervisor.getCheckpoint().lastCursor).toBe("cursor-100");
+  });
+
+  it("emits an outage event after exceeding maxReconnectAttempts", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error("network down"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    supervisor = new HorizonStreamSupervisor(
+      baseConfig({ maxReconnectAttempts: 2, baseBackoffMs: 5, maxBackoffMs: 10 })
+    );
+
+    const outage = vi.fn();
+    supervisor.on("outage", outage);
+    supervisor.start();
+
+    await waitUntil(() => outage.mock.calls.length >= 1);
+
+    expect(outage).toHaveBeenCalledWith(
+      expect.objectContaining({ streamId: "test-stream", reconnectCount: 2 })
+    );
+  });
+
+  it("stops scheduling reconnects once stop() is called", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error("network down"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    supervisor = new HorizonStreamSupervisor(baseConfig({ maxReconnectAttempts: 20 }));
+    supervisor.start();
+
+    await waitUntil(() => fetchMock.mock.calls.length >= 1);
+    supervisor.stop();
+    const callsAtStop = fetchMock.mock.calls.length;
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(fetchMock.mock.calls.length).toBe(callsAtStop);
+    expect(supervisor.getHealthMetrics().status).toBe("closed");
+  });
+});

--- a/frontend/src/pages/LiquidityDashboard.test.tsx
+++ b/frontend/src/pages/LiquidityDashboard.test.tsx
@@ -75,4 +75,11 @@ describe("LiquidityDashboard", () => {
     renderPage();
     expect(screen.getByTestId("depth-chart")).toBeInTheDocument();
   });
+
+  it("renders an enabled Export CSV button when depth data is available", () => {
+    renderPage();
+    const button = screen.getByRole("button", { name: /export csv/i });
+    expect(button).toBeInTheDocument();
+    expect(button).not.toBeDisabled();
+  });
 });

--- a/frontend/src/pages/LiquidityDashboard.tsx
+++ b/frontend/src/pages/LiquidityDashboard.tsx
@@ -7,7 +7,39 @@ import {
   PriceImpactCalculator,
   PairSelector,
 } from "../components/liquidity";
-import type { TradingPair, VenueLiquidity } from "../types/liquidity";
+import type { DepthData, TradingPair, VenueLiquidity } from "../types/liquidity";
+
+function toCsvValue(value: string | number): string {
+  const str = String(value);
+  return /[",\n]/.test(str) ? `"${str.replace(/"/g, '""')}"` : str;
+}
+
+function buildDepthCsv(depth: DepthData): string {
+  const lines = ["Side,Price,Volume,Venue"];
+  for (const level of depth.bids) {
+    lines.push(
+      ["bid", level.price, level.volume, level.venue].map(toCsvValue).join(",")
+    );
+  }
+  for (const level of depth.asks) {
+    lines.push(
+      ["ask", level.price, level.volume, level.venue].map(toCsvValue).join(",")
+    );
+  }
+  return lines.join("\n");
+}
+
+function downloadCsv(content: string, filename: string) {
+  const blob = new Blob([content], { type: "text/csv" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
 
 export default function LiquidityDashboard() {
   const [pair, setPair] = useLocalStorageState<TradingPair>(
@@ -80,11 +112,31 @@ export default function LiquidityDashboard() {
       >
         <div className="flex items-center justify-between mb-4">
           <h2 className="text-lg font-semibold text-white">Order Book Depth</h2>
-          {lastUpdated && (
-            <span className="text-xs text-stellar-text-secondary">
-              Updated {new Date(lastUpdated).toLocaleTimeString()}
-            </span>
-          )}
+          <div className="flex items-center gap-3">
+            {lastUpdated && (
+              <span className="text-xs text-stellar-text-secondary">
+                Updated {new Date(lastUpdated).toLocaleTimeString()}
+              </span>
+            )}
+            <button
+              onClick={() => {
+                if (!depth) return;
+                const date = new Date().toISOString().slice(0, 10);
+                const safePair = pair.replace("/", "-");
+                downloadCsv(
+                  buildDepthCsv(depth),
+                  `liquidity-depth-${safePair}-${date}.csv`
+                );
+              }}
+              disabled={!depth}
+              className="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-stellar-border bg-stellar-card text-xs font-medium text-white hover:border-stellar-blue/60 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+              </svg>
+              Export CSV
+            </button>
+          </div>
         </div>
         <LiquidityDepthChart data={depth} isLoading={isLoading} pair={pair} />
       </section>

--- a/frontend/src/pages/Reconciliation.tsx
+++ b/frontend/src/pages/Reconciliation.tsx
@@ -14,6 +14,7 @@ import {
   getReconciliationMismatchDetail,
   updateReconciliationTriage,
 } from "../services/api";
+import { formatUtcDate } from "../utils/formatUtcDate";
 import type {
   CommitmentVerificationStatus,
   DriftSeverity,
@@ -126,10 +127,7 @@ function formatTime(value: string | null): string {
 }
 
 function formatDate(value: string): string {
-  return new Date(value).toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-  });
+  return formatUtcDate(value);
 }
 
 function titleCase(value: string): string {

--- a/frontend/src/pages/Watchlist.test.tsx
+++ b/frontend/src/pages/Watchlist.test.tsx
@@ -1,0 +1,81 @@
+import { fireEvent, render, screen, waitFor } from "../test/utils";
+import { WatchlistProvider } from "../hooks/useWatchlist";
+import WatchlistPage from "./Watchlist";
+
+vi.mock("../services/api", () => ({
+  getAssetPrice: vi.fn().mockResolvedValue(null),
+  getAssetHealth: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("../components/WatchlistManager", () => ({
+  WatchlistManager: () => <div data-testid="watchlist-manager" />,
+}));
+
+const STORAGE_KEY = "bridgewatch.watchlists.v1";
+
+function seedWatchlists() {
+  window.localStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify({
+      activeListId: "default",
+      lists: [
+        { id: "default", name: "Default", assets: ["XLM", "USDC"] },
+        { id: "starred", name: "Starred", assets: [] },
+      ],
+    })
+  );
+}
+
+function Harness() {
+  return (
+    <WatchlistProvider>
+      <WatchlistPage />
+    </WatchlistProvider>
+  );
+}
+
+describe("WatchlistPage bulk actions", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    seedWatchlists();
+  });
+
+  it("shows the bulk action toolbar once an asset is selected", async () => {
+    render(<Harness />);
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select XLM" }));
+
+    expect(screen.getByRole("toolbar", { name: "Bulk watchlist actions" })).toBeInTheDocument();
+    expect(screen.getByText("1 selected")).toBeInTheDocument();
+  });
+
+  it("removes selected assets from the active watchlist", async () => {
+    render(<Harness />);
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select XLM" }));
+    fireEvent.click(screen.getByRole("button", { name: "Remove Selected" }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("XLM")).not.toBeInTheDocument();
+    });
+    expect(screen.getByText("USDC")).toBeInTheDocument();
+  });
+
+  it("moves selected assets to another watchlist", async () => {
+    render(<Harness />);
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select XLM" }));
+    fireEvent.change(screen.getByDisplayValue("Move to watchlist…"), {
+      target: { value: "starred" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Move" }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("XLM")).not.toBeInTheDocument();
+    });
+
+    const stored = JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? "{}");
+    const starred = stored.lists.find((l: { id: string }) => l.id === "starred");
+    expect(starred.assets).toContain("XLM");
+  });
+});

--- a/frontend/src/pages/Watchlist.tsx
+++ b/frontend/src/pages/Watchlist.tsx
@@ -19,10 +19,56 @@ interface AssetDetails {
 }
 
 export default function WatchlistPage() {
-  const { activeWatchlist, importWatchlists } = useWatchlist();
+  const { activeWatchlist, watchlists, addAsset, removeAsset, importWatchlists } =
+    useWatchlist();
   const [searchParams, setSearchParams] = useSearchParams();
   const [assetDetails, setAssetDetails] = useState<Record<string, AssetDetails>>({});
   const [isLoading, setIsLoading] = useState(false);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [moveTargetId, setMoveTargetId] = useState("");
+
+  useEffect(() => {
+    setSelected(new Set());
+  }, [activeWatchlist?.id]);
+
+  const toggleSelected = (symbol: string) => {
+    setSelected((previous) => {
+      const next = new Set(previous);
+      if (next.has(symbol)) {
+        next.delete(symbol);
+      } else {
+        next.add(symbol);
+      }
+      return next;
+    });
+  };
+
+  const toggleSelectAll = () => {
+    if (!activeWatchlist) return;
+    setSelected((previous) =>
+      previous.size === activeWatchlist.assets.length
+        ? new Set()
+        : new Set(activeWatchlist.assets)
+    );
+  };
+
+  const handleRemoveSelected = () => {
+    if (!activeWatchlist) return;
+    for (const symbol of selected) {
+      removeAsset(symbol, activeWatchlist.id);
+    }
+    setSelected(new Set());
+  };
+
+  const handleMoveSelected = () => {
+    if (!activeWatchlist || !moveTargetId) return;
+    for (const symbol of selected) {
+      addAsset(symbol, moveTargetId);
+      removeAsset(symbol, activeWatchlist.id);
+    }
+    setSelected(new Set());
+    setMoveTargetId("");
+  };
 
   // Handle shared link import
   useEffect(() => {
@@ -92,6 +138,47 @@ export default function WatchlistPage() {
             </h2>
           </div>
 
+          {selected.size > 0 && (
+            <div
+              className="flex flex-wrap items-center gap-3 px-6 py-3 border-b border-stellar-border bg-stellar-dark/60"
+              role="toolbar"
+              aria-label="Bulk watchlist actions"
+            >
+              <span className="text-sm text-stellar-text-secondary">
+                {selected.size} selected
+              </span>
+              <button
+                onClick={handleRemoveSelected}
+                className="text-sm text-red-500 hover:text-red-400 transition-colors"
+              >
+                Remove Selected
+              </button>
+              <div className="flex items-center gap-2">
+                <select
+                  value={moveTargetId}
+                  onChange={(e) => setMoveTargetId(e.target.value)}
+                  className="bg-stellar-card border border-stellar-border text-white text-sm rounded-lg px-2 py-1"
+                >
+                  <option value="">Move to watchlist…</option>
+                  {watchlists
+                    .filter((list) => list.id !== activeWatchlist.id)
+                    .map((list) => (
+                      <option key={list.id} value={list.id}>
+                        {list.name}
+                      </option>
+                    ))}
+                </select>
+                <button
+                  onClick={handleMoveSelected}
+                  disabled={!moveTargetId}
+                  className="text-sm text-gray-400 hover:text-white transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                >
+                  Move
+                </button>
+              </div>
+            </div>
+          )}
+
           {activeWatchlist.assets.length === 0 ? (
             <div className="p-12 text-center text-gray-400">
               <div className="inline-block p-4 rounded-full bg-stellar-dark mb-4">
@@ -110,6 +197,18 @@ export default function WatchlistPage() {
               <table className="w-full">
                 <thead className="bg-stellar-dark border-b border-stellar-border">
                   <tr>
+                    <th className="px-6 py-4 text-left w-10">
+                      <input
+                        type="checkbox"
+                        aria-label="Select all assets"
+                        checked={
+                          activeWatchlist.assets.length > 0 &&
+                          selected.size === activeWatchlist.assets.length
+                        }
+                        onChange={toggleSelectAll}
+                        className="rounded border-stellar-border"
+                      />
+                    </th>
                     <th className="px-6 py-4 text-left text-xs font-semibold text-stellar-text-secondary uppercase tracking-wider">
                       Asset
                     </th>
@@ -130,6 +229,15 @@ export default function WatchlistPage() {
                     const healthScore = data?.health?.overallScore;
                     return (
                       <tr key={symbol} className="hover:bg-stellar-dark/50 transition-colors">
+                        <td className="px-6 py-4 whitespace-nowrap">
+                          <input
+                            type="checkbox"
+                            aria-label={`Select ${symbol}`}
+                            checked={selected.has(symbol)}
+                            onChange={() => toggleSelected(symbol)}
+                            className="rounded border-stellar-border"
+                          />
+                        </td>
                         <td className="px-6 py-4 whitespace-nowrap">
                           <Link to={`/assets/${symbol}`} className="flex items-center gap-3 group">
                             <div className="w-8 h-8 rounded-full bg-stellar-blue/10 flex items-center justify-center border border-stellar-blue/20 group-hover:border-stellar-blue transition-colors">

--- a/frontend/src/utils/formatUtcDate.test.ts
+++ b/frontend/src/utils/formatUtcDate.test.ts
@@ -1,0 +1,15 @@
+import { formatUtcDate } from "./formatUtcDate";
+
+describe("formatUtcDate", () => {
+  it("formats a date-only string using its UTC calendar day, not the local one", () => {
+    expect(formatUtcDate("2024-01-15")).toBe("Jan 15");
+  });
+
+  it("does not shift to the previous day for a UTC midnight timestamp", () => {
+    expect(formatUtcDate("2024-03-01T00:00:00.000Z")).toBe("Mar 1");
+  });
+
+  it("keeps the UTC calendar day for a late-night UTC timestamp", () => {
+    expect(formatUtcDate("2024-06-30T23:45:00.000Z")).toBe("Jun 30");
+  });
+});

--- a/frontend/src/utils/formatUtcDate.ts
+++ b/frontend/src/utils/formatUtcDate.ts
@@ -1,0 +1,15 @@
+const SHORT_MONTHS = [
+  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+
+/**
+ * Formats an ISO date/timestamp string as "Mon D" using UTC date components,
+ * so the displayed calendar day never shifts based on the viewer's local
+ * timezone offset (e.g. a date-only string like "2024-01-15" always renders
+ * as "Jan 15", even for viewers in negative UTC offsets).
+ */
+export function formatUtcDate(value: string): string {
+  const d = new Date(value);
+  return `${SHORT_MONTHS[d.getUTCMonth()]} ${d.getUTCDate()}`;
+}


### PR DESCRIPTION
## Summary

Closes #937
Closes #936
Closes #935 
Closes #934

- **#937** — Adds an "Export CSV" button to the Order Book Depth section of the Liquidity dashboard (`LiquidityDashboard.tsx`), exporting aggregated bid/ask rows (price, volume, venue) for the selected pair.
- **#936** — Fixes a timezone day-shift bug where chart date labels formatted with `toLocaleDateString()` on a UTC date string render the previous day for viewers in negative UTC offsets. Adds a reusable `formatUtcDate()` helper and applies it to the reconciliation history chart's date labels.
  - Note: the issue references a "Bridge Volume Stats chart", which doesn't exist yet in the codebase (only a "Bridge Volume Analytics" placeholder with no chart wired up). This PR fixes the same bug class in the real, shipped chart that has it (`Reconciliation.tsx`).
- **#935** — Adds multi-select checkboxes to the active watchlist's asset table plus a bulk action toolbar with "Remove Selected" and "Move to Watchlist" actions.
- **#934** — Adds `backend/tests/integration/horizonStreamSupervisor.test.ts` covering `HorizonStreamSupervisor` reconnect behavior: resetting `reconnectCount` after a successful reconnect, resuming from the last checkpointed cursor, emitting an `outage` event after `maxReconnectAttempts` is exceeded, and halting further reconnects after `stop()`.

## Test plan

- [ ] `LiquidityDashboard.test.tsx` — Export CSV button renders and is enabled when depth data is present
- [ ] `formatUtcDate.test.ts` — UTC date formatting doesn't shift across midnight boundaries
- [ ] `Watchlist.test.tsx` — bulk toolbar appears on selection; Remove Selected and Move to Watchlist work against the watchlist store
- [ ] `horizonStreamSupervisor.test.ts` — reconnect/backoff/outage/stop behavior under mocked SSE fetch failures