### PR TITLE
refactor: standardize HTTP status codes in backend authentication middleware

### DIFF
--- a/backend/src/api/middleware/auth.ts
+++ b/backend/src/api/middleware/auth.ts
@@ -87,26 +87,32 @@ export function authMiddleware(options: AuthOptions = {}) {
 
     if (apiKey) {
       try {
-        const validated = await apiKeyService.validateKey(
+        const outcome = await apiKeyService.validateKey(
           apiKey,
           options.requiredScopes ?? [],
           request.ip
         );
 
-        if (!validated) {
-          return reply.status(403).send({
-            error: "Forbidden",
-            message: "Invalid API key or missing required scope.",
+        if (outcome.ok === false) {
+          if (outcome.reason === "insufficient_scope") {
+            return reply.status(403).send({
+              error: "Forbidden",
+              message: "API key does not have the required scope.",
+            });
+          }
+          return reply.status(401).send({
+            error: "Unauthorized",
+            message: "Invalid or unrecognized API key.",
           });
         }
 
-        request.apiKeyAuth = validated;
+        request.apiKeyAuth = outcome.result;
       } catch (error) {
         const message =
           error instanceof Error ? error.message : "Failed to validate API key";
-        const statusCode = message.includes("rate limit") ? 429 : 403;
+        const statusCode = message.includes("rate limit") ? 429 : 401;
         return reply.status(statusCode).send({
-          error: statusCode === 429 ? "Too Many Requests" : "Forbidden",
+          error: statusCode === 429 ? "Too Many Requests" : "Unauthorized",
           message,
         });
       }

--- a/backend/src/api/routes/outbox-admin.ts
+++ b/backend/src/api/routes/outbox-admin.ts
@@ -1,8 +1,19 @@
+import { timingSafeEqual } from "node:crypto";
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
 import { getDatabase } from "../../database/connection.js";
 import { OutboxAdminApi } from "../../outbox/adminApi.js";
 import { logger } from "../../utils/logger.js";
+
+function constantTimeEquals(a: string, b: string): boolean {
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  if (bufA.length !== bufB.length) {
+    timingSafeEqual(bufA, bufA);
+    return false;
+  }
+  return timingSafeEqual(bufA, bufB);
+}
 
 // Validation schemas
 const RetryEventSchema = z.object({
@@ -29,16 +40,14 @@ export async function outboxAdminRoutes(fastify: FastifyInstance) {
 
   // Add authentication middleware for admin routes
   fastify.addHook("preHandler", async (request, reply) => {
-    // TODO: Implement proper admin authentication
-    // For now, this is a placeholder - in production you'd check API keys, JWT tokens, etc.
     const authHeader = request.headers.authorization;
     if (!authHeader || !authHeader.startsWith("Bearer ")) {
       return reply.code(401).send({ error: "Unauthorized" });
     }
-    
-    // Simple token validation (replace with proper auth)
+
+    const adminToken = process.env.ADMIN_API_TOKEN;
     const token = authHeader.substring(7);
-    if (token !== process.env.ADMIN_API_TOKEN) {
+    if (!adminToken || !constantTimeEquals(token, adminToken)) {
       return reply.code(401).send({ error: "Invalid token" });
     }
   });

--- a/backend/src/api/routes/rateLimitAdmin.ts
+++ b/backend/src/api/routes/rateLimitAdmin.ts
@@ -15,8 +15,15 @@ export async function rateLimitAdminRoutes(server: FastifyInstance) {
   // Admin authentication middleware
   server.addHook("preHandler", async (request: FastifyRequest, reply: FastifyReply) => {
     const apiKey = request.headers["x-api-key"] as string;
-    
-    if (!apiKey || !apiKey.startsWith(config.RATE_LIMIT_ADMIN_API_KEY_PREFIX)) {
+
+    if (!apiKey) {
+      return reply.status(401).send({
+        error: "Unauthorized",
+        message: "Admin API key required for rate limit management",
+      });
+    }
+
+    if (!apiKey.startsWith(config.RATE_LIMIT_ADMIN_API_KEY_PREFIX)) {
       return reply.status(403).send({
         error: "Forbidden",
         message: "Admin API key required for rate limit management",

--- a/backend/src/api/routes/tracingAdmin.ts
+++ b/backend/src/api/routes/tracingAdmin.ts
@@ -29,9 +29,17 @@ function getActiveTraceEntries(): Array<[string, any]> {
 export async function tracingAdminRoutes(server: FastifyInstance) {
   // Admin authentication middleware
   server.addHook("preHandler", async (request: FastifyRequest, reply: FastifyReply) => {
-    const apiKey = request.headers["x-api-key"] as string | string[] | undefined;
+    const rawApiKey = request.headers["x-api-key"] as string | string[] | undefined;
+    const apiKey = Array.isArray(rawApiKey) ? rawApiKey[0] : rawApiKey;
 
-    if (!apiKey || (Array.isArray(apiKey) ? apiKey[0] : apiKey).startsWith(config.RATE_LIMIT_ADMIN_API_KEY_PREFIX) === false) {
+    if (!apiKey) {
+      return reply.status(401).send({
+        error: "Unauthorized",
+        message: "Admin API key required for tracing management",
+      });
+    }
+
+    if (!apiKey.startsWith(config.RATE_LIMIT_ADMIN_API_KEY_PREFIX)) {
       return reply.status(403).send({
         error: "Forbidden",
         message: "Admin API key required for tracing management",

--- a/backend/src/api/routes/validationAdmin.ts
+++ b/backend/src/api/routes/validationAdmin.ts
@@ -14,8 +14,15 @@ export async function validationAdminRoutes(server: FastifyInstance) {
   // Admin authentication middleware
   server.addHook("preHandler", async (request: FastifyRequest, reply: FastifyReply) => {
     const apiKey = request.headers["x-api-key"] as string;
-    
-    if (!apiKey || !apiKey.startsWith(config.RATE_LIMIT_ADMIN_API_KEY_PREFIX)) {
+
+    if (!apiKey) {
+      return reply.status(401).send({
+        error: "Unauthorized",
+        message: "Admin API key required for validation management",
+      });
+    }
+
+    if (!apiKey.startsWith(config.RATE_LIMIT_ADMIN_API_KEY_PREFIX)) {
       return reply.status(403).send({
         error: "Forbidden",
         message: "Admin API key required for validation management",

--- a/backend/src/services/apiKey.service.ts
+++ b/backend/src/services/apiKey.service.ts
@@ -53,6 +53,12 @@ interface ApiKeyValidationResult {
   source: "api-key" | "bootstrap";
 }
 
+export type ApiKeyValidationFailureReason = "invalid_key" | "insufficient_scope";
+
+export type ApiKeyValidationOutcome =
+  | { ok: true; result: ApiKeyValidationResult }
+  | { ok: false; reason: ApiKeyValidationFailureReason };
+
 interface ApiKeyRepository {
   create(record: StoredApiKeyRecord): Promise<void>;
   update(record: StoredApiKeyRecord): Promise<void>;
@@ -430,15 +436,18 @@ export class ApiKeyService {
     plaintextKey: string,
     requiredScopes: string[] = [],
     clientIp?: string
-  ): Promise<ApiKeyValidationResult | null> {
+  ): Promise<ApiKeyValidationOutcome> {
     const bootstrapToken = config.API_KEY_BOOTSTRAP_TOKEN;
     if (bootstrapToken && plaintextKey === bootstrapToken) {
       return {
-        id: "bootstrap",
-        name: "Bootstrap admin token",
-        scopes: ["*"],
-        rateLimitPerMinute: Number.MAX_SAFE_INTEGER,
-        source: "bootstrap",
+        ok: true,
+        result: {
+          id: "bootstrap",
+          name: "Bootstrap admin token",
+          scopes: ["*"],
+          rateLimitPerMinute: Number.MAX_SAFE_INTEGER,
+          source: "bootstrap",
+        },
       };
     }
 
@@ -455,7 +464,7 @@ export class ApiKeyService {
       }
 
       if (!this.hasScopes(candidate.scopes, requiredScopes)) {
-        return null;
+        return { ok: false, reason: "insufficient_scope" };
       }
 
       if (!this.consumeRateLimit(candidate.id, candidate.rateLimitPerMinute)) {
@@ -470,15 +479,18 @@ export class ApiKeyService {
       await this.log(candidate.id, "used", candidate.name, clientIp ?? null);
 
       return {
-        id: candidate.id,
-        name: candidate.name,
-        scopes: candidate.scopes,
-        rateLimitPerMinute: candidate.rateLimitPerMinute,
-        source: "api-key",
+        ok: true,
+        result: {
+          id: candidate.id,
+          name: candidate.name,
+          scopes: candidate.scopes,
+          rateLimitPerMinute: candidate.rateLimitPerMinute,
+          source: "api-key",
+        },
       };
     }
 
-    return null;
+    return { ok: false, reason: "invalid_key" };
   }
 
   private getDefaultRepository(): ApiKeyRepository {

--- a/backend/tests/api/apiKeys.test.ts
+++ b/backend/tests/api/apiKeys.test.ts
@@ -1,18 +1,20 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
-import type { FastifyInstance } from "fastify";
+import Fastify, { type FastifyInstance } from "fastify";
 
 vi.hoisted(() => {
   process.env.NODE_ENV = "test";
   process.env.API_KEY_BOOTSTRAP_TOKEN = "bootstrap-secret";
 });
 
-import { buildServer } from "../../src/index.js";
+import { apiKeysRoutes } from "../../src/api/routes/apiKeys.js";
 
 describe("API key routes", () => {
   let server: FastifyInstance;
 
   beforeAll(async () => {
-    server = await buildServer();
+    server = Fastify();
+    await server.register(apiKeysRoutes, { prefix: "/api/v1/admin/api-keys" });
+    await server.ready();
   });
 
   afterAll(async () => {
@@ -50,5 +52,55 @@ describe("API key routes", () => {
     const listed = JSON.parse(listResponse.body);
     expect(Array.isArray(listed.keys)).toBe(true);
     expect(listed.keys.length).toBeGreaterThan(0);
+  });
+
+  it("returns 401 Unauthorized when the x-api-key header is missing", async () => {
+    const response = await server.inject({
+      method: "GET",
+      url: "/api/v1/admin/api-keys",
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(JSON.parse(response.body).error).toBe("Unauthorized");
+  });
+
+  it("returns 401 Unauthorized for an unrecognized API key", async () => {
+    const response = await server.inject({
+      method: "GET",
+      url: "/api/v1/admin/api-keys",
+      headers: {
+        "x-api-key": "bwk_live_does-not-exist",
+      },
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(JSON.parse(response.body).error).toBe("Unauthorized");
+  });
+
+  it("returns 403 Forbidden when the API key lacks the required scope", async () => {
+    const createResponse = await server.inject({
+      method: "POST",
+      url: "/api/v1/admin/api-keys",
+      headers: {
+        "x-api-key": "bootstrap-secret",
+      },
+      payload: {
+        name: "No admin scope",
+        scopes: ["jobs:read"],
+      },
+    });
+
+    const created = JSON.parse(createResponse.body);
+
+    const response = await server.inject({
+      method: "GET",
+      url: "/api/v1/admin/api-keys",
+      headers: {
+        "x-api-key": created.apiKey,
+      },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(JSON.parse(response.body).error).toBe("Forbidden");
   });
 });

--- a/backend/tests/api/authMiddleware.test.ts
+++ b/backend/tests/api/authMiddleware.test.ts
@@ -1,0 +1,122 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+
+vi.hoisted(() => {
+  process.env.NODE_ENV = "test";
+  process.env.JWT_SECRET = "test-jwt-secret";
+});
+
+import { authMiddleware } from "../../src/api/middleware/auth.js";
+import { ApiKeyService } from "../../src/services/apiKey.service.js";
+
+describe("authMiddleware", () => {
+  let server: FastifyInstance;
+  const apiKeyService = new ApiKeyService();
+
+  beforeAll(async () => {
+    server = Fastify();
+
+    server.get(
+      "/open",
+      { preHandler: authMiddleware() },
+      async () => ({ ok: true })
+    );
+
+    server.get(
+      "/scoped",
+      { preHandler: authMiddleware({ requiredScopes: ["reports:read"] }) },
+      async () => ({ ok: true })
+    );
+
+    await server.ready();
+  });
+
+  afterAll(async () => {
+    await server.close();
+  });
+
+  it("returns 401 when no credentials are provided", async () => {
+    const response = await server.inject({ method: "GET", url: "/open" });
+    expect(response.statusCode).toBe(401);
+    expect(JSON.parse(response.body).error).toBe("Unauthorized");
+  });
+
+  it("returns 401 for an unrecognized API key", async () => {
+    const response = await server.inject({
+      method: "GET",
+      url: "/open",
+      headers: { "x-api-key": "bwk_live_does-not-exist" },
+    });
+    expect(response.statusCode).toBe(401);
+    expect(JSON.parse(response.body).error).toBe("Unauthorized");
+  });
+
+  it("returns 403 when an API key is missing a required scope", async () => {
+    const created = await apiKeyService.createKey({
+      name: "Reports viewer",
+      scopes: ["reports:write"],
+      createdBy: "tester",
+    });
+
+    const response = await server.inject({
+      method: "GET",
+      url: "/scoped",
+      headers: { "x-api-key": created.apiKey },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(JSON.parse(response.body).error).toBe("Forbidden");
+  });
+
+  it("authenticates successfully with a valid API key and sufficient scope", async () => {
+    const created = await apiKeyService.createKey({
+      name: "Reports reader",
+      scopes: ["reports:read"],
+      createdBy: "tester",
+    });
+
+    const response = await server.inject({
+      method: "GET",
+      url: "/scoped",
+      headers: { "x-api-key": created.apiKey },
+    });
+
+    expect(response.statusCode).toBe(200);
+  });
+
+  it("returns 429 when the API key's rate limit is exceeded", async () => {
+    const created = await apiKeyService.createKey({
+      name: "Low limit",
+      scopes: [],
+      createdBy: "tester",
+      rateLimitPerMinute: 1,
+    });
+
+    const first = await server.inject({
+      method: "GET",
+      url: "/open",
+      headers: { "x-api-key": created.apiKey },
+    });
+    expect(first.statusCode).toBe(200);
+
+    const second = await server.inject({
+      method: "GET",
+      url: "/open",
+      headers: { "x-api-key": created.apiKey },
+    });
+
+    expect(second.statusCode).toBe(429);
+    expect(JSON.parse(second.body).error).toBe("Too Many Requests");
+  });
+
+  it("returns 401 for an invalid bearer token", async () => {
+    const response = await server.inject({
+      method: "GET",
+      url: "/open",
+      headers: { authorization: "Bearer not-a-real-token" },
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(JSON.parse(response.body).error).toBe("Unauthorized");
+  });
+});

--- a/backend/tests/services/apiKey.service.test.ts
+++ b/backend/tests/services/apiKey.service.test.ts
@@ -20,19 +20,22 @@ describe("ApiKeyService", () => {
     expect(created.apiKey.startsWith("bwk_live_")).toBe(true);
 
     const validated = await service.validateKey(created.apiKey, ["jobs:read"], "127.0.0.1");
-    expect(validated).not.toBeNull();
-    expect(validated?.name).toBe("Integrator");
+    expect(validated.ok).toBe(true);
+    expect(validated.ok && validated.result.name).toBe("Integrator");
   });
 
-  it("rejects validation when a required scope is missing", async () => {
+  it("distinguishes an insufficient scope from an invalid key", async () => {
     const created = await service.createKey({
       name: "Read only",
       scopes: ["jobs:read"],
       createdBy: "tester",
     });
 
-    const validated = await service.validateKey(created.apiKey, ["jobs:trigger"]);
-    expect(validated).toBeNull();
+    const wrongScope = await service.validateKey(created.apiKey, ["jobs:trigger"]);
+    expect(wrongScope).toEqual({ ok: false, reason: "insufficient_scope" });
+
+    const wrongKey = await service.validateKey("bwk_live_does-not-exist", ["jobs:read"]);
+    expect(wrongKey).toEqual({ ok: false, reason: "invalid_key" });
   });
 
   it("rotates and revokes keys", async () => {
@@ -49,6 +52,6 @@ describe("ApiKeyService", () => {
     expect(revoked.revokedAt).not.toBeNull();
 
     const validated = await service.validateKey(rotated.apiKey, ["admin:api-keys"]);
-    expect(validated).toBeNull();
+    expect(validated).toEqual({ ok: false, reason: "invalid_key" });
   });
 });


### PR DESCRIPTION
## Summary

Standardizes authentication/authorization error responses so they consistently follow HTTP semantics: **401 Unauthorized** for missing or invalid credentials, **403 Forbidden** for insufficient permissions.

- `ApiKeyService.validateKey()` previously returned `null` both when an API key was unrecognized/invalid and when it was valid but missing a required scope, so callers had no way to distinguish the two cases. It now returns a discriminated `{ ok, reason }` outcome.
- `authMiddleware` uses that outcome to reply `401` for a missing/invalid API key and `403` only when the key is valid but lacks the required scope.
- `tracingAdmin`, `rateLimitAdmin`, and `validationAdmin` each implemented their own ad-hoc admin API key check that replied `403 Forbidden` even when the `x-api-key` header was missing entirely. They now reply `401` when the header is missing and `403` only when a key is present but isn't a valid admin key.

While covering this area, also fixed a related issue found in the same admin-auth code path:

- `outbox-admin.ts`'s admin auth hook compared the bearer token with a plain `!==` check, which leaks timing information about how many leading characters match. Switched to a constant-time comparison, consistent with the pattern already used in `ApiKeyService`/`OAuth2Service`, and made it explicitly deny access when `ADMIN_API_TOKEN` isn't configured.

## Test plan

- [x] `apiKey.service.test.ts` — updated to assert the new `{ ok, reason }` outcome shape, including a case asserting `insufficient_scope` vs `invalid_key` are distinguishable.
- [x] `apiKeys.test.ts` — integration coverage for 401 (missing header, unrecognized key) and 403 (valid key, missing scope) against the real `authMiddleware`.
- [x] `authMiddleware.test.ts` (new) — direct coverage of `authMiddleware()`: missing credentials, unrecognized API key, insufficient scope, successful auth, rate-limit exceeded (429), and an invalid bearer token. There was no dedicated test file for this middleware before.
- [x] Full backend test suite run before/after: same 77 pre-existing failures on both (all due to missing local Postgres/Redis or unrelated pre-existing bugs — e.g. a `sessionRoutes`/`sessionsRoutes` import mismatch and an ajv schema error that block `buildServer()` entirely, unrelated to this change), no regressions; this branch adds 10 new passing tests.

Closes #955