### PR TITLE
chore: consolidate pagination, document env and toolchain, cover focu…

### DIFF
--- a/frontend/src/components/BridgeSummaryCard/BridgeSummaryCard.test.tsx
+++ b/frontend/src/components/BridgeSummaryCard/BridgeSummaryCard.test.tsx
@@ -102,14 +102,14 @@ describe("BridgeSummaryCard", () => {
       render(<BridgeSummaryCard summary={degradedBridge} variant="standard" />);
       
       expect(screen.getByText("Degraded")).toBeInTheDocument();
-      expect(screen.getByLabelText("Status: Degraded")).toHaveClass("text-yellow-400");
+      expect(screen.getByLabelText("Status: Degraded")).toHaveClass("text-status-warning");
     });
 
     it("displays down status with red styling", () => {
       render(<BridgeSummaryCard summary={downBridge} variant="standard" />);
       
       expect(screen.getByText("Down")).toBeInTheDocument();
-      expect(screen.getByLabelText("Status: Down")).toHaveClass("text-red-400");
+      expect(screen.getByLabelText("Status: Down")).toHaveClass("text-status-danger");
     });
 
     it("displays mismatch percentage with appropriate color", () => {
@@ -181,14 +181,14 @@ describe("BridgeSummaryCard", () => {
       render(<BridgeSummaryCard summary={degradedBridge} variant="detailed" />);
       
       const mismatch = screen.getByLabelText(/Supply mismatch: 5.26%/);
-      expect(mismatch).toHaveClass("text-red-400");
+      expect(mismatch).toHaveClass("text-status-danger");
     });
 
     it("renders mismatch in green when below 0.5%", () => {
       render(<BridgeSummaryCard summary={mockBridgeSummary} variant="detailed" />);
       
       const mismatch = screen.getByLabelText(/Supply mismatch: 0.00%/);
-      expect(mismatch).toHaveClass("text-green-400");
+      expect(mismatch).toHaveClass("text-status-success");
     });
 
     it("renders mismatch in yellow when 0.5-1%", () => {
@@ -199,7 +199,7 @@ describe("BridgeSummaryCard", () => {
       render(<BridgeSummaryCard summary={bridge} variant="detailed" />);
       
       const mismatch = screen.getByLabelText(/Supply mismatch: 0.80%/);
-      expect(mismatch).toHaveClass("text-yellow-400");
+      expect(mismatch).toHaveClass("text-status-warning");
     });
   });
 

--- a/frontend/src/components/BridgeSummaryCard/BridgeSummaryCard.tsx
+++ b/frontend/src/components/BridgeSummaryCard/BridgeSummaryCard.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Link } from "react-router-dom";
 import type { BridgeSummary } from "../../types";
 import SkeletonCard from "../Skeleton/SkeletonCard";
@@ -24,9 +25,9 @@ interface BridgeSummaryCardProps {
  */
 function StatusBadge({ status }: { status: string }) {
   const styles: Record<string, string> = {
-    healthy: "bg-green-500/20 text-green-400",
-    degraded: "bg-yellow-500/20 text-yellow-400",
-    down: "bg-red-500/20 text-red-400",
+    healthy: "bg-status-success/20 text-status-success",
+    degraded: "bg-status-warning/20 text-status-warning",
+    down: "bg-status-danger/20 text-status-danger",
     unknown: "bg-gray-500/20 text-gray-400",
   };
 
@@ -100,14 +101,43 @@ function MetricValue({
   );
 }
 
+type DisplayMode = "usd" | "native";
+
 /**
- * Format TVL value with proper scaling
+ * Format TVL value with proper scaling based on display mode
  */
-function formatTVL(value: number): string {
-  if (value >= 1_000_000_000) return `$${(value / 1_000_000_000).toFixed(2)}B`;
-  if (value >= 1_000_000) return `$${(value / 1_000_000).toFixed(2)}M`;
-  if (value >= 1_000) return `$${(value / 1_000).toFixed(2)}K`;
-  return `$${value.toFixed(2)}`;
+function formatTVL(value: number, mode: DisplayMode): string {
+  const prefix = mode === "usd" ? "$" : "";
+  if (value >= 1_000_000_000) return `${prefix}${(value / 1_000_000_000).toFixed(2)}B`;
+  if (value >= 1_000_000) return `${prefix}${(value / 1_000_000).toFixed(2)}M`;
+  if (value >= 1_000) return `${prefix}${(value / 1_000).toFixed(2)}K`;
+  return `${prefix}${value.toFixed(2)}`;
+}
+
+/**
+ * Toggle button for switching between USD and Native value display
+ */
+function DisplayModeToggle({
+  mode,
+  onChange,
+}: {
+  mode: DisplayMode;
+  onChange: (mode: DisplayMode) => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onChange(mode === "usd" ? "native" : "usd")}
+      className="text-xs text-stellar-text-secondary hover:text-stellar-text-primary transition-colors focus:outline-none"
+      aria-label={`Switch to ${mode === "usd" ? "native" : "USD"} value display`}
+    >
+      <span className="flex items-center gap-1">
+        <span className={mode === "usd" ? "font-semibold text-white" : ""}>USD</span>
+        <span className="text-stellar-border">/</span>
+        <span className={mode === "native" ? "font-semibold text-white" : ""}>Native</span>
+      </span>
+    </button>
+  );
 }
 
 /**
@@ -198,7 +228,17 @@ function CompactVariant({ summary }: { summary: BridgeSummary }) {
 /**
  * Standard variant: shows name, status, coverage, and performance
  */
-function StandardVariant({ summary }: { summary: BridgeSummary }) {
+function StandardVariant({
+  summary,
+  displayMode,
+}: {
+  summary: BridgeSummary;
+  displayMode: DisplayMode;
+}) {
+  const tvlValue = displayMode === "native" && summary.totalValueLockedNative != null
+    ? summary.totalValueLockedNative
+    : summary.totalValueLocked;
+
   return (
     <Link
       to={`/bridges?selected=${encodeURIComponent(summary.name)}`}
@@ -240,7 +280,7 @@ function StandardVariant({ summary }: { summary: BridgeSummary }) {
           <div className="text-xs font-medium text-stellar-text-secondary uppercase tracking-wide mb-2">
             Value
           </div>
-          <MetricValue label="TVL" value={formatTVL(summary.totalValueLocked)} unit="" />
+          <MetricValue label="TVL" value={formatTVL(tvlValue, displayMode)} unit="" />
         </div>
       </div>
 
@@ -257,7 +297,17 @@ function StandardVariant({ summary }: { summary: BridgeSummary }) {
 /**
  * Detailed variant: shows all available bridge data
  */
-function DetailedVariant({ summary }: { summary: BridgeSummary }) {
+function DetailedVariant({
+  summary,
+  displayMode,
+}: {
+  summary: BridgeSummary;
+  displayMode: DisplayMode;
+}) {
+  const tvlValue = displayMode === "native" && summary.totalValueLockedNative != null
+    ? summary.totalValueLockedNative
+    : summary.totalValueLocked;
+
   return (
     <Link
       to={`/bridges?selected=${encodeURIComponent(summary.name)}`}
@@ -304,7 +354,7 @@ function DetailedVariant({ summary }: { summary: BridgeSummary }) {
             Assets & Liquidity
           </div>
           <div className="space-y-2">
-            <MetricValue label="TVL" value={formatTVL(summary.totalValueLocked)} unit="" />
+            <MetricValue label="TVL" value={formatTVL(tvlValue, displayMode)} unit="" />
             <MetricValue
               label="Supply (Stellar)"
               value={summary.supplyOnStellar.toLocaleString()}
@@ -320,10 +370,10 @@ function DetailedVariant({ summary }: { summary: BridgeSummary }) {
               <span
                 className={`text-sm font-medium ${
                   summary.mismatchPercentage > 1
-                    ? "text-red-400"
+                    ? "text-status-danger"
                     : summary.mismatchPercentage > 0.5
-                      ? "text-yellow-400"
-                      : "text-green-400"
+                      ? "text-status-warning"
+                      : "text-status-success"
                 }`}
                 aria-label={`Supply mismatch: ${summary.mismatchPercentage.toFixed(2)}%`}
               >
@@ -379,6 +429,8 @@ export default function BridgeSummaryCard({
   className = "",
   "data-testid": dataTestId = "bridge-summary-card",
 }: BridgeSummaryCardProps) {
+  const [displayMode, setDisplayMode] = useState<DisplayMode>("usd");
+
   // Loading state
   if (isLoading) {
     return (
@@ -402,15 +454,20 @@ export default function BridgeSummaryCard({
       case "compact":
         return <CompactVariant summary={summary} />;
       case "detailed":
-        return <DetailedVariant summary={summary} />;
+        return <DetailedVariant summary={summary} displayMode={displayMode} />;
       case "standard":
       default:
-        return <StandardVariant summary={summary} />;
+        return <StandardVariant summary={summary} displayMode={displayMode} />;
     }
   })();
 
   return (
     <div className={className} data-testid={dataTestId}>
+      {variant !== "compact" && (
+        <div className="flex justify-end mb-1">
+          <DisplayModeToggle mode={displayMode} onChange={setDisplayMode} />
+        </div>
+      )}
       {cardElement}
     </div>
   );

--- a/frontend/src/components/SupplyChainViz/BridgeEdge.tsx
+++ b/frontend/src/components/SupplyChainViz/BridgeEdge.tsx
@@ -11,10 +11,10 @@ interface Props {
   onHover: (id: string | null) => void;
 }
 
-const STATUS_COLORS: Record<BridgeEdgeType["status"], string> = {
-  healthy: "#22c55e",
-  degraded: "#f59e0b",
-  offline: "#ef4444",
+const STATUS_CLASSES: Record<BridgeEdgeType["status"], string> = {
+  healthy: "text-status-success",
+  degraded: "text-status-warning",
+  offline: "text-status-danger",
 };
 
 function formatVolume(value: number): string {
@@ -63,7 +63,8 @@ export default function BridgeEdge({
 
   if (!src || !tgt || !path) return null;
 
-  const color = STATUS_COLORS[edge.status];
+  const strokeClass = STATUS_CLASSES[edge.status].replace("text-", "stroke-");
+  const fillClass = STATUS_CLASSES[edge.status].replace("text-", "fill-");
   const strokeWidth = isSelected || isHovered ? 2.5 : edge.status === "offline" ? 0.8 : 1.5;
   const opacity = isDimmed ? 0.15 : edge.status === "offline" ? 0.35 : 1;
   const dashLen = Math.max(4, Math.min(12, edge.volume24hUsd / 3_000_000));
@@ -87,7 +88,7 @@ export default function BridgeEdge({
       <path
         d={path}
         fill="none"
-        stroke={color}
+        className={strokeClass}
         strokeWidth={strokeWidth}
         strokeOpacity={0.3}
         style={{ transition: "stroke-width 0.15s" }}
@@ -98,7 +99,7 @@ export default function BridgeEdge({
         <path
           d={path}
           fill="none"
-          stroke={color}
+          className={strokeClass}
           strokeWidth={strokeWidth}
           strokeDasharray={`${dashLen} ${dashLen * 2.5}`}
           style={{
@@ -110,20 +111,20 @@ export default function BridgeEdge({
       {/* Bidirectional arrow markers */}
       {edge.flowDirection === "bidirectional" && (
         <>
-          <circle cx={src.position.x} cy={src.position.y} r={3} fill={color} opacity={0.6} />
-          <circle cx={tgt.position.x} cy={tgt.position.y} r={3} fill={color} opacity={0.6} />
+          <circle cx={src.position.x} cy={src.position.y} r={3} className={fillClass} opacity={0.6} />
+          <circle cx={tgt.position.x} cy={tgt.position.y} r={3} className={fillClass} opacity={0.6} />
         </>
       )}
 
       {/* Volume label at mid-point */}
       {(isSelected || isHovered) && (
         <g transform={`translate(${mx},${my})`}>
-          <rect x={-28} y={-10} width={56} height={20} rx={4} fill="#1e293b" stroke={color} strokeWidth={1} />
+          <rect x={-28} y={-10} width={56} height={20} rx={4} fill="#1e293b" className={strokeClass} strokeWidth={1} />
           <text
             textAnchor="middle"
             dominantBaseline="central"
             fontSize={9}
-            fill={color}
+            className={fillClass}
             fontWeight="600"
             style={{ userSelect: "none", pointerEvents: "none" }}
           >

--- a/frontend/src/components/SupplyChainViz/ChainNode.tsx
+++ b/frontend/src/components/SupplyChainViz/ChainNode.tsx
@@ -11,10 +11,15 @@ interface Props {
 
 const RADIUS = 38;
 
-function healthColor(score: number): string {
-  if (score >= 85) return "#22c55e";
-  if (score >= 60) return "#f59e0b";
-  return "#ef4444";
+function healthStrokeClass(score: number): string {
+  if (score >= 85) return "stroke-status-success";
+  if (score >= 60) return "stroke-status-warning";
+  return "stroke-status-danger";
+}
+function healthFillClass(score: number): string {
+  if (score >= 85) return "fill-status-success";
+  if (score >= 60) return "fill-status-warning";
+  return "fill-status-danger";
 }
 
 function formatSupply(value: number): string {
@@ -33,7 +38,8 @@ export default function ChainNode({
 }: Props) {
   const { position: { x, y }, color, label, healthScore, totalSupplyUsd } = node;
   const ringRadius = RADIUS + 6;
-  const hc = healthColor(healthScore);
+  const hcStroke = healthStrokeClass(healthScore);
+  const hcFill = healthFillClass(healthScore);
   const opacity = isDimmed ? 0.25 : 1;
 
   return (
@@ -50,7 +56,7 @@ export default function ChainNode({
       <circle
         r={ringRadius}
         fill="none"
-        stroke={hc}
+        className={hcStroke}
         strokeWidth={isSelected || isHovered ? 3 : 1.5}
         strokeDasharray={isSelected ? "none" : "6 3"}
         style={{ transition: "stroke-width 0.15s" }}
@@ -115,13 +121,13 @@ export default function ChainNode({
 
       {/* Health score badge */}
       <g transform={`translate(${RADIUS - 4}, ${-RADIUS + 4})`}>
-        <circle r={10} fill="#1e293b" stroke={hc} strokeWidth={1.5} />
+        <circle r={10} fill="#1e293b" className={hcStroke} strokeWidth={1.5} />
         <text
           textAnchor="middle"
           dominantBaseline="central"
           fontSize={7}
           fontWeight="700"
-          fill={hc}
+          className={hcFill}
           style={{ userSelect: "none", pointerEvents: "none" }}
         >
           {healthScore}

--- a/frontend/src/components/SupplyChainViz/Legend.tsx
+++ b/frontend/src/components/SupplyChainViz/Legend.tsx
@@ -1,13 +1,13 @@
 const STATUS_ITEMS = [
-  { label: "Healthy", color: "#22c55e" },
-  { label: "Degraded", color: "#f59e0b" },
-  { label: "Offline", color: "#ef4444" },
+  { label: "Healthy", className: "bg-status-success" },
+  { label: "Degraded", className: "bg-status-warning" },
+  { label: "Offline", className: "bg-status-danger" },
 ] as const;
 
 const HEALTH_ITEMS = [
-  { label: "High (≥85)", color: "#22c55e" },
-  { label: "Medium (60–84)", color: "#f59e0b" },
-  { label: "Low (<60)", color: "#ef4444" },
+  { label: "High (≥85)", className: "border-status-success" },
+  { label: "Medium (60–84)", className: "border-status-warning" },
+  { label: "Low (<60)", className: "border-status-danger" },
 ] as const;
 
 export default function Legend() {
@@ -18,22 +18,20 @@ export default function Legend() {
       </p>
 
       <p className="text-slate-500 mb-1">Bridge Status</p>
-      {STATUS_ITEMS.map(({ label, color }) => (
+      {STATUS_ITEMS.map(({ label, className }) => (
         <div key={label} className="flex items-center gap-2 mb-1">
           <span
-            className="inline-block w-5 h-[2px] rounded"
-            style={{ backgroundColor: color }}
+            className={`inline-block w-5 h-[2px] rounded ${className}`}
           />
           <span>{label}</span>
         </div>
       ))}
 
       <p className="text-slate-500 mt-2 mb-1">Chain Health</p>
-      {HEALTH_ITEMS.map(({ label, color }) => (
+      {HEALTH_ITEMS.map(({ label, className }) => (
         <div key={label} className="flex items-center gap-2 mb-1">
           <span
-            className="inline-block w-3 h-3 rounded-full border-2"
-            style={{ borderColor: color, backgroundColor: "transparent" }}
+            className={`inline-block w-3 h-3 rounded-full border-2 ${className}`}
           />
           <span>{label}</span>
         </div>

--- a/frontend/src/components/SupplyChainViz/MiniMap.tsx
+++ b/frontend/src/components/SupplyChainViz/MiniMap.tsx
@@ -15,10 +15,10 @@ const MM_WIDTH = 140;
 const MM_HEIGHT = 100;
 const PADDING = 20;
 
-const STATUS_COLORS: Record<BridgeEdge["status"], string> = {
-  healthy: "#22c55e",
-  degraded: "#f59e0b",
-  offline: "#ef4444",
+const STATUS_STROKE: Record<BridgeEdge["status"], string> = {
+  healthy: "stroke-status-success",
+  degraded: "stroke-status-warning",
+  offline: "stroke-status-danger",
 };
 
 export default function MiniMap({
@@ -86,7 +86,7 @@ export default function MiniMap({
               key={edge.id}
               x1={s.x} y1={s.y}
               x2={t.x} y2={t.y}
-              stroke={STATUS_COLORS[edge.status]}
+              className={STATUS_STROKE[edge.status]}
               strokeWidth={0.8}
               opacity={0.5}
             />

--- a/frontend/src/hooks/useAlertSimulation.test.ts
+++ b/frontend/src/hooks/useAlertSimulation.test.ts
@@ -1,0 +1,175 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { useAlertSimulation, type SimulationInput } from "./useAlertSimulation";
+
+const mockInput: SimulationInput = {
+  severity: "high",
+  assetCode: "USDC",
+  sourceType: "stellar",
+  ownerAddress: "GA...",
+  label: "test-alert",
+  triggeredValue: 1500,
+  threshold: 1000,
+  metric: "tx_volume",
+};
+
+const mockResult = {
+  simulationId: "sim-1",
+  timestamp: "2026-07-29T12:00:00.000Z",
+  input: { ...mockInput, ownerAddress: null, label: null, triggeredValue: null, threshold: null, metric: null },
+  results: [
+    {
+      ruleId: "r1",
+      ruleName: "High Volume Alert",
+      priorityOrder: 1,
+      ownerAddress: null,
+      matched: true,
+      reasons: ["Volume exceeds threshold"],
+      channels: ["email"],
+      fallbackChannels: ["sms"],
+      suppressionWindowSeconds: 3600,
+    },
+  ],
+  skippedInactive: [],
+  summary: {
+    totalActiveRules: 1,
+    totalMatched: 1,
+    firstMatchingRule: { ruleId: "r1", ruleName: "High Volume Alert" },
+    wouldDispatch: true,
+    effectiveChannels: ["email"],
+    effectiveFallbackChannels: ["sms"],
+    suppressionWindowSeconds: 3600,
+  },
+};
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  localStorage.clear();
+});
+
+describe("useAlertSimulation", () => {
+  it("initialises with empty history and no current result", () => {
+    const { result } = renderHook(() => useAlertSimulation("test-token"));
+
+    expect(result.current.isRunning).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.currentResult).toBeNull();
+    expect(result.current.history).toEqual([]);
+  });
+
+  it("runs simulation and updates state on success", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockResult),
+    } as Response);
+
+    const { result } = renderHook(() => useAlertSimulation("test-token"));
+
+    await act(async () => {
+      await result.current.runSimulation(mockInput);
+    });
+
+    expect(result.current.isRunning).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.currentResult).toEqual(mockResult);
+    expect(result.current.history).toHaveLength(1);
+    expect(result.current.history[0]).toEqual(mockResult);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/v1/admin/alert-routing/simulate",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+          "X-API-Key": "test-token",
+        }),
+        body: expect.stringContaining("high"),
+      }),
+    );
+  });
+
+  it("sets error when simulation request fails", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({ error: "Server error" }),
+    } as Response);
+
+    const { result } = renderHook(() => useAlertSimulation("test-token"));
+
+    await act(async () => {
+      await result.current.runSimulation(mockInput);
+    });
+
+    expect(result.current.isRunning).toBe(false);
+    expect(result.current.error).toBe("Server error");
+    expect(result.current.currentResult).toBeNull();
+  });
+
+  it("restores a result from history", () => {
+    const { result } = renderHook(() => useAlertSimulation("test-token"));
+
+    act(() => {
+      result.current.restoreFromHistory(mockResult);
+    });
+
+    expect(result.current.currentResult).toEqual(mockResult);
+  });
+
+  it("clears history", () => {
+    const { result } = renderHook(() => useAlertSimulation("test-token"));
+
+    act(() => {
+      result.current.restoreFromHistory(mockResult);
+    });
+
+    act(() => {
+      result.current.clearHistory();
+    });
+
+    expect(result.current.history).toEqual([]);
+  });
+
+  it("persists history to localStorage", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockResult),
+    } as Response);
+
+    const { result } = renderHook(() => useAlertSimulation("test-token"));
+
+    await act(async () => {
+      await result.current.runSimulation(mockInput);
+    });
+
+    const stored = JSON.parse(localStorage.getItem("bw_sim_history") || "[]");
+    expect(stored).toHaveLength(1);
+    expect(stored[0].simulationId).toBe("sim-1");
+  });
+
+  it("loads persisted history on initialisation", () => {
+    localStorage.setItem("bw_sim_history", JSON.stringify([mockResult]));
+
+    const { result } = renderHook(() => useAlertSimulation("test-token"));
+
+    expect(result.current.history).toHaveLength(1);
+    expect(result.current.history[0].simulationId).toBe("sim-1");
+  });
+
+  it("caps history at 20 entries", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockResult),
+    } as Response);
+
+    const { result } = renderHook(() => useAlertSimulation("test-token"));
+
+    for (let i = 0; i < 25; i++) {
+      await act(async () => {
+        await result.current.runSimulation(mockInput);
+      });
+    }
+
+    expect(result.current.history).toHaveLength(20);
+  });
+});

--- a/frontend/src/pages/CustomMetricBuilder.tsx
+++ b/frontend/src/pages/CustomMetricBuilder.tsx
@@ -98,6 +98,9 @@ export default function CustomMetricBuilder() {
               className="mt-1 h-48 w-full rounded-md border border-stellar-border bg-stellar-dark px-3 py-2 font-mono text-sm text-white"
               value={formula}
               onChange={(e) => setFormula(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") e.stopPropagation();
+              }}
               spellCheck={false}
             />
           </div>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -191,8 +191,10 @@ export interface BridgeSummary {
   coverage: number;
   /** Performance metric: average transfer time in milliseconds */
   performance: number;
-  /** Total value locked in the bridge */
+  /** Total value locked in the bridge (USD) */
   totalValueLocked: number;
+  /** Total value locked in native token (optional, for USD/Native toggle) */
+  totalValueLockedNative?: number;
   /** Supply on Stellar */
   supplyOnStellar: number;
   /** Supply on source chain */


### PR DESCRIPTION
## Summary

This PR addresses four issues consolidating CSS color variables, adding tests for alert simulation, fixing Enter key submission in the SQL textarea, and adding a USD/Native toggle for TVL display.

### Changes

**closes #959 — Consolidate CSS color variables**
- Replaced inline hex values (`#22c55e`, `#f59e0b`, `#ef4444`) with unified `status-{success,warning,danger}` Tailwind classes across `BridgeEdge`, `ChainNode`, `Legend`, `MiniMap`, and `BridgeSummaryCard`.

**closes #958 — Add unit tests for useAlertSimulation hook**
- Created `useAlertSimulation.test.ts` covering: simulation runs, HTTP error handling, `restoreFromHistory`, `clearHistory`, localStorage persistence, history cap at 20 entries, and loading stored history on init.

**closes #956 — Fix Enter key submission in CustomMetricBuilder**
- Added `onKeyDown` handler to the SQL textarea that stops Enter key propagation, preventing unwanted form submission.

**closes #957 — Add USD/Native toggle to BridgeSummaryCard**
- Added `displayMode` state (`"usd"` | `"native"`) and a toggle button in the card header.
- Added optional `totalValueLockedNative` field to `BridgeSummary` type.
- Standard and Detailed variants conditionally render TVL based on the selected mode.

closes #959 
closes #958 
closes #956
closes #957 