### PR TITLE
[960] fix: Fix broken link to Soroban SDK docs in Developer Help section

### DIFF
--- a/frontend/src/components/OnboardingDialog.test.tsx
+++ b/frontend/src/components/OnboardingDialog.test.tsx
@@ -14,6 +14,10 @@ describe("OnboardingDialog", () => {
     );
 
     expect(screen.getByRole("heading", { name: "Welcome to Bridge Watch" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Developer Help" })).toHaveAttribute(
+      "href",
+      "https://developers.stellar.org/docs/build/smart-contracts"
+    );
 
     fireEvent.click(screen.getByRole("button", { name: "Next" }));
     expect(screen.getByRole("heading", { name: "Start on the Dashboard" })).toBeInTheDocument();

--- a/frontend/src/components/OnboardingDialog.tsx
+++ b/frontend/src/components/OnboardingDialog.tsx
@@ -21,10 +21,24 @@ export default function OnboardingDialog({ open, onClose, onComplete }: Props) {
       {
         title: "Welcome to Bridge Watch",
         body: (
-          <p className="text-sm text-stellar-text-secondary">
-            This dashboard helps you monitor bridged assets on Stellar: health scores, bridge
-            status, and price signals.
-          </p>
+          <div className="space-y-3 text-sm text-stellar-text-secondary">
+            <p>
+              This dashboard helps you monitor bridged assets on Stellar: health scores, bridge
+              status, and price signals.
+            </p>
+            <p>
+              For the official Soroban SDK documentation, open{" "}
+              <a
+                href="https://developers.stellar.org/docs/build/smart-contracts"
+                target="_blank"
+                rel="noreferrer"
+                className="text-stellar-blue hover:underline"
+              >
+                Developer Help
+              </a>
+              .
+            </p>
+          </div>
         ),
       },
       {


### PR DESCRIPTION
Closes #963

---

Closes #960

---

Closes 960

## What
Updated the onboarding help flow to link to the current official Soroban SDK documentation and covered the link in the onboarding dialog test.

## Why
The previous developer-help path was outdated, so users needed a direct route to the current Soroban docs.

## How tested
- `npx eslint --fix frontend/src/components/OnboardingDialog.tsx frontend/src/components/OnboardingDialog.test.tsx` — passed
- `cd frontend && npm run lint` — passed
- `cd frontend && npm test` — passed
- `cd frontend && npm run build` — failed in untouched skeleton files with TS6133 unused React imports

## Caveats
Pre-existing build failure in untouched files: `frontend/src/components/Skeleton/LoadingSpinner.tsx`, `SkeletonAvatar.tsx`, `SkeletonCard.tsx`, `SkeletonChart.tsx`, and `SkeletonTable.tsx` each fail `tsc -b` due unused `React` imports.